### PR TITLE
feat(frontend): add NotFound and Offline pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,8 @@ import CommissionConfigPage from './pages/CommissionConfigPage';
 import PublicProfile from './pages/PublicProfile';
 import LandingPages from './pages/LandingPages';
 import CRM from './pages/CRM';
+import NotFound from './pages/NotFound';
+import Offline from './pages/Offline';
 import { ProtectedRoute, AdminRoute, PublicRoute, PublicProfileRoute } from './components/routes';
 
 // Lazy loaded pages for streaming subscriptions e-commerce
@@ -170,6 +172,13 @@ function App() {
               </ProtectedRoute>
             }
           />
+
+          {/* Error Pages */}
+          <Route path="/404" element={<NotFound />} />
+          <Route path="/offline" element={<Offline />} />
+
+          {/* Catch-all: Redirect unknown routes to 404 */}
+          <Route path="*" element={<Navigate to="/404" replace />} />
         </Routes>
       </BrowserRouter>
     </AuthProvider>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1,4 +1,17 @@
 {
+  "notFound": {
+    "title": "Page Not Found",
+    "description": "The page you're looking for doesn't exist or has been moved.",
+    "goToDashboard": "Go to Dashboard",
+    "goBack": "Go Back"
+  },
+  "offline": {
+    "title": "No Internet Connection",
+    "description": "You seem to have lost your connection. Check your internet connection and try again.",
+    "hint": "You can also check if WiFi is on or if there's any issue with your data connection.",
+    "retry": "Retry",
+    "goBack": "Go Back"
+  },
   "tree": {
     "title": "Binary Tree",
     "search": {

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1,4 +1,17 @@
 {
+  "notFound": {
+    "title": "Página no encontrada",
+    "description": "La página que buscas no existe o ha sido movida.",
+    "goToDashboard": "Ir al Dashboard",
+    "goBack": "Volver"
+  },
+  "offline": {
+    "title": "Sin conexión a internet",
+    "description": "Parece que perdiste la conexión. Verificá tu conexión a internet e intentá de nuevo.",
+    "hint": "También podés verificar si el WiFi está activado o si hay algún problema con tu conexión de datos.",
+    "retry": "Reintentar",
+    "goBack": "Volver"
+  },
   "tree": {
     "title": "Árbol Binario",
     "search": {

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,58 @@
+/**
+ * NotFound - Página 404 cuando la ruta no existe
+ *
+ * @module pages/NotFound
+ */
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Home, ArrowLeft } from 'lucide-react';
+
+export default function NotFound() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+      <div className="text-center">
+        {/* Animated 404 */}
+        <div className="relative mb-8">
+          <h1 className="text-[120px] lg:text-[180px] font-bold text-slate-200 leading-none select-none">
+            404
+          </h1>
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="w-24 h-24 lg:w-32 lg:h-32 bg-gradient-to-br from-emerald-400 to-emerald-600 rounded-full flex items-center justify-center shadow-lg animate-pulse">
+              <span className="text-4xl lg:text-5xl font-bold text-white">!</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Message */}
+        <div className="space-y-4">
+          <h2 className="text-2xl lg:text-3xl font-bold text-slate-900">
+            {t('notFound.title', 'Página no encontrada')}
+          </h2>
+          <p className="text-slate-500 max-w-md mx-auto">
+            {t('notFound.description', 'La página que buscas no existe o ha sido movida.')}
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col sm:flex-row gap-4 justify-center mt-8">
+          <Link
+            to="/dashboard"
+            className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-slate-900 text-white font-medium rounded-xl hover:bg-slate-800 transition-colors"
+          >
+            <Home className="w-5 h-5" />
+            {t('notFound.goToDashboard', 'Ir al Dashboard')}
+          </Link>
+          <button
+            onClick={() => window.history.back()}
+            className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-white text-slate-700 font-medium rounded-xl border border-slate-200 hover:bg-slate-50 transition-colors"
+          >
+            <ArrowLeft className="w-5 h-5" />
+            {t('notFound.goBack', 'Volver')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Offline.tsx
+++ b/frontend/src/pages/Offline.tsx
@@ -1,0 +1,75 @@
+/**
+ * Offline - Página mostrada cuando no hay conexión a internet
+ *
+ * @module pages/Offline
+ */
+import { useTranslation } from 'react-i18next';
+import { WifiOff, RefreshCw, ArrowLeft } from 'lucide-react';
+
+export default function Offline() {
+  const { t } = useTranslation();
+
+  const handleRetry = () => {
+    window.location.reload();
+  };
+
+  const handleGoBack = () => {
+    window.history.back();
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+      <div className="text-center">
+        {/* Animated WiFi/Offline Icon */}
+        <div className="relative mb-8">
+          <div className="w-32 h-32 lg:w-40 lg:h-40 mx-auto bg-gradient-to-br from-amber-400 to-orange-500 rounded-full flex items-center justify-center shadow-lg animate-pulse">
+            <WifiOff className="w-16 h-16 lg:w-20 lg:h-20 text-white" />
+          </div>
+          {/* Animated rings */}
+          <div className="absolute inset-0 w-32 h-32 lg:w-40 lg:h-40 mx-auto border-4 border-amber-200 rounded-full animate-ping opacity-20" />
+          <div
+            className="absolute inset-4 lg:inset-6 border-4 border-amber-200 rounded-full animate-ping opacity-30"
+            style={{ animationDelay: '0.5s' }}
+          />
+        </div>
+
+        {/* Message */}
+        <div className="space-y-4">
+          <h2 className="text-2xl lg:text-3xl font-bold text-slate-900">
+            {t('offline.title', 'Sin conexión a internet')}
+          </h2>
+          <p className="text-slate-500 max-w-md mx-auto">
+            {t(
+              'offline.description',
+              'Parece que perdiste la conexión. Verificá tu conexión a internet e intentá de nuevo.'
+            )}
+          </p>
+          <p className="text-slate-400 text-sm">
+            {t(
+              'offline.hint',
+              'También podés verificar si el WiFi está activado o si hay algún problema con tu conexión de datos.'
+            )}
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col sm:flex-row gap-4 justify-center mt-8">
+          <button
+            onClick={handleRetry}
+            className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-emerald-500 text-white font-medium rounded-xl hover:bg-emerald-600 transition-colors"
+          >
+            <RefreshCw className="w-5 h-5" />
+            {t('offline.retry', 'Reintentar')}
+          </button>
+          <button
+            onClick={handleGoBack}
+            className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-white text-slate-700 font-medium rounded-xl border border-slate-200 hover:bg-slate-50 transition-colors"
+          >
+            <ArrowLeft className="w-5 h-5" />
+            {t('offline.goBack', 'Volver')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Add 404 and Offline pages to improve user experience when routes don't exist or there's no internet connection.

### Changes

| File | Change |
|------|--------|
| `NotFound.tsx` | New 404 page with navigation options |
| `Offline.tsx` | New offline page with retry button |
| `App.tsx` | Added routes + catch-all redirect |
| `es.json` / `en.json` | Added i18n translations |

### Features

- **404 Page**: Animated icon, message, buttons to Dashboard and Home
- **Offline Page**: WifiOff icon, retry button, connection suggestions
- **Catch-all Route**: Any unknown path redirects to /404

### Tests

✅ 31 tests passing

### Next Phases

- Phase 2: Complete PWA manifest
- Phase 3: Landing pages for products
- Phase 4: Push notifications

Refs: PWA offline pages phase