### PR TITLE
fix: allow vercel.app subdomains in CORS

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -50,7 +50,8 @@ const corsOptions = {
 
     // In production: validate against whitelist
     if (isProduction) {
-      if (config.cors.allowedOrigins.includes(origin)) {
+      // Allow any subdomain of vercel.app
+      if (origin.endsWith('.vercel.app') || config.cors.allowedOrigins.includes(origin)) {
         callback(null, true);
       } else {
         callback(new Error(`CORS: Origin ${origin} not allowed`));


### PR DESCRIPTION
## Changes

- Allow any subdomain of vercel.app in CORS configuration
- Fixes CORS errors when frontend is deployed to Vercel