### PR TITLE
feat: add Cloudflare Access headers to CORS

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -63,7 +63,13 @@ const corsOptions = {
   },
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
+  allowedHeaders: [
+    'Content-Type',
+    'Authorization',
+    'X-Requested-With',
+    'CF-Access-Client-Id',
+    'CF-Access-Client-Secret',
+  ],
   exposedHeaders: ['X-RateLimit-Limit', 'X-RateLimit-Remaining'],
   maxAge: 86400, // 24 hours for preflight cache
 };


### PR DESCRIPTION
## Changes

- Add CF-Access-Client-Id and CF-Access-Client-Secret to allowed CORS headers
- Required for Cloudflare Access authentication