### PR TITLE
docs: update documentation for v1.8.0 payment integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ Todos los cambios notables de este proyecto serán documentados en este archivo.
 
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/).
 
+## [1.8.0] - 2026-04-03
+
+### Added
+
+- **Payment Integrations**
+  - PayPal SDK full integration: create order, capture, refund, webhooks, idempotency keys
+  - MercadoPago SDK v2 integration: preferences, payments, refunds, webhooks — Colombian market
+
+### Fixed
+
+- **Security**
+  - Prevent SSRF in PayPal webhook certificate URL validation — reconstructs URL from validated hostname instead of trusting user-supplied URL (CWE-918)
+
+## [1.7.0] - 2026-04-02
+
+### Added
+
+- **PWA**
+  - PWA support with service worker and offline pages
+  - Offline-dedicated pages (404, offline) with OfflineBanner component
+
+- **Product Landing Pages**
+  - Public product landing pages with public routes
+
+- **Push Notifications**
+  - Push notifications system with VAPID keys (Web Push)
+
+- **Public Profiles**
+  - Public profile pages with UUID support
+
+- **Infrastructure**
+  - Cloudflare Access headers support in CORS configuration
+
 ## [1.6.0] - 2026-04-01
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,10 @@ We currently support the following versions with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.5.x   | :white_check_mark: |
+| 1.8.x   | :white_check_mark: |
+| 1.7.x   | :white_check_mark: |
 | 1.6.x   | :white_check_mark: |
-| < 1.0   | :x:                |
+| < 1.6   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -77,6 +78,24 @@ To prevent brute-force attacks:
 
 ---
 
+## Payment Security
+
+### PayPal Integration
+
+| Feature                        | Implementation                                                                                                 |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| Webhook Signature Verification | PayPal-provided signature headers validated on every incoming webhook event                                    |
+| Idempotency Keys               | Unique keys per request prevent duplicate payment captures and refunds                                         |
+| SSRF Prevention (CWE-918)      | Certificate URL reconstructed from validated hostname — user-supplied URL never passed directly to HTTP client |
+
+### MercadoPago Integration
+
+| Feature                         | Implementation                                                 |
+| ------------------------------- | -------------------------------------------------------------- |
+| Webhook Notification Validation | Incoming MercadoPago notifications validated before processing |
+
+---
+
 ## Dependencies Security
 
 We use Dependabot for automated security updates:
@@ -98,5 +117,5 @@ When contributing to this project:
 
 ---
 
-_Last updated: 2026-04-01_
-_Version: 1.6.0_
+_Last updated: 2026-04-03_
+_Version: 1.8.0_

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -4,6 +4,7 @@ import swaggerJsdoc from 'swagger-jsdoc';
  * Swagger/OpenAPI Configuration for MLM Binary Affiliations API
  * Configuración Swagger/OpenAPI para la API MLM de Afiliaciones Binarias
  *
+ * v1.8.0: PayPal + MercadoPago payment integrations
  * v1.7.0: PWA Landing Pages + Push Notifications
  * v1.6.0: PWA + Offline pages, icons multi-size
  * v1.5.0: Backend controllers refactoring (modular structure)
@@ -15,7 +16,7 @@ const options: swaggerJsdoc.Options = {
     openapi: '3.0.0',
     info: {
       title: 'MLM Binary Affiliations API',
-      version: '1.7.0',
+      version: '1.8.0',
       description: `
 ## API REST para plataforma MLM de Afiliaciones Binarias
 
@@ -35,6 +36,7 @@ Esta API usa JWT Bearer tokens. Incluye el token en el header:
 | 429 | Rate limit excedido / Rate Limit Exceeded |
 
 ### Versiones / Versions
+- **v1.8.0** (2026-04-03): PayPal + MercadoPago payment integrations
 - **v1.7.0** (2026-04-02): PWA Landing Pages + Push Notifications
 - **v1.6.0** (2026-04-01): PWA, Offline pages, Backend refactoring completo
 - **v1.5.0** (2026-03-31): Controllers modulares, Notificaciones Email
@@ -1205,6 +1207,97 @@ Esta API usa JWT Bearer tokens. Incluye el token en el header:
             imageUrl: { type: 'string' },
           },
         },
+
+        // ============================================================
+        // PAYPAL PAYMENTS (Phase 7 / v1.8.0)
+        // ============================================================
+        PayPalCreateOrderRequest: {
+          type: 'object',
+          required: ['amount', 'currency', 'orderReference'],
+          properties: {
+            amount: { type: 'string', example: '10.00', description: 'Payment amount as string' },
+            currency: { type: 'string', example: 'USD', description: 'ISO 4217 currency code' },
+            orderReference: {
+              type: 'string',
+              example: 'ORDER-123',
+              description: 'Internal order reference',
+            },
+          },
+        },
+
+        PayPalCaptureOrderRequest: {
+          type: 'object',
+          required: ['orderId'],
+          properties: {
+            orderId: {
+              type: 'string',
+              example: 'PAYPAL_ORDER_ID',
+              description: 'PayPal order ID to capture',
+            },
+          },
+        },
+
+        PayPalRefundRequest: {
+          type: 'object',
+          required: ['amount', 'currency'],
+          properties: {
+            amount: { type: 'string', example: '10.00' },
+            currency: { type: 'string', example: 'USD' },
+            note: {
+              type: 'string',
+              example: 'Customer refund',
+              description: 'Optional refund reason',
+            },
+          },
+        },
+
+        // ============================================================
+        // MERCADOPAGO PAYMENTS (Phase 7 / v1.8.0)
+        // ============================================================
+        MercadoPagoCreatePreferenceRequest: {
+          type: 'object',
+          required: ['items', 'payer'],
+          properties: {
+            items: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  title: { type: 'string', example: 'Product name' },
+                  quantity: { type: 'integer', example: 1 },
+                  unit_price: {
+                    type: 'number',
+                    example: 50000,
+                    description: 'Price in Colombian pesos (COP)',
+                  },
+                },
+              },
+            },
+            payer: {
+              type: 'object',
+              properties: {
+                email: { type: 'string', format: 'email', example: 'customer@example.com' },
+              },
+            },
+          },
+        },
+
+        MercadoPagoProcessPaymentRequest: {
+          type: 'object',
+          required: ['token', 'payment_method_id', 'installments', 'transaction_amount', 'payer'],
+          properties: {
+            token: { type: 'string', description: 'Card token from MercadoPago.js' },
+            payment_method_id: { type: 'string', example: 'visa' },
+            installments: { type: 'integer', example: 1, minimum: 1 },
+            transaction_amount: { type: 'number', example: 50000 },
+            payer: {
+              type: 'object',
+              properties: {
+                email: { type: 'string', format: 'email', example: 'customer@example.com' },
+              },
+            },
+          },
+        },
       },
     },
 
@@ -1248,6 +1341,11 @@ Esta API usa JWT Bearer tokens. Incluye el token en el header:
       {
         name: 'public',
         description: 'Public Endpoints / Endpoints Públicos - Landing pages, profiles (Phase 6)',
+      },
+      { name: 'PayPal', description: 'PayPal payment processing endpoints' },
+      {
+        name: 'MercadoPago',
+        description: 'MercadoPago payment processing endpoints (Colombian market)',
       },
     ],
   },

--- a/docs/API.md
+++ b/docs/API.md
@@ -627,6 +627,262 @@ Authorization: Bearer <token> (admin only)
 
 ---
 
+## 💳 Payments
+
+> All payment endpoints live under `/api/payment/`. Webhook endpoints do **not** require a Bearer token — they are verified via provider signature.
+
+---
+
+### PayPal
+
+#### Create PayPal Order
+
+```
+POST /api/payment/paypal/create-order
+Authorization: Bearer <token>
+```
+
+**Body:**
+
+```json
+{
+  "amount": "10.00",
+  "currency": "USD",
+  "orderReference": "ORDER-123"
+}
+```
+
+**Response:**
+
+```json
+{
+  "id": "PAYPAL_ORDER_ID",
+  "status": "CREATED",
+  "approveUrl": "https://www.sandbox.paypal.com/checkoutnow?token=PAYPAL_ORDER_ID"
+}
+```
+
+---
+
+#### Capture PayPal Order
+
+```
+POST /api/payment/paypal/capture-order
+Authorization: Bearer <token>
+```
+
+**Body:**
+
+```json
+{
+  "orderId": "PAYPAL_ORDER_ID"
+}
+```
+
+**Response:**
+
+```json
+{
+  "id": "CAPTURE_ID",
+  "status": "COMPLETED",
+  "amount": {
+    "value": "10.00",
+    "currencyCode": "USD"
+  }
+}
+```
+
+---
+
+#### Get PayPal Order
+
+```
+GET /api/payment/paypal/order/:orderId
+Authorization: Bearer <token>
+```
+
+**Response:** PayPal order details object as returned by the PayPal Orders API.
+
+---
+
+#### Refund PayPal Capture
+
+```
+POST /api/payment/paypal/refund/:captureId
+Authorization: Bearer <token>
+```
+
+**Body:**
+
+```json
+{
+  "amount": "10.00",
+  "currency": "USD",
+  "note": "Customer refund"
+}
+```
+
+**Response:**
+
+```json
+{
+  "id": "REFUND_ID",
+  "status": "COMPLETED"
+}
+```
+
+---
+
+#### PayPal Webhook
+
+```
+POST /api/payment/paypal/webhook
+```
+
+> No Bearer token required. PayPal signature is verified server-side (SSRF-safe certificate URL validation).
+
+**Body:** PayPal webhook event payload (as sent by PayPal).
+
+**Response:**
+
+```json
+{
+  "received": true
+}
+```
+
+---
+
+### MercadoPago
+
+#### Create Preference
+
+```
+POST /api/payment/mercadopago/create-preference
+Authorization: Bearer <token>
+```
+
+**Body:**
+
+```json
+{
+  "items": [
+    {
+      "title": "Product",
+      "quantity": 1,
+      "unit_price": 50000
+    }
+  ],
+  "payer": {
+    "email": "customer@example.com"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "id": "PREFERENCE_ID",
+  "init_point": "https://www.mercadopago.com.co/checkout/v1/redirect?pref_id=PREFERENCE_ID",
+  "sandbox_init_point": "https://sandbox.mercadopago.com.co/checkout/v1/redirect?pref_id=PREFERENCE_ID"
+}
+```
+
+---
+
+#### Process Payment
+
+```
+POST /api/payment/mercadopago/process
+Authorization: Bearer <token>
+```
+
+**Body:**
+
+```json
+{
+  "token": "CARD_TOKEN",
+  "payment_method_id": "visa",
+  "installments": 1,
+  "transaction_amount": 50000,
+  "payer": {
+    "email": "customer@example.com"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "id": 123456,
+  "status": "approved",
+  "status_detail": "accredited"
+}
+```
+
+---
+
+#### Get Payment
+
+```
+GET /api/payment/mercadopago/payment/:paymentId
+Authorization: Bearer <token>
+```
+
+**Response:** MercadoPago payment object as returned by the MercadoPago Payments API.
+
+---
+
+#### Get Payment Methods
+
+```
+GET /api/payment/mercadopago/payment-methods
+Authorization: Bearer <token>
+```
+
+**Response:**
+
+```json
+{
+  "payment_methods": [
+    {
+      "id": "visa",
+      "name": "Visa",
+      "payment_type_id": "credit_card"
+    },
+    {
+      "id": "mastercard",
+      "name": "Mastercard",
+      "payment_type_id": "credit_card"
+    }
+  ]
+}
+```
+
+---
+
+#### MercadoPago Webhook
+
+```
+POST /api/payment/mercadopago/webhook
+```
+
+> No Bearer token required. MercadoPago signature is verified server-side.
+
+**Body:** MercadoPago webhook event payload (as sent by MercadoPago).
+
+**Response:**
+
+```json
+{
+  "received": true
+}
+```
+
+---
+
 ## ⚠️ Error Codes
 
 | Code               | Description              |

--- a/docs/specs/SPEC.md
+++ b/docs/specs/SPEC.md
@@ -4,27 +4,28 @@
 
 ### ✅ DONE - Core MVP Features
 
-| Feature                       | Description                                                                                |
-| ----------------------------- | ------------------------------------------------------------------------------------------ |
-| Authentication                | JWT tokens, bcrypt password hashing, rate limiting (5 req/15min)                           |
-| Binary Tree                   | Closure Table pattern, automatic left/right placement                                      |
-| Commission System             | 5 niveles (direct 10%, level_1 5%, level_2 3%, level_3 2%, level_4 1%), configurable rates |
-| Dashboard                     | Stats, charts, recent commissions, QR code link                                            |
-| QR Code Generation            | Data URL for referral links                                                                |
-| Admin Panel                   | User management, status control (active/inactive/suspended), promote to admin              |
-| CRM                           | Leads CRUD, Tasks, Communications, Kanban board, CSV import/export                         |
-| Tree Visualization            | React Flow with pan/zoom, minimap, search, details panel                                   |
-| i18n Bilingual                | Spanish/English with auto-detection and localStorage persistence                           |
-| Horizontal Navbar             | Responsive design with mobile hamburger menu                                               |
-| Landing Pages                 | Visual builder, tracking (views/conversions), templates                                    |
-| E-commerce Streaming          | Products catalog, orders, subscriptions (Netflix, Spotify, etc.)                           |
-| Wallet                        | Balance tracking, deposits, withdrawals with fee calculation (5%, $20 min)                 |
-| Currency Conversion           | Frankfurter API integration                                                                |
-| CommissionConfig API          | Admin CRUD for configurable commission rates                                               |
-| Tests                         | 271 total (93 unit + 178 integration) + 37 E2E = 308 tests passing                         |
-| **2FA (TOTP)**                | **Two-Factor Authentication with TOTP, recovery codes, AES-256-GCM encryption** ⭐ NEW     |
-| **Playwright Visual Testing** | **E2E tests with headed mode, video recording, UI mode** ⭐ NEW                            |
-| **Frontend 2FA UI**           | **React UI for 2FA setup, QR code display, enable/disable, recovery codes** ⭐ NEW         |
+| Feature                         | Description                                                                                                                                     |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Authentication                  | JWT tokens, bcrypt password hashing, rate limiting (5 req/15min)                                                                                |
+| Binary Tree                     | Closure Table pattern, automatic left/right placement                                                                                           |
+| Commission System               | 5 niveles (direct 10%, level_1 5%, level_2 3%, level_3 2%, level_4 1%), configurable rates                                                      |
+| Dashboard                       | Stats, charts, recent commissions, QR code link                                                                                                 |
+| QR Code Generation              | Data URL for referral links                                                                                                                     |
+| Admin Panel                     | User management, status control (active/inactive/suspended), promote to admin                                                                   |
+| CRM                             | Leads CRUD, Tasks, Communications, Kanban board, CSV import/export                                                                              |
+| Tree Visualization              | React Flow with pan/zoom, minimap, search, details panel                                                                                        |
+| i18n Bilingual                  | Spanish/English with auto-detection and localStorage persistence                                                                                |
+| Horizontal Navbar               | Responsive design with mobile hamburger menu                                                                                                    |
+| Landing Pages                   | Visual builder, tracking (views/conversions), templates                                                                                         |
+| E-commerce Streaming            | Products catalog, orders, subscriptions (Netflix, Spotify, etc.)                                                                                |
+| Wallet                          | Balance tracking, deposits, withdrawals with fee calculation (5%, $20 min)                                                                      |
+| Currency Conversion             | Frankfurter API integration                                                                                                                     |
+| CommissionConfig API            | Admin CRUD for configurable commission rates                                                                                                    |
+| Tests                           | 271 total (93 unit + 178 integration) + 37 E2E = 308 tests passing                                                                              |
+| **2FA (TOTP)**                  | **Two-Factor Authentication with TOTP, recovery codes, AES-256-GCM encryption** ⭐ NEW                                                          |
+| **Playwright Visual Testing**   | **E2E tests with headed mode, video recording, UI mode** ⭐ NEW                                                                                 |
+| **Frontend 2FA UI**             | **React UI for 2FA setup, QR code display, enable/disable, recovery codes** ⭐ NEW                                                              |
+| **Payment Gateway Integration** | **PayPal (global) + MercadoPago (Colombia) — order creation, capture, refunds, webhooks, idempotency, SSRF-safe certificate validation** ⭐ NEW |
 
 ### ⏳ IN PROGRESS
 
@@ -34,14 +35,14 @@
 
 ### 📋 TODO - Future Features
 
-| Feature                                | Status               |
-| -------------------------------------- | -------------------- |
-| Email/SMS Notifications                | Not planned for v1.x |
-| Push Notifications                     | Not planned for v1.x |
-| KYC (Identity Verification)            | Not planned for v1.x |
-| Audit Logs                             | Not planned for v1.x |
-| Multi-gateway Payments (Stripe/PayPal) | Not planned for v1.x |
-| Team Chat                              | Not planned for v1.x |
+| Feature                                | Status                                                                      |
+| -------------------------------------- | --------------------------------------------------------------------------- |
+| Email/SMS Notifications                | Not planned for v1.x                                                        |
+| Push Notifications                     | Not planned for v1.x                                                        |
+| KYC (Identity Verification)            | Not planned for v1.x                                                        |
+| Audit Logs                             | Not planned for v1.x                                                        |
+| Multi-gateway Payments (Stripe/PayPal) | ~~Not planned for v1.x~~ — **Implemented in v1.8.0** (PayPal + MercadoPago) |
+| Team Chat                              | Not planned for v1.x                                                        |
 
 ---
 
@@ -646,6 +647,30 @@ Get commissions report with breakdown by type.
 
 ---
 
+### Payment Endpoints
+
+#### PayPal
+
+| Method | Endpoint                                | Auth     | Description                                        |
+| ------ | --------------------------------------- | -------- | -------------------------------------------------- |
+| POST   | `/api/payment/paypal/create-order`      | Required | Create a PayPal order for checkout                 |
+| POST   | `/api/payment/paypal/capture-order`     | Required | Capture (complete) an approved PayPal order        |
+| GET    | `/api/payment/paypal/order/:orderId`    | Required | Retrieve details of a PayPal order                 |
+| POST   | `/api/payment/paypal/refund/:captureId` | Required | Issue a refund for a captured PayPal payment       |
+| POST   | `/api/payment/paypal/webhook`           | None     | Receive PayPal webhook events (signature-verified) |
+
+#### MercadoPago
+
+| Method | Endpoint                                      | Auth     | Description                                             |
+| ------ | --------------------------------------------- | -------- | ------------------------------------------------------- |
+| POST   | `/api/payment/mercadopago/create-preference`  | Required | Create a MercadoPago checkout preference                |
+| POST   | `/api/payment/mercadopago/process`            | Required | Process a direct card payment via MercadoPago           |
+| GET    | `/api/payment/mercadopago/payment/:paymentId` | Required | Retrieve details of a MercadoPago payment               |
+| GET    | `/api/payment/mercadopago/payment-methods`    | Required | List available payment methods in Colombia              |
+| POST   | `/api/payment/mercadopago/webhook`            | None     | Receive MercadoPago webhook events (signature-verified) |
+
+---
+
 ## Commission Distribution
 
 ### Rates by Level
@@ -821,6 +846,24 @@ pnpm test:all
 | `TEST_DB_PASSWORD` | Test database password | mlm_test  |
 | `TEST_DB_DIALECT`  | Test database dialect  | postgres  |
 
+### Payment Gateways
+
+#### PayPal
+
+| Variable               | Description                              | Example          |
+| ---------------------- | ---------------------------------------- | ---------------- |
+| `PAYPAL_CLIENT_ID`     | PayPal app client ID                     | -                |
+| `PAYPAL_CLIENT_SECRET` | PayPal app client secret                 | -                |
+| `PAYPAL_WEBHOOK_ID`    | PayPal webhook ID for event verification | -                |
+| `PAYPAL_MODE`          | API environment                          | `sandbox`/`live` |
+
+#### MercadoPago
+
+| Variable                     | Description                                    | Example |
+| ---------------------------- | ---------------------------------------------- | ------- |
+| `MERCADOPAGO_ACCESS_TOKEN`   | MercadoPago API access token (Colombia)        | -       |
+| `MERCADOPAGO_WEBHOOK_SECRET` | Secret for MercadoPago webhook signature check | -       |
+
 ---
 
 ## Version History
@@ -839,3 +882,7 @@ pnpm test:all
   - CommissionConfig API for admin rate management
   - Landing Pages builder with tracking
   - Two-Factor Authentication (2FA) with TOTP
+- **v1.8.0** - Payment Gateway Integration
+  - PayPal SDK: order creation, capture, refunds, webhooks, duplicate prevention, idempotency
+  - MercadoPago SDK v2: Colombian market — preferences, payments, refunds, webhooks
+  - SSRF fix in PayPalService: validates certificate URLs before fetching


### PR DESCRIPTION
## Summary

Documentación completa para la versión **v1.8.0** que incluye las integraciones de PayPal y MercadoPago mergeadas en los PRs #31, #32, #33 y #34.

## Files Changed

| File | Changes |
|------|---------|
| `CHANGELOG.md` | Added v1.7.0 and v1.8.0 entries (Keep a Changelog format) |
| `SECURITY.md` | Updated supported versions table + new Payment Security section (CWE-918 SSRF note) |
| `docs/specs/SPEC.md` | Added payment endpoints table, env vars (PayPal + MercadoPago), feature status row |
| `docs/API.md` | New Payments section with 10 fully documented endpoints (request/response examples) |
| `backend/src/config/swagger.ts` | Bumped to v1.8.0, added PayPal/MercadoPago tags and 5 request schemas |

## New Endpoints Documented

**PayPal:**
- `POST /api/payment/paypal/create-order`
- `POST /api/payment/paypal/capture-order`
- `GET /api/payment/paypal/order/:orderId`
- `POST /api/payment/paypal/refund/:captureId`
- `POST /api/payment/paypal/webhook`

**MercadoPago:**
- `POST /api/payment/mercadopago/create-preference`
- `POST /api/payment/mercadopago/process`
- `GET /api/payment/mercadopago/payment/:paymentId`
- `GET /api/payment/mercadopago/payment-methods`
- `POST /api/payment/mercadopago/webhook`

## Related PRs
- Closes documentation gap from #31, #32, #33, #34