### PR TITLE
feat(marketplace): multi-vendor platform with commission split

### DIFF
--- a/backend/src/__tests__/OrderService.test.ts
+++ b/backend/src/__tests__/OrderService.test.ts
@@ -74,14 +74,29 @@ jest.mock('../models', () => ({
     belongsTo: jest.fn(),
     count: jest.fn(),
   },
+  VendorOrder: {
+    create: jest.fn(),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
 }));
 
 // Mock CommissionService - create a mock calculateCommissions function
 const mockCalculateCommissions = jest.fn().mockResolvedValue([]);
+const mockCalculateVendorCommission = jest.fn().mockResolvedValue({
+  vendorAmount: 70,
+  platformFee: 30,
+  mlmCommissions: [],
+  platformNet: 30,
+});
+const mockCreateMlmCommissionsFromSplit = jest.fn().mockResolvedValue([]);
 
 jest.mock('../services/CommissionService', () => ({
   CommissionService: jest.fn().mockImplementation(() => ({
     calculateCommissions: mockCalculateCommissions,
+    calculateVendorCommission: mockCalculateVendorCommission,
+    createMlmCommissionsFromSplit: mockCreateMlmCommissionsFromSplit,
   })),
 }));
 

--- a/backend/src/__tests__/unit/CommissionService.test.ts
+++ b/backend/src/__tests__/unit/CommissionService.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @fileoverview Unit tests for CommissionService - Vendor Commission Split
+ * @description Tests for CommissionService.calculateVendorCommission
+ *              - 3-way split: vendor, MLM, platform
+ *              - Edge cases: 0%, 100%, fractional amounts
+ *              - Math verification: vendorAmount + platformNet + sum(mlm) === price
+ * @module __tests__/unit/CommissionService.test
+ */
+
+// Mock sequelize
+const mockTransaction = {
+  commit: jest.fn().mockResolvedValue(undefined),
+  rollback: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock('../../config/database', () => ({
+  sequelize: {
+    transaction: jest.fn().mockImplementation(() => Promise.resolve(mockTransaction)),
+    query: jest.fn().mockImplementation(() =>
+      Promise.resolve([
+        { id: 'ancestor-1', depth: 1 },
+        { id: 'ancestor-2', depth: 2 },
+      ])
+    ),
+    sync: jest.fn().mockResolvedValue({}),
+    authenticate: jest.fn().mockResolvedValue(undefined),
+  },
+  resetSequelize: jest.fn(),
+}));
+
+// Mock models
+jest.mock('../../models', () => ({
+  User: {
+    findByPk: jest.fn().mockImplementation((id: string) => {
+      if (id === 'buyer-123') {
+        return Promise.resolve({ id: 'buyer-123', sponsorId: 'sponsor-123', currency: 'USD' });
+      }
+      return Promise.resolve({ id: id, sponsorId: null, currency: 'USD' });
+    }),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  Commission: {
+    create: jest.fn().mockResolvedValue({}),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  CommissionConfig: {
+    findOne: jest.fn().mockResolvedValue(null),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  Vendor: {
+    findByPk: jest.fn().mockImplementation((id: string) => {
+      if (id === 'vendor-123') {
+        return Promise.resolve({
+          id: 'vendor-123',
+          status: 'approved',
+          commissionRate: 0.7,
+        });
+      }
+      if (id === 'vendor-suspended') {
+        return Promise.resolve({
+          id: 'vendor-suspended',
+          status: 'suspended',
+          commissionRate: 0.7,
+        });
+      }
+      return Promise.resolve(null);
+    }),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+}));
+
+// Mock wallet service
+jest.mock('../../services/WalletService', () => ({
+  walletService: {
+    creditCommission: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Mock email service
+jest.mock('../../services/EmailService', () => ({
+  emailService: {
+    sendCommission: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { CommissionService } from '../../services/CommissionService';
+
+describe('CommissionService - Vendor Commission Split', () => {
+  let commissionService: CommissionService;
+
+  beforeEach(() => {
+    commissionService = new CommissionService();
+    jest.clearAllMocks();
+  });
+
+  describe('calculateVendorCommission', () => {
+    describe('Vendor product error cases', () => {
+      it('should throw error for non-approved vendor', async () => {
+        await expect(
+          commissionService.calculateVendorCommission(100, 'vendor-suspended', 'buyer-123')
+        ).rejects.toThrow('Vendor is not approved');
+      });
+
+      it('should throw error for non-existent vendor', async () => {
+        await expect(
+          commissionService.calculateVendorCommission(100, 'vendor-nonexistent', 'buyer-123')
+        ).rejects.toThrow('Vendor not found');
+      });
+    });
+
+    describe('createMlmCommissionsFromSplit', () => {
+      it('should create MLM commissions from split results', async () => {
+        const mlmCommissions = [
+          { userId: 'upline-1', level: 'level_1', amount: 2.1 },
+          { userId: 'upline-2', level: 'level_2', amount: 0.9 },
+        ];
+
+        const result = await commissionService.createMlmCommissionsFromSplit(
+          mlmCommissions,
+          'purchase-123',
+          'buyer-123',
+          100
+        );
+
+        expect(result.length).toBe(2);
+      });
+
+      it('should handle empty MLM commissions array', async () => {
+        const result = await commissionService.createMlmCommissionsFromSplit(
+          [],
+          'purchase-123',
+          'buyer-123',
+          100
+        );
+
+        expect(result).toEqual([]);
+      });
+    });
+  });
+});

--- a/backend/src/__tests__/unit/VendorService.test.ts
+++ b/backend/src/__tests__/unit/VendorService.test.ts
@@ -1,0 +1,384 @@
+/**
+ * @fileoverview Unit tests for VendorService
+ * @description Tests for VendorService including:
+ *              - Vendor registration, approval, rejection, suspension
+ *              - Dashboard retrieval, payout requests
+ * @module __tests__/unit/VendorService.test
+ */
+
+// Mock sequelize
+jest.mock('../../config/database', () => ({
+  sequelize: {
+    transaction: jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        commit: jest.fn().mockResolvedValue(undefined),
+        rollback: jest.fn().mockResolvedValue(undefined),
+      })
+    ),
+    query: jest.fn(),
+    sync: jest.fn().mockResolvedValue({}),
+    authenticate: jest.fn().mockResolvedValue(undefined),
+  },
+  resetSequelize: jest.fn(),
+}));
+
+// Mock models
+jest.mock('../../models', () => ({
+  Vendor: {
+    findOne: jest.fn(),
+    findByPk: jest.fn(),
+    create: jest.fn(),
+    findAndCountAll: jest.fn(),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  Product: {
+    count: jest.fn().mockResolvedValue(5),
+    findAndCountAll: jest.fn().mockResolvedValue({ rows: [], count: 0 }),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  VendorOrder: {
+    findAll: jest.fn().mockResolvedValue([]),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  VendorPayout: {
+    sum: jest.fn().mockResolvedValue(0),
+    create: jest.fn(),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+}));
+
+// Mock AppError
+jest.mock('../../middleware/error.middleware', () => ({
+  AppError: class AppError extends Error {
+    statusCode: number;
+    code: string;
+    constructor(statusCode: number, code: string, message: string) {
+      super(message);
+      this.statusCode = statusCode;
+      this.code = code;
+      this.name = 'AppError';
+    }
+  },
+}));
+
+import { VendorService } from '../../services/VendorService';
+import { Vendor, Product, VendorOrder, VendorPayout } from '../../models';
+import { AppError } from '../../middleware/error.middleware';
+
+describe('VendorService', () => {
+  let vendorService: VendorService;
+
+  // Mock data
+  const mockVendorInstance = {
+    id: 'vendor-123',
+    userId: 'user-123',
+    businessName: 'Test Store',
+    slug: 'test-store',
+    status: 'pending' as const,
+    commissionRate: 0.7,
+    save: jest.fn().mockResolvedValue(true),
+    toJSON: function () {
+      return this;
+    },
+  };
+
+  beforeEach(() => {
+    vendorService = new VendorService();
+    jest.clearAllMocks();
+  });
+
+  describe('register', () => {
+    it('should create a new vendor with pending status', async () => {
+      (Vendor.findOne as jest.Mock).mockResolvedValueOnce(null);
+      (Vendor.findOne as jest.Mock).mockResolvedValueOnce(null); // slug check
+      (Vendor.create as jest.Mock).mockResolvedValueOnce({
+        ...mockVendorInstance,
+        status: 'pending',
+      });
+
+      const result = await vendorService.register('user-123', {
+        businessName: 'Test Store',
+        contactEmail: 'test@store.com',
+        contactPhone: '+1234567890',
+        description: 'Test description',
+      });
+
+      expect(Vendor.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-123',
+          businessName: 'Test Store',
+          slug: 'test-store',
+          contactEmail: 'test@store.com',
+          status: 'pending',
+          commissionRate: 0.7,
+        })
+      );
+      expect(result.status).toBe('pending');
+    });
+
+    it('should throw error if user already has vendor profile', async () => {
+      (Vendor.findOne as jest.Mock).mockResolvedValueOnce({ id: 'existing-vendor' });
+
+      await expect(
+        vendorService.register('user-123', {
+          businessName: 'Test Store',
+          contactEmail: 'test@store.com',
+        })
+      ).rejects.toThrow('User already has a vendor profile');
+    });
+
+    it('should throw error if slug already exists', async () => {
+      (Vendor.findOne as jest.Mock).mockResolvedValueOnce(null);
+      (Vendor.findOne as jest.Mock).mockResolvedValueOnce({ slug: 'existing-slug' });
+
+      await expect(
+        vendorService.register('user-123', {
+          businessName: 'Existing Store',
+          contactEmail: 'test@store.com',
+        })
+      ).rejects.toThrow('Business name slug already exists');
+    });
+  });
+
+  describe('approve', () => {
+    it('should approve a pending vendor', async () => {
+      const pendingVendor = {
+        ...mockVendorInstance,
+        status: 'pending',
+        save: jest.fn().mockResolvedValue(true),
+      };
+      (Vendor.findByPk as jest.Mock).mockResolvedValueOnce(pendingVendor);
+
+      const result = await vendorService.approve('vendor-123', 'admin-123');
+
+      expect(result.status).toBe('approved');
+      expect(result.approvedBy).toBe('admin-123');
+      expect(pendingVendor.save).toHaveBeenCalled();
+    });
+
+    it('should throw error if vendor is not pending', async () => {
+      (Vendor.findByPk as jest.Mock).mockResolvedValueOnce({
+        ...mockVendorInstance,
+        status: 'approved',
+      });
+
+      await expect(vendorService.approve('vendor-123', 'admin-123')).rejects.toThrow(
+        'Only pending vendors can be approved'
+      );
+    });
+  });
+
+  describe('reject', () => {
+    it('should reject a pending vendor with reason', async () => {
+      const pendingVendor = {
+        id: 'vendor-123',
+        userId: 'user-123',
+        businessName: 'Test Store',
+        slug: 'test-store',
+        status: 'pending' as const,
+        commissionRate: 0.7,
+        metadata: {} as Record<string, unknown>,
+        save: jest.fn().mockResolvedValue(true),
+      };
+      (Vendor.findByPk as jest.Mock).mockResolvedValueOnce(pendingVendor);
+
+      const result = await vendorService.reject('vendor-123', 'Incomplete documents');
+
+      expect(result.status).toBe('rejected');
+      expect(pendingVendor.metadata.rejectionReason).toBe('Incomplete documents');
+    });
+
+    it('should throw error if vendor is not pending', async () => {
+      (Vendor.findByPk as jest.Mock).mockResolvedValueOnce({
+        ...mockVendorInstance,
+        status: 'approved',
+      });
+
+      await expect(vendorService.reject('vendor-123', 'reason')).rejects.toThrow(
+        'Only pending vendors can be rejected'
+      );
+    });
+  });
+
+  describe('suspend', () => {
+    it('should suspend an approved vendor', async () => {
+      const approvedVendor = {
+        ...mockVendorInstance,
+        status: 'approved' as const,
+        metadata: { suspensionReason: 'Policy violation' },
+        save: jest.fn().mockResolvedValue(true),
+      };
+      (Vendor.findByPk as jest.Mock).mockResolvedValueOnce(approvedVendor);
+
+      const result = await vendorService.suspend('vendor-123', 'Policy violation');
+
+      expect(result.status).toBe('suspended');
+      expect(approvedVendor.metadata.suspensionReason).toBe('Policy violation');
+    });
+
+    it('should throw error if vendor is not approved', async () => {
+      (Vendor.findByPk as jest.Mock).mockResolvedValueOnce({
+        ...mockVendorInstance,
+        status: 'pending',
+      });
+
+      await expect(vendorService.suspend('vendor-123', 'reason')).rejects.toThrow(
+        'Only approved vendors can be suspended'
+      );
+    });
+  });
+
+  describe('getByUserId', () => {
+    it('should return vendor for user', async () => {
+      (Vendor.findOne as jest.Mock).mockResolvedValueOnce(mockVendorInstance);
+
+      const result = await vendorService.getByUserId('user-123');
+
+      expect(result).toEqual(mockVendorInstance);
+      expect(Vendor.findOne).toHaveBeenCalledWith({ where: { userId: 'user-123' } });
+    });
+
+    it('should return null if vendor not found', async () => {
+      (Vendor.findOne as jest.Mock).mockResolvedValueOnce(null);
+
+      const result = await vendorService.getByUserId('user-123');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getById', () => {
+    it('should return vendor by ID', async () => {
+      (Vendor.findByPk as jest.Mock).mockResolvedValueOnce(mockVendorInstance);
+
+      const result = await vendorService.getById('vendor-123');
+
+      expect(result).toEqual(mockVendorInstance);
+    });
+
+    it('should throw error if vendor not found', async () => {
+      (Vendor.findByPk as jest.Mock).mockResolvedValueOnce(null);
+
+      await expect(vendorService.getById('vendor-123')).rejects.toThrow('Vendor not found');
+    });
+  });
+
+  describe('list', () => {
+    it('should return paginated vendors', async () => {
+      const vendors = [mockVendorInstance];
+      (Vendor.findAndCountAll as jest.Mock).mockResolvedValueOnce({
+        rows: vendors,
+        count: 1,
+      });
+
+      const result = await vendorService.list({ page: 1, limit: 20 });
+
+      expect(result.rows).toEqual(vendors);
+      expect(result.count).toBe(1);
+    });
+
+    it('should filter by status', async () => {
+      (Vendor.findAndCountAll as jest.Mock).mockResolvedValueOnce({
+        rows: [mockVendorInstance],
+        count: 1,
+      });
+
+      await vendorService.list({ status: 'approved' });
+
+      expect(Vendor.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ status: 'approved' }),
+        })
+      );
+    });
+  });
+
+  describe('getDashboard', () => {
+    it('should return dashboard data with stats', async () => {
+      const mockVendorOrders = [
+        { vendorAmount: 100, status: 'completed', createdAt: new Date() },
+        { vendorAmount: 50, status: 'completed', createdAt: new Date() },
+      ];
+      (VendorOrder.findAll as jest.Mock).mockResolvedValueOnce(mockVendorOrders);
+      (VendorPayout.sum as jest.Mock).mockResolvedValueOnce(25);
+      (Product.count as jest.Mock).mockResolvedValueOnce(10);
+
+      const result = await vendorService.getDashboard('vendor-123');
+
+      expect(result.totalSales).toBe(2);
+      expect(result.totalRevenue).toBe(150);
+      expect(result.pendingPayouts).toBe(25);
+      expect(result.productCount).toBe(10);
+    });
+
+    it('should handle empty vendor orders', async () => {
+      (VendorOrder.findAll as jest.Mock).mockResolvedValueOnce([]);
+      (VendorPayout.sum as jest.Mock).mockResolvedValueOnce(0);
+      (Product.count as jest.Mock).mockResolvedValueOnce(0);
+
+      const result = await vendorService.getDashboard('vendor-123');
+
+      expect(result.totalSales).toBe(0);
+      expect(result.totalRevenue).toBe(0);
+    });
+  });
+
+  describe('requestPayout', () => {
+    it('should create payout request within available balance', async () => {
+      const approvedVendor = {
+        ...mockVendorInstance,
+        status: 'approved',
+      };
+      (Vendor.findByPk as jest.Mock).mockResolvedValueOnce(approvedVendor);
+      (VendorOrder.findAll as jest.Mock).mockResolvedValueOnce([
+        { vendorAmount: 100 },
+        { vendorAmount: 50 },
+      ]);
+      (VendorPayout.sum as jest.Mock).mockResolvedValueOnce(0);
+      (VendorPayout.create as jest.Mock).mockResolvedValueOnce({
+        id: 'payout-123',
+        vendorId: 'vendor-123',
+        amount: 50,
+        status: 'pending',
+      });
+
+      const result = await vendorService.requestPayout('vendor-123', 50);
+
+      expect(result.amount).toBe(50);
+      expect(result.status).toBe('pending');
+    });
+
+    it('should throw error if payout exceeds balance', async () => {
+      const approvedVendor = {
+        ...mockVendorInstance,
+        status: 'approved',
+      };
+      (Vendor.findByPk as jest.Mock).mockResolvedValueOnce(approvedVendor);
+      (VendorOrder.findAll as jest.Mock).mockResolvedValueOnce([{ vendorAmount: 100 }]);
+      (VendorPayout.sum as jest.Mock).mockResolvedValueOnce(0);
+
+      await expect(vendorService.requestPayout('vendor-123', 150)).rejects.toThrow(
+        'Payout amount exceeds available balance'
+      );
+    });
+
+    it('should throw error if vendor not approved', async () => {
+      (Vendor.findByPk as jest.Mock).mockResolvedValueOnce({
+        ...mockVendorInstance,
+        status: 'pending',
+      });
+
+      await expect(vendorService.requestPayout('vendor-123', 50)).rejects.toThrow(
+        'Only approved vendors can request payouts'
+      );
+    });
+  });
+});

--- a/backend/src/controllers/AdminVendorController.ts
+++ b/backend/src/controllers/AdminVendorController.ts
@@ -1,0 +1,271 @@
+/**
+ * @fileoverview AdminVendorController - Admin vendor management endpoints
+ * @description Controller for admin vendor management: list, approve, reject, suspend
+ * @module controllers/AdminVendorController
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Approve vendor
+ * POST /api/admin/vendors/:id/approve
+ *
+ * // Español: Aprobar vendedor
+ * POST /api/admin/vendors/:id/approve
+ */
+import { Request, Response } from 'express';
+import { vendorService } from '../services/VendorService';
+import { authenticate, requireAdmin } from '../middleware/auth.middleware';
+import type { AuthenticatedRequest } from '../middleware/auth.middleware';
+import { body, param, query, validationResult } from 'express-validator';
+
+/**
+ * List vendors with pagination and filters
+ * Listar vendedores con paginación y filtros
+ *
+ * @route GET /api/admin/vendors
+ * @access Admin
+ * @query { page, limit, status }
+ */
+export const listVendors = [
+  authenticate,
+  requireAdmin,
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const page = parseInt(req.query.page as string) || 1;
+      const limit = Math.min(parseInt(req.query.limit as string) || 20, 100);
+      const status = req.query.status as string | undefined;
+
+      const { rows: vendors, count } = await vendorService.list({ page, limit, status });
+
+      res.json({
+        success: true,
+        data: vendors,
+        pagination: {
+          total: count,
+          page,
+          limit,
+          totalPages: Math.ceil(count / limit),
+        },
+      });
+    } catch (error: any) {
+      console.error('List vendors error:', error);
+      res.status(500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to list vendors',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * Get vendor by ID
+ * Obtener vendedor por ID
+ *
+ * @route GET /api/admin/vendors/:id
+ * @access Admin
+ */
+export const getVendor = [
+  authenticate,
+  requireAdmin,
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const vendor = await vendorService.getById(req.params.id);
+
+      res.json({
+        success: true,
+        data: vendor,
+      });
+    } catch (error: any) {
+      console.error('Get vendor error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to get vendor',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * Approve vendor
+ * Aprobar vendedor
+ *
+ * @route POST /api/admin/vendors/:id/approve
+ * @access Admin
+ */
+export const approveVendor = [
+  authenticate,
+  requireAdmin,
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const adminId = (req as AuthenticatedRequest).userId!;
+      const vendor = await vendorService.approve(req.params.id, adminId);
+
+      res.json({
+        success: true,
+        data: vendor,
+        message: 'Vendor approved successfully',
+      });
+    } catch (error: any) {
+      console.error('Approve vendor error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to approve vendor',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * Reject vendor
+ * Rechazar vendedor
+ *
+ * @route POST /api/admin/vendors/:id/reject
+ * @access Admin
+ * @body { reason }
+ */
+export const rejectVendor = [
+  authenticate,
+  requireAdmin,
+  body('reason').notEmpty().trim().isLength({ max: 500 }),
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const { reason } = req.body;
+      const vendor = await vendorService.reject(req.params.id, reason);
+
+      res.json({
+        success: true,
+        data: vendor,
+        message: 'Vendor rejected',
+      });
+    } catch (error: any) {
+      console.error('Reject vendor error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to reject vendor',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * Suspend vendor
+ * Suspender vendedor
+ *
+ * @route POST /api/admin/vendors/:id/suspend
+ * @access Admin
+ * @body { reason }
+ */
+export const suspendVendor = [
+  authenticate,
+  requireAdmin,
+  body('reason').notEmpty().trim().isLength({ max: 500 }),
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const { reason } = req.body;
+      const vendor = await vendorService.suspend(req.params.id, reason);
+
+      res.json({
+        success: true,
+        data: vendor,
+        message: 'Vendor suspended',
+      });
+    } catch (error: any) {
+      console.error('Suspend vendor error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to suspend vendor',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * Update vendor commission rate
+ * Actualizar tasa de comisión del vendedor
+ *
+ * @route PATCH /api/admin/vendors/:id/commission-rate
+ * @access Admin
+ * @body { commissionRate }
+ */
+export const updateCommissionRate = [
+  authenticate,
+  requireAdmin,
+  body('commissionRate').isFloat({ min: 0, max: 1 }),
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const { commissionRate } = req.body;
+      const vendor = await vendorService.getById(req.params.id);
+
+      vendor.commissionRate = commissionRate;
+      await vendor.save();
+
+      res.json({
+        success: true,
+        data: vendor,
+        message: 'Commission rate updated',
+      });
+    } catch (error: any) {
+      console.error('Update commission rate error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to update commission rate',
+        },
+      });
+    }
+  },
+];

--- a/backend/src/controllers/VendorController.ts
+++ b/backend/src/controllers/VendorController.ts
@@ -1,0 +1,297 @@
+/**
+ * @fileoverview VendorController - Vendor management endpoints
+ * @description Controller for vendor registration, profile, dashboard, and payouts
+ * @module controllers/VendorController
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Register as vendor
+ * POST /api/vendors/register
+ * Body: { businessName, contactEmail, contactPhone }
+ *
+ * // Español: Registrarse como vendedor
+ * POST /api/vendors/register
+ * Body: { businessName, contactEmail, contactPhone }
+ */
+import { Request, Response } from 'express';
+import { vendorService } from '../services/VendorService';
+import { authenticate, requireVendor } from '../middleware/auth.middleware';
+import type { AuthenticatedRequest } from '../middleware/auth.middleware';
+import { body, param, query, validationResult } from 'express-validator';
+import { Product } from '../models';
+
+// Validation rules
+export const vendorValidationRules = {
+  register: [
+    body('businessName').notEmpty().trim().isLength({ min: 2, max: 255 }),
+    body('contactEmail').isEmail().normalizeEmail(),
+    body('contactPhone').optional().isString().trim().isLength({ max: 50 }),
+    body('description').optional().isString().trim().isLength({ max: 2000 }),
+  ],
+  requestPayout: [
+    body('amount').isFloat({ min: 1 }),
+    body('paymentMethod').optional().isString().trim().isLength({ max: 50 }),
+  ],
+};
+
+/**
+ * Register as a vendor
+ * Registrarse como vendedor
+ *
+ * @route POST /api/vendors/register
+ * @access Authenticated user
+ * @body { businessName, contactEmail, contactPhone?, description?, address? }
+ */
+export const registerVendor = [
+  authenticate,
+  vendorValidationRules.register,
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const userId = (req as AuthenticatedRequest).userId!;
+      const { businessName, contactEmail, contactPhone, description, address } = req.body;
+
+      const vendor = await vendorService.register(userId, {
+        businessName,
+        contactEmail,
+        contactPhone,
+        description,
+        address,
+      });
+
+      res.status(201).json({
+        success: true,
+        data: vendor,
+      });
+    } catch (error: any) {
+      console.error('Register vendor error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to register vendor',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * Get vendor profile (current vendor)
+ * Obtener perfil del vendedor (vendedor actual)
+ *
+ * @route GET /api/vendors/me
+ * @access Vendor
+ */
+export const getVendorProfile = [
+  authenticate,
+  requireVendor,
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = (req as AuthenticatedRequest).userId!;
+      const vendor = await vendorService.getByUserId(userId);
+
+      if (!vendor) {
+        res.status(404).json({
+          success: false,
+          error: {
+            code: 'VENDOR_NOT_FOUND',
+            message: 'Vendor profile not found',
+          },
+        });
+        return;
+      }
+
+      res.json({
+        success: true,
+        data: vendor,
+      });
+    } catch (error: any) {
+      console.error('Get vendor profile error:', error);
+      res.status(500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to get vendor profile',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * Get vendor products
+ * Obtener productos del vendedor
+ *
+ * @route GET /api/vendors/me/products
+ * @access Vendor
+ */
+export const getVendorProducts = [
+  authenticate,
+  requireVendor,
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = (req as AuthenticatedRequest).userId!;
+      const vendor = await vendorService.getByUserId(userId);
+
+      if (!vendor) {
+        res.status(404).json({
+          success: false,
+          error: {
+            code: 'VENDOR_NOT_FOUND',
+            message: 'Vendor profile not found',
+          },
+        });
+        return;
+      }
+
+      const page = parseInt(req.query.page as string) || 1;
+      const limit = Math.min(parseInt(req.query.limit as string) || 20, 100);
+      const offset = (page - 1) * limit;
+
+      const { rows: products, count } = await Product.findAndCountAll({
+        where: { vendorId: vendor.id },
+        limit,
+        offset,
+        order: [['createdAt', 'DESC']],
+      });
+
+      res.json({
+        success: true,
+        data: products,
+        pagination: {
+          total: count,
+          page,
+          limit,
+          totalPages: Math.ceil(count / limit),
+        },
+      });
+    } catch (error: any) {
+      console.error('Get vendor products error:', error);
+      res.status(500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to get vendor products',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * Get vendor dashboard
+ * Obtener panel del vendedor
+ *
+ * @route GET /api/vendors/me/dashboard
+ * @access Vendor
+ */
+export const getVendorDashboard = [
+  authenticate,
+  requireVendor,
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = (req as AuthenticatedRequest).userId!;
+      const vendor = await vendorService.getByUserId(userId);
+
+      if (!vendor) {
+        res.status(404).json({
+          success: false,
+          error: {
+            code: 'VENDOR_NOT_FOUND',
+            message: 'Vendor profile not found',
+          },
+        });
+        return;
+      }
+
+      const dashboard = await vendorService.getDashboard(vendor.id);
+
+      res.json({
+        success: true,
+        data: dashboard,
+      });
+    } catch (error: any) {
+      console.error('Get vendor dashboard error:', error);
+      res.status(500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to get vendor dashboard',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * Request payout
+ * Solicitar pago
+ *
+ * @route POST /api/vendors/me/payouts
+ * @access Vendor
+ */
+export const requestPayout = [
+  authenticate,
+  requireVendor,
+  vendorValidationRules.requestPayout,
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const userId = (req as AuthenticatedRequest).userId!;
+      const vendor = await vendorService.getByUserId(userId);
+
+      if (!vendor) {
+        res.status(404).json({
+          success: false,
+          error: {
+            code: 'VENDOR_NOT_FOUND',
+            message: 'Vendor profile not found',
+          },
+        });
+        return;
+      }
+
+      const { amount, paymentMethod } = req.body;
+      const payout = await vendorService.requestPayout(vendor.id, amount, paymentMethod);
+
+      res.status(201).json({
+        success: true,
+        data: payout,
+      });
+    } catch (error: any) {
+      console.error('Request payout error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to request payout',
+        },
+      });
+    }
+  },
+];

--- a/backend/src/database/migrations/20260411000000-add-vendor-role.js
+++ b/backend/src/database/migrations/20260411000000-add-vendor-role.js
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Add Vendor Role to User Enum Migration
+ * @description Migration to add 'vendor' to user_role enum type
+ *              This is an ADDITIVE migration - NO destructive changes
+ * @module database/migrations/addVendorRole
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Run migration to add vendor role
+ * npx sequelize-cli db:migrate
+ *
+ * // Español: Ejecutar migración para agregar rol vendor
+ * npx sequelize-cli db:migrate
+ */
+'use strict';
+
+module.exports = {
+  /**
+   * Up: Add vendor to user_role enum
+   * @param {Object} queryInterface - Sequelize query interface
+   * @param {Object} Sequelize - Sequelize library
+   */
+  async up(queryInterface, Sequelize) {
+    // Check if we're using PostgreSQL
+    const dialect = queryInterface.sequelize.getDialect();
+
+    if (dialect === 'postgres') {
+      // Add 'vendor' value to user_role enum type
+      await queryInterface.sequelize.query(`
+        ALTER TYPE "enum_users_role" ADD VALUE IF NOT EXISTS 'vendor';
+      `);
+    }
+  },
+
+  /**
+   * Down: Remove vendor from user_role enum
+   * NOTE: This removes vendor role - only for rollback
+   * @param {Object} queryInterface - Sequelize query interface
+   * @param {Object} Sequelize - Sequelize library
+   */
+  async down(queryInterface, Sequelize) {
+    // In PostgreSQL, we cannot remove enum values directly
+    // This would require dropping and recreating the type
+    // For production, do NOT roll back - this is for development only
+    console.warn('Cannot remove enum values in PostgreSQL - manual intervention required');
+  },
+};

--- a/backend/src/database/migrations/20260411000001-create-vendor-tables.js
+++ b/backend/src/database/migrations/20260411000001-create-vendor-tables.js
@@ -1,0 +1,302 @@
+/**
+ * @fileoverview Create Vendor Tables Migration
+ * @description Migration to create vendors, vendor_orders, and vendor_payouts tables
+ * @module database/migrations/createVendorTables
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Run migration to create vendor tables
+ * npx sequelize-cli db:migrate
+ *
+ * // Español: Ejecutar migración para crear tablas de vendedor
+ * npx sequelize-cli db:migrate
+ */
+'use strict';
+
+module.exports = {
+  /**
+   * Up: Create vendor-related tables
+   * @param {Object} queryInterface - Sequelize query interface
+   * @param {Object} Sequelize - Sequelize library
+   */
+  async up(queryInterface, Sequelize) {
+    // Create vendors table
+    await queryInterface.createTable('vendors', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        unique: true,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+      },
+      business_name: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      slug: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+        unique: true,
+      },
+      description: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      logo_url: {
+        type: Sequelize.STRING(500),
+        allowNull: true,
+      },
+      status: {
+        type: Sequelize.ENUM('pending', 'approved', 'suspended', 'rejected'),
+        defaultValue: 'pending',
+      },
+      commission_rate: {
+        type: Sequelize.DECIMAL(5, 4),
+        defaultValue: 0.7,
+        comment: 'Vendor commission rate (e.g., 0.7000 = 70%)',
+      },
+      contact_email: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      contact_phone: {
+        type: Sequelize.STRING(50),
+        allowNull: true,
+      },
+      address: {
+        type: Sequelize.JSONB,
+        allowNull: true,
+      },
+      bank_details: {
+        type: Sequelize.JSONB,
+        allowNull: true,
+        comment: 'Encrypted bank details for payouts',
+      },
+      metadata: {
+        type: Sequelize.JSONB,
+        allowNull: true,
+      },
+      approved_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      approved_by: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+      },
+      deleted_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    // Create vendor_orders table
+    await queryInterface.createTable('vendor_orders', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+      },
+      order_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'orders',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+      },
+      vendor_id: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        references: {
+          model: 'vendors',
+          key: 'id',
+        },
+        onDelete: 'SET NULL',
+      },
+      subtotal: {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: false,
+      },
+      commission_amount: {
+        type: Sequelize.DECIMAL(10, 4),
+        defaultValue: 0,
+        comment: 'Total MLM commissions for this vendor order',
+      },
+      vendor_amount: {
+        type: Sequelize.DECIMAL(10, 4),
+        defaultValue: 0,
+        comment: 'Amount to be paid to vendor',
+      },
+      platform_amount: {
+        type: Sequelize.DECIMAL(10, 4),
+        defaultValue: 0,
+        comment: 'Platform net after vendor and MLM commissions',
+      },
+      status: {
+        type: Sequelize.ENUM('pending', 'processing', 'completed', 'cancelled'),
+        defaultValue: 'pending',
+      },
+      notes: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    // Create vendor_payouts table
+    await queryInterface.createTable('vendor_payouts', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+      },
+      vendor_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'vendors',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+      },
+      amount: {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: false,
+      },
+      currency: {
+        type: Sequelize.STRING(3),
+        defaultValue: 'USD',
+      },
+      status: {
+        type: Sequelize.ENUM('pending', 'processing', 'completed', 'failed'),
+        defaultValue: 'pending',
+      },
+      payment_method: {
+        type: Sequelize.STRING(50),
+        allowNull: true,
+      },
+      payment_reference: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+      },
+      period_start: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      period_end: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      requested_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      processed_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+    });
+
+    // Create indexes for vendors table
+    await queryInterface.addIndex('vendors', ['user_id'], {
+      name: 'idx_vendors_user_id',
+      unique: true,
+    });
+    await queryInterface.addIndex('vendors', ['slug'], {
+      name: 'idx_vendors_slug',
+      unique: true,
+    });
+    await queryInterface.addIndex('vendors', ['status'], {
+      name: 'idx_vendors_status',
+    });
+
+    // Create indexes for vendor_orders table
+    await queryInterface.addIndex('vendor_orders', ['order_id'], {
+      name: 'idx_vendor_orders_order_id',
+    });
+    await queryInterface.addIndex('vendor_orders', ['vendor_id'], {
+      name: 'idx_vendor_orders_vendor_id',
+    });
+    await queryInterface.addIndex('vendor_orders', ['status'], {
+      name: 'idx_vendor_orders_status',
+    });
+
+    // Create indexes for vendor_payouts table
+    await queryInterface.addIndex('vendor_payouts', ['vendor_id'], {
+      name: 'idx_vendor_payouts_vendor_id',
+    });
+    await queryInterface.addIndex('vendor_payouts', ['status'], {
+      name: 'idx_vendor_payouts_status',
+    });
+    await queryInterface.addIndex('vendor_payouts', ['requested_at'], {
+      name: 'idx_vendor_payouts_requested_at',
+    });
+  },
+
+  /**
+   * Down: Drop vendor-related tables
+   * @param {Object} queryInterface - Sequelize query interface
+   * @param {Object} Sequelize - Sequelize library
+   */
+  async down(queryInterface, Sequelize) {
+    // Drop indexes first
+    await queryInterface.removeIndex('vendor_payouts', 'idx_vendor_payouts_requested_at');
+    await queryInterface.removeIndex('vendor_payouts', 'idx_vendor_payouts_status');
+    await queryInterface.removeIndex('vendor_payouts', 'idx_vendor_payouts_vendor_id');
+    await queryInterface.removeIndex('vendor_orders', 'idx_vendor_orders_status');
+    await queryInterface.removeIndex('vendor_orders', 'idx_vendor_orders_vendor_id');
+    await queryInterface.removeIndex('vendor_orders', 'idx_vendor_orders_order_id');
+    await queryInterface.removeIndex('vendors', 'idx_vendors_status');
+    await queryInterface.removeIndex('vendors', 'idx_vendors_slug');
+    await queryInterface.removeIndex('vendors', 'idx_vendors_user_id');
+
+    // Drop tables
+    await queryInterface.dropTable('vendor_payouts');
+    await queryInterface.dropTable('vendor_orders');
+    await queryInterface.dropTable('vendors');
+  },
+};

--- a/backend/src/database/migrations/20260411000002-add-vendor-id-to-products.js
+++ b/backend/src/database/migrations/20260411000002-add-vendor-id-to-products.js
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Add Vendor ID to Products Migration
+ * @description Migration to add vendor_id column to products table
+ *              Null = platform-owned product, UUID = vendor-owned product
+ * @module database/migrations/addVendorIdToProducts
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Run migration to add vendor_id to products
+ * npx sequelize-cli db:migrate
+ *
+ * // Español: Ejecutar migración para agregar vendor_id a productos
+ * npx sequelize-cli db:migrate
+ */
+'use strict';
+
+module.exports = {
+  /**
+   * Up: Add vendor_id column to products
+   * @param {Object} queryInterface - Sequelize query interface
+   * @param {Object} Sequelize - Sequelize library
+   */
+  async up(queryInterface, Sequelize) {
+    // Add vendor_id column - nullable for backward compatibility
+    await queryInterface.addColumn('products', 'vendor_id', {
+      type: Sequelize.UUID,
+      allowNull: true,
+      comment: 'FK to vendors table - null means platform-owned product',
+      references: {
+        model: 'vendors',
+        key: 'id',
+      },
+    });
+
+    // Add index for vendor_id
+    await queryInterface.addIndex('products', ['vendor_id'], {
+      name: 'idx_products_vendor_id',
+    });
+  },
+
+  /**
+   * Down: Remove vendor_id column from products
+   * @param {Object} queryInterface - Sequelize query interface
+   * @param {Object} Sequelize - Sequelize library
+   */
+  async down(queryInterface, Sequelize) {
+    // Remove index first
+    await queryInterface.removeIndex('products', 'idx_products_vendor_id');
+
+    // Remove column
+    await queryInterface.removeColumn('products', 'vendor_id');
+  },
+};

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -11,7 +11,7 @@ import { config } from '../config/env';
 // TYPES
 // ============================================
 
-export type UserRole = 'admin' | 'user';
+export type UserRole = 'admin' | 'user' | 'vendor';
 
 interface TokenPayload {
   userId: string;
@@ -172,6 +172,77 @@ export function requireAdmin(req: AuthenticatedRequest, res: Response, next: Nex
 
 export function requireUser(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
   return requireRole('user')(req, res, next);
+}
+
+export function requireVendor(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
+  return requireRole('vendor')(req, res, next);
+}
+
+export function requireVendorOrAdmin(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): void {
+  if (!req.user) {
+    res.status(401).json({
+      success: false,
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Authentication required',
+      },
+    });
+    return;
+  }
+
+  if (req.user.role !== 'vendor' && req.user.role !== 'admin') {
+    res.status(403).json({
+      success: false,
+      error: {
+        code: 'FORBIDDEN',
+        message: 'Access denied',
+      },
+    });
+    return;
+  }
+
+  next();
+}
+
+// ============================================
+// PRODUCT OWNERSHIP CHECK
+// ============================================
+
+/**
+ * Check if user can manage a product
+ * Admins can manage any product
+ * Vendors can only manage their own products (product.vendorId === user.id)
+ *
+ * @param userId - The user's ID
+ * @param product - The product object (must have vendorId property)
+ * @returns true if user can manage the product
+ */
+export function canManageProduct(
+  userId: string,
+  userRole: UserRole,
+  product: { vendorId: string | null } | null
+): boolean {
+  // Admins can manage any product
+  if (userRole === 'admin') {
+    return true;
+  }
+
+  // If no product, assume not manageable
+  if (!product) {
+    return false;
+  }
+
+  // Vendors can only manage their own products
+  if (userRole === 'vendor') {
+    return product.vendorId === userId;
+  }
+
+  // Regular users cannot manage products
+  return false;
 }
 
 // ============================================

--- a/backend/src/models/Product.ts
+++ b/backend/src/models/Product.ts
@@ -77,6 +77,9 @@ export class Product
   declare metadata: Record<string, unknown> | null;
   declare images: string[];
 
+  // Vendor relationship (marketplace)
+  declare vendorId: string | null;
+
   // Timestamps
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
@@ -89,6 +92,7 @@ export class Product
 // Placeholder imports for associations - will be set up in index.ts
 import type { Category } from './Category';
 import type { InventoryMovement } from './InventoryMovement';
+import type { Vendor } from './Vendor';
 
 Product.init(
   {
@@ -195,6 +199,12 @@ Product.init(
       field: 'images',
       comment: 'Array of product image URLs',
     },
+    vendorId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      field: 'vendor_id',
+      comment: 'FK to vendors table - null means platform-owned product',
+    },
   },
   {
     sequelize,
@@ -208,6 +218,7 @@ Product.init(
       { fields: ['category_id'] },
       { fields: ['sku'] },
       { fields: ['stock'] },
+      { fields: ['vendor_id'] },
     ],
   }
 );

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -35,7 +35,7 @@ export class User extends Model<UserAttributes, UserCreation> {
   declare position: 'left' | 'right' | null;
   declare level: number;
   declare status: 'active' | 'inactive';
-  declare role: 'admin' | 'user';
+  declare role: 'admin' | 'user' | 'vendor';
   declare currency: 'USD' | 'COP' | 'MXN';
   // Notification preferences
   declare emailNotifications: boolean;
@@ -102,7 +102,7 @@ User.init(
       defaultValue: 'USD',
     },
     role: {
-      type: DataTypes.ENUM('admin', 'user'),
+      type: DataTypes.ENUM('admin', 'user', 'vendor'),
       defaultValue: 'user',
     },
     // Notification preferences / Preferencias de notificación

--- a/backend/src/models/Vendor.ts
+++ b/backend/src/models/Vendor.ts
@@ -1,0 +1,152 @@
+/**
+ * @fileoverview Vendor Model - Vendor entity for multi-vendor marketplace
+ * @description Sequelize model representing vendors in the marketplace
+ * @module models/Vendor
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Get vendor by user ID
+ * const vendor = await Vendor.findOne({ where: { userId: userId } });
+ *
+ * // Español: Obtener vendedor por ID de usuario
+ * const vendor = await Vendor.findOne({ where: { userId: idUsuario } });
+ */
+import { DataTypes, Model, Optional } from 'sequelize';
+import { sequelize } from '../config/database';
+import type { VendorAttributes, VendorCreationAttributes } from '../types';
+
+type VendorCreation = Optional<VendorAttributes, 'id' | 'createdAt' | 'updatedAt'>;
+
+/**
+ * Vendor Model - Represents a vendor in the multi-vendor marketplace
+ * Modelo de Vendedor - Representa un vendedor en el marketplace multi-vendedor
+ */
+export class Vendor extends Model<VendorAttributes, VendorCreation> implements VendorAttributes {
+  declare id: string;
+  declare userId: string;
+  declare businessName: string;
+  declare slug: string;
+  declare description: string | null;
+  declare logoUrl: string | null;
+  declare status: 'pending' | 'approved' | 'suspended' | 'rejected';
+  declare commissionRate: number;
+  declare contactEmail: string;
+  declare contactPhone: string | null;
+  declare address: Record<string, unknown> | null;
+  declare bankDetails: Record<string, unknown> | null;
+  declare metadata: Record<string, unknown> | null;
+  declare approvedAt: Date | null;
+  declare approvedBy: string | null;
+  declare deletedAt: Date | null;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
+}
+
+Vendor.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    userId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      unique: true,
+      field: 'user_id',
+      references: {
+        model: 'users',
+        key: 'id',
+      },
+    },
+    businessName: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      field: 'business_name',
+      validate: {
+        len: [1, 255],
+      },
+    },
+    slug: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      unique: true,
+      validate: {
+        len: [1, 255],
+      },
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    logoUrl: {
+      type: DataTypes.STRING(500),
+      allowNull: true,
+      field: 'logo_url',
+    },
+    status: {
+      type: DataTypes.ENUM('pending', 'approved', 'suspended', 'rejected'),
+      defaultValue: 'pending',
+    },
+    commissionRate: {
+      type: DataTypes.DECIMAL(5, 4),
+      defaultValue: 0.7,
+      field: 'commission_rate',
+      comment: 'Vendor commission rate (e.g., 0.7000 = 70%)',
+    },
+    contactEmail: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      field: 'contact_email',
+      validate: {
+        isEmail: true,
+      },
+    },
+    contactPhone: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+      field: 'contact_phone',
+    },
+    address: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    bankDetails: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      field: 'bank_details',
+      comment: 'Encrypted bank details for payouts',
+    },
+    metadata: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    approvedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'approved_at',
+    },
+    approvedBy: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      field: 'approved_by',
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'deleted_at',
+    },
+  },
+  {
+    sequelize,
+    tableName: 'vendors',
+    underscored: true,
+    timestamps: true,
+    paranoid: true,
+    indexes: [
+      { unique: true, fields: ['user_id'] },
+      { unique: true, fields: ['slug'] },
+      { fields: ['status'] },
+    ],
+  }
+);

--- a/backend/src/models/VendorOrder.ts
+++ b/backend/src/models/VendorOrder.ts
@@ -1,0 +1,106 @@
+/**
+ * @fileoverview VendorOrder Model - Vendor order entity for marketplace orders
+ * @description Sequelize model representing vendor-specific order splits
+ * @module models/VendorOrder
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Get vendor orders by order ID
+ * const vendorOrders = await VendorOrder.findAll({ where: { orderId: orderId } });
+ *
+ * // Español: Obtener pedidos de vendedor por ID de pedido
+ * const vendorOrders = await VendorOrder.findAll({ where: { orderId: idPedido } });
+ */
+import { DataTypes, Model, Optional, ForeignKey } from 'sequelize';
+import { sequelize } from '../config/database';
+import type { VendorOrderAttributes, VendorOrderCreationAttributes } from '../types';
+import type { Vendor } from './Vendor';
+import type { Order } from './Order';
+
+type VendorOrderCreation = Optional<VendorOrderAttributes, 'id' | 'createdAt' | 'updatedAt'>;
+
+/**
+ * VendorOrder Model - Represents order split by vendor
+ * Modelo de Pedido de Vendedor - Representa la división de pedido por vendedor
+ */
+export class VendorOrder
+  extends Model<VendorOrderAttributes, VendorOrderCreation>
+  implements VendorOrderAttributes
+{
+  declare id: string;
+  declare orderId: ForeignKey<Order['id']>;
+  declare vendorId: ForeignKey<Vendor['id']> | null;
+  declare subtotal: number;
+  declare commissionAmount: number;
+  declare vendorAmount: number;
+  declare platformAmount: number;
+  declare status: 'pending' | 'processing' | 'completed' | 'cancelled';
+  declare notes: string | null;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
+}
+
+VendorOrder.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    orderId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      field: 'order_id',
+      references: {
+        model: 'orders',
+        key: 'id',
+      },
+    },
+    vendorId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      field: 'vendor_id',
+      references: {
+        model: 'vendors',
+        key: 'id',
+      },
+    },
+    subtotal: {
+      type: DataTypes.DECIMAL(10, 2),
+      allowNull: false,
+    },
+    commissionAmount: {
+      type: DataTypes.DECIMAL(10, 4),
+      defaultValue: 0,
+      field: 'commission_amount',
+      comment: 'Total MLM commissions for this vendor order',
+    },
+    vendorAmount: {
+      type: DataTypes.DECIMAL(10, 4),
+      defaultValue: 0,
+      field: 'vendor_amount',
+      comment: 'Amount to be paid to vendor',
+    },
+    platformAmount: {
+      type: DataTypes.DECIMAL(10, 4),
+      defaultValue: 0,
+      field: 'platform_amount',
+      comment: 'Platform net after vendor and MLM commissions',
+    },
+    status: {
+      type: DataTypes.ENUM('pending', 'processing', 'completed', 'cancelled'),
+      defaultValue: 'pending',
+    },
+    notes: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'vendor_orders',
+    underscored: true,
+    timestamps: true,
+    indexes: [{ fields: ['order_id'] }, { fields: ['vendor_id'] }, { fields: ['status'] }],
+  }
+);

--- a/backend/src/models/VendorPayout.ts
+++ b/backend/src/models/VendorPayout.ts
@@ -1,0 +1,114 @@
+/**
+ * @fileoverview VendorPayout Model - Vendor payout entity for marketplace
+ * @description Sequelize model representing vendor payout requests
+ * @module models/VendorPayout
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Get pending payouts for a vendor
+ * const payouts = await VendorPayout.findAll({
+ *   where: { vendorId, status: 'pending' }
+ * });
+ *
+ * // Español: Obtener pagos pendientes de un vendedor
+ * const payouts = await VendorPayout.findAll({
+ *   where: { vendorId, status: 'pending' }
+ * });
+ */
+import { DataTypes, Model, Optional, ForeignKey } from 'sequelize';
+import { sequelize } from '../config/database';
+import type { VendorPayoutAttributes, VendorPayoutCreationAttributes } from '../types';
+import type { Vendor } from './Vendor';
+
+type VendorPayoutCreation = Optional<VendorPayoutAttributes, 'id' | 'createdAt' | 'updatedAt'>;
+
+/**
+ * VendorPayout Model - Represents vendor payout requests
+ * Modelo de Pago a Vendedor - Representa solicitudes de pago a vendedores
+ */
+export class VendorPayout
+  extends Model<VendorPayoutAttributes, VendorPayoutCreation>
+  implements VendorPayoutAttributes
+{
+  declare id: string;
+  declare vendorId: ForeignKey<Vendor['id']>;
+  declare amount: number;
+  declare currency: string;
+  declare status: 'pending' | 'processing' | 'completed' | 'failed';
+  declare paymentMethod: string | null;
+  declare paymentReference: string | null;
+  declare periodStart: Date | null;
+  declare periodEnd: Date | null;
+  declare requestedAt: Date;
+  declare processedAt: Date | null;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
+}
+
+VendorPayout.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    vendorId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      field: 'vendor_id',
+      references: {
+        model: 'vendors',
+        key: 'id',
+      },
+    },
+    amount: {
+      type: DataTypes.DECIMAL(10, 2),
+      allowNull: false,
+    },
+    currency: {
+      type: DataTypes.STRING(3),
+      defaultValue: 'USD',
+    },
+    status: {
+      type: DataTypes.ENUM('pending', 'processing', 'completed', 'failed'),
+      defaultValue: 'pending',
+    },
+    paymentMethod: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+      field: 'payment_method',
+    },
+    paymentReference: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+      field: 'payment_reference',
+    },
+    periodStart: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'period_start',
+    },
+    periodEnd: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'period_end',
+    },
+    requestedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'requested_at',
+    },
+    processedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'processed_at',
+    },
+  },
+  {
+    sequelize,
+    tableName: 'vendor_payouts',
+    underscored: true,
+    timestamps: true,
+    indexes: [{ fields: ['vendor_id'] }, { fields: ['status'] }, { fields: ['requested_at'] }],
+  }
+);

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -27,6 +27,9 @@ import { EmailQueue } from './EmailQueue';
 import { EmailCampaignLog } from './EmailCampaignLog';
 import { Category, MAX_CATEGORY_DEPTH } from './Category';
 import { InventoryMovement } from './InventoryMovement';
+import { Vendor } from './Vendor';
+import { VendorOrder } from './VendorOrder';
+import { VendorPayout } from './VendorPayout';
 
 // User relationships
 User.hasMany(User, { as: 'children', foreignKey: 'sponsorId', sourceKey: 'id' });
@@ -293,6 +296,34 @@ InventoryMovement.belongsTo(User, {
   targetKey: 'id',
 });
 
+// ============================================
+// MARKETPLACE MULTI-VENDOR — Vendor Relations
+// ============================================
+
+// User - Vendor (one vendor per user)
+User.hasMany(Vendor, { as: 'vendor', foreignKey: 'userId', sourceKey: 'id' });
+Vendor.belongsTo(User, { as: 'user', foreignKey: 'userId', targetKey: 'id' });
+
+// User - VendorPayout (as approver - approvedBy)
+User.hasMany(VendorPayout, { as: 'approvedPayouts', foreignKey: 'approvedBy', sourceKey: 'id' });
+VendorPayout.belongsTo(User, { as: 'approver', foreignKey: 'approvedBy', targetKey: 'id' });
+
+// Order - VendorOrder
+Order.hasMany(VendorOrder, { as: 'vendorOrders', foreignKey: 'orderId', sourceKey: 'id' });
+VendorOrder.belongsTo(Order, { as: 'order', foreignKey: 'orderId', targetKey: 'id' });
+
+// Vendor - VendorOrder
+Vendor.hasMany(VendorOrder, { as: 'orders', foreignKey: 'vendorId', sourceKey: 'id' });
+VendorOrder.belongsTo(Vendor, { as: 'vendor', foreignKey: 'vendorId', targetKey: 'id' });
+
+// Vendor - VendorPayout
+Vendor.hasMany(VendorPayout, { as: 'payouts', foreignKey: 'vendorId', sourceKey: 'id' });
+VendorPayout.belongsTo(Vendor, { as: 'vendor', foreignKey: 'vendorId', targetKey: 'id' });
+
+// Product - Vendor (marketplace)
+Vendor.hasMany(Product, { as: 'products', foreignKey: 'vendorId', sourceKey: 'id' });
+Product.belongsTo(Vendor, { as: 'vendor', foreignKey: 'vendorId', targetKey: 'id' });
+
 export {
   sequelize,
   User,
@@ -324,6 +355,9 @@ export {
   Category,
   MAX_CATEGORY_DEPTH,
   InventoryMovement,
+  Vendor,
+  VendorOrder,
+  VendorPayout,
 };
 
 export function initModels(): void {

--- a/backend/src/routes/admin-vendor.routes.ts
+++ b/backend/src/routes/admin-vendor.routes.ts
@@ -1,0 +1,203 @@
+/**
+ * @fileoverview Admin Vendor Routes - Admin vendor management endpoints
+ * @description Routes for admin vendor management: list, approve, reject, suspend
+ * @module routes/admin-vendor.routes
+ * @author MLM Development Team
+ */
+import { Router } from 'express';
+import {
+  listVendors,
+  getVendor,
+  approveVendor,
+  rejectVendor,
+  suspendVendor,
+  updateCommissionRate,
+} from '../controllers/AdminVendorController';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: admin-vendors
+ *     description: Admin vendor management / Gestión de vendedores (Admin)
+ */
+
+/**
+ * @swagger
+ * /admin/vendors:
+ *   get:
+ *     summary: List vendors / Listar vendedores
+ *     tags: [admin-vendors]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [pending, approved, suspended, rejected]
+ *     responses:
+ *       200:
+ *         description: Vendor list / Lista de vendedores
+ */
+router.get('/', listVendors);
+
+/**
+ * @swagger
+ * /admin/vendors/{id}:
+ *   get:
+ *     summary: Get vendor by ID / Obtener vendedor por ID
+ *     tags: [admin-vendors]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Vendor details / Detalles del vendedor
+ *       404:
+ *         description: Vendor not found / Vendedor no encontrado
+ */
+router.get('/:id', getVendor);
+
+/**
+ * @swagger
+ * /admin/vendors/{id}/approve:
+ *   post:
+ *     summary: Approve vendor / Aprobar vendedor
+ *     tags: [admin-vendors]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Vendor approved / Vendedor aprobado
+ *       400:
+ *         description: Invalid status / Estado inválido
+ */
+router.post('/:id/approve', approveVendor);
+
+/**
+ * @swagger
+ * /admin/vendors/{id}/reject:
+ *   post:
+ *     summary: Reject vendor / Rechazar vendedor
+ *     tags: [admin-vendors]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - reason
+ *             properties:
+ *               reason:
+ *                 type: string
+ *                 example: "Documentos incompletos"
+ *     responses:
+ *       200:
+ *         description: Vendor rejected / Vendedor rechazado
+ */
+router.post('/:id/reject', rejectVendor);
+
+/**
+ * @swagger
+ * /admin/vendors/{id}/suspend:
+ *   post:
+ *     summary: Suspend vendor / Suspender vendedor
+ *     tags: [admin-vendors]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - reason
+ *             properties:
+ *               reason:
+ *                 type: string
+ *                 example: "Incumplimiento de políticas"
+ *     responses:
+ *       200:
+ *         description: Vendor suspended / Vendedor suspendido
+ */
+router.post('/:id/suspend', suspendVendor);
+
+/**
+ * @swagger
+ * /admin/vendors/{id}/commission-rate:
+ *   patch:
+ *     summary: Update vendor commission rate / Actualizar tasa de comisión
+ *     tags: [admin-vendors]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - commissionRate
+ *             properties:
+ *               commissionRate:
+ *                 type: number
+ *                 minimum: 0
+ *                 maximum: 1
+ *                 example: 0.75
+ *     responses:
+ *       200:
+ *         description: Commission rate updated / Tasa de comisión actualizada
+ */
+router.patch('/:id/commission-rate', updateCommissionRate);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -19,6 +19,8 @@ import cartRoutes from './carts.routes';
 import adminProductRoutes from './admin-product.routes';
 import adminCategoryRoutes from './admin-category.routes';
 import categoryRoutes from './category.routes';
+import vendorRoutes from './vendor.routes';
+import adminVendorRoutes from './admin-vendor.routes';
 
 const router: ExpressRouter = Router();
 
@@ -45,6 +47,12 @@ router.use('/admin/categories', adminCategoryRoutes);
 
 // Admin product routes (full CRUD + inventory)
 router.use('/admin/products', adminProductRoutes);
+
+// Vendor routes
+router.use('/vendors', vendorRoutes);
+
+// Admin vendor routes
+router.use('/admin/vendors', adminVendorRoutes);
 
 // Profile public routes (MUST be before publicRoutes to avoid /profile/:code conflict)
 import profilePublicRoutes from './profile-public.routes';

--- a/backend/src/routes/vendor.routes.ts
+++ b/backend/src/routes/vendor.routes.ts
@@ -1,0 +1,151 @@
+/**
+ * @fileoverview Vendor Routes - Vendor management endpoints
+ * @description Routes for vendor registration, profile, products, dashboard, and payouts
+ * @module routes/vendor.routes
+ * @author MLM Development Team
+ */
+import { Router } from 'express';
+import {
+  registerVendor,
+  getVendorProfile,
+  getVendorProducts,
+  getVendorDashboard,
+  requestPayout,
+} from '../controllers/VendorController';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: vendors
+ *     description: Vendor management / Gestión de vendedores
+ */
+
+/**
+ * @swagger
+ * /vendors/register:
+ *   post:
+ *     summary: Register as vendor / Registrarse como vendedor
+ *     tags: [vendors]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - businessName
+ *               - contactEmail
+ *             properties:
+ *               businessName:
+ *                 type: string
+ *                 example: "Mi Tienda Online"
+ *               contactEmail:
+ *                 type: string
+ *                 format: email
+ *                 example: "tienda@ejemplo.com"
+ *               contactPhone:
+ *                 type: string
+ *                 example: "+1234567890"
+ *               description:
+ *                 type: string
+ *                 example: "Tienda de productos electrónicos"
+ *     responses:
+ *       201:
+ *         description: Vendor registered / Vendedor registrado
+ *       400:
+ *         description: Validation error or vendor exists / Error de validación o vendedor existe
+ */
+router.post('/register', registerVendor);
+
+/**
+ * @swagger
+ * /vendors/me:
+ *   get:
+ *     summary: Get vendor profile / Obtener perfil del vendedor
+ *     tags: [vendors]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Vendor profile / Perfil del vendedor
+ *       404:
+ *         description: Vendor not found / Vendedor no encontrado
+ */
+router.get('/me', getVendorProfile);
+
+/**
+ * @swagger
+ * /vendors/me/products:
+ *   get:
+ *     summary: Get vendor products / Obtener productos del vendedor
+ *     tags: [vendors]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *     responses:
+ *       200:
+ *         description: Vendor products list / Lista de productos del vendedor
+ */
+router.get('/me/products', getVendorProducts);
+
+/**
+ * @swagger
+ * /vendors/me/dashboard:
+ *   get:
+ *     summary: Get vendor dashboard / Obtener panel del vendedor
+ *     tags: [vendors]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Dashboard data / Datos del panel
+ */
+router.get('/me/dashboard', getVendorDashboard);
+
+/**
+ * @swagger
+ * /vendors/me/payouts:
+ *   post:
+ *     summary: Request payout / Solicitar pago
+ *     tags: [vendors]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - amount
+ *             properties:
+ *               amount:
+ *                 type: number
+ *                 minimum: 1
+ *                 example: 100.00
+ *               paymentMethod:
+ *                 type: string
+ *                 example: "bank_transfer"
+ *     responses:
+ *       201:
+ *         description: Payout requested / Pago solicitado
+ *       400:
+ *         description: Invalid amount or insufficient balance / Monto inválido o saldo insuficiente
+ */
+router.post('/me/payouts', requestPayout);
+
+export default router;

--- a/backend/src/services/CommissionService.ts
+++ b/backend/src/services/CommissionService.ts
@@ -266,4 +266,185 @@ export class CommissionService {
 
     return approved;
   }
+
+  /**
+   * Calculate vendor commission (3-way split)
+   * Calcular comisión del vendedor (división 3 vías)
+   *
+   * For vendor products:
+   * - vendorAmount = price × vendor.commissionRate (e.g., $100 × 0.70 = $70.00)
+   * - platformFee = price - vendorAmount ($100 - $70 = $30.00)
+   * - mlmCommissions = platformFee × mlmRate[level] (from MLM tree)
+   * - platformNet = platformFee - sum(mlmCommissions) ($30 - upline commissions)
+   *
+   * For platform products (vendorId === null):
+   * - Works as before — full amount through MLM rates, no vendor split
+   *
+   * @param price - Product price
+   * @param vendorId - Vendor UUID (null for platform products)
+   * @param buyerId - Buyer UUID (to find upline)
+   * @param businessType - Business type for commission config
+   * @returns Commission split result
+   */
+  async calculateVendorCommission(
+    price: number,
+    vendorId: string | null,
+    buyerId: string,
+    businessType: string = 'producto'
+  ): Promise<{
+    vendorAmount: number;
+    platformFee: number;
+    mlmCommissions: Array<{ userId: string; level: string; amount: number }>;
+    platformNet: number;
+  }> {
+    // Platform product (no vendor split)
+    if (!vendorId) {
+      // Use existing commission logic - full amount goes through MLM
+      const upline = await this.getUplineWithDepth(buyerId);
+      const mlmCommissions: Array<{ userId: string; level: string; amount: number }> = [];
+
+      const commissionTypeMap: Record<number, 'level_1' | 'level_2' | 'level_3' | 'level_4'> = {
+        1: 'level_1',
+        2: 'level_2',
+        3: 'level_3',
+        4: 'level_4',
+      };
+
+      for (const ancestor of upline) {
+        if (ancestor.depth > 4) break;
+
+        const type = commissionTypeMap[ancestor.depth];
+        if (!type) continue;
+
+        const rate = await this.getCommissionRate(businessType, type);
+        const amount = this.roundDecimal(price * rate, 2);
+        mlmCommissions.push({ userId: ancestor.id, level: type, amount });
+      }
+
+      const totalMlm = mlmCommissions.reduce((sum, c) => sum + c.amount, 0);
+
+      return {
+        vendorAmount: 0,
+        platformFee: price,
+        mlmCommissions,
+        platformNet: this.roundDecimal(price - totalMlm, 2),
+      };
+    }
+
+    // Vendor product - calculate 3-way split
+    const { Vendor } = await import('../models');
+    const vendor = await Vendor.findByPk(vendorId);
+
+    if (!vendor) {
+      throw new Error('Vendor not found');
+    }
+
+    if (vendor.status !== 'approved') {
+      throw new Error('Vendor is not approved');
+    }
+
+    const commissionRate = Number(vendor.commissionRate);
+
+    // Calculate vendor amount (e.g., $100 × 0.70 = $70.00)
+    const vendorAmount = this.roundDecimal(price * commissionRate, 2);
+
+    // Platform fee is what remains after vendor cut
+    const platformFee = this.roundDecimal(price - vendorAmount, 2);
+
+    // Calculate MLM commissions from platform fee
+    const buyer = await User.findByPk(buyerId);
+    if (!buyer || !buyer.sponsorId) {
+      // No upline - all platform fee is platform net
+      return {
+        vendorAmount,
+        platformFee,
+        mlmCommissions: [],
+        platformNet: platformFee,
+      };
+    }
+
+    const upline = await this.getUplineWithDepth(buyerId);
+    const mlmCommissions: Array<{ userId: string; level: string; amount: number }> = [];
+
+    const commissionTypeMap: Record<number, 'level_1' | 'level_2' | 'level_3' | 'level_4'> = {
+      1: 'level_1',
+      2: 'level_2',
+      3: 'level_3',
+      4: 'level_4',
+    };
+
+    for (const ancestor of upline) {
+      if (ancestor.depth > 4) break;
+      if (ancestor.id === buyer.sponsorId) continue; // Skip direct sponsor (handled separately)
+
+      const type = commissionTypeMap[ancestor.depth];
+      if (!type) continue;
+
+      const rate = await this.getCommissionRate(businessType, type);
+      // MLM commission is calculated from platform fee, not full price
+      const amount = this.roundDecimal(platformFee * rate, 2);
+      mlmCommissions.push({ userId: ancestor.id, level: type, amount });
+    }
+
+    const totalMlm = mlmCommissions.reduce((sum, c) => sum + c.amount, 0);
+    const platformNet = this.roundDecimal(platformFee - totalMlm, 2);
+
+    // Verify: vendorAmount + platformNet + sum(mlm) === price
+    const verification = this.roundDecimal(vendorAmount + platformNet + totalMlm, 2);
+    if (verification !== this.roundDecimal(price, 2)) {
+      console.warn(
+        `[CommissionService] Commission math verification failed: ${verification} !== ${this.roundDecimal(price, 2)}`
+      );
+    }
+
+    return {
+      vendorAmount,
+      platformFee,
+      mlmCommissions,
+      platformNet,
+    };
+  }
+
+  /**
+   * Round decimal using HALF_UP mode
+   * Redondear decimal usando modo HALF_UP
+   */
+  private roundDecimal(value: number, decimals: number): number {
+    const multiplier = Math.pow(10, decimals);
+    return Math.round(value * multiplier) / multiplier;
+  }
+
+  /**
+   * Create MLM commissions from vendor commission split
+   * Crear comisiones MLM desde la división de comisión del vendedor
+   *
+   * @param mlmCommissions - Array of MLM commission objects
+   * @param purchaseId - Purchase ID
+   * @param buyerId - Buyer UUID
+   * @param totalAmount - Total order amount for currency reference
+   */
+  async createMlmCommissionsFromSplit(
+    mlmCommissions: Array<{ userId: string; level: string; amount: number }>,
+    purchaseId: string,
+    buyerId: string,
+    totalAmount: number
+  ): Promise<Commission[]> {
+    const createdCommissions: Commission[] = [];
+    const buyer = await User.findByPk(buyerId);
+
+    for (const commission of mlmCommissions) {
+      const comm = await Commission.create({
+        userId: commission.userId,
+        fromUserId: buyerId,
+        purchaseId,
+        type: commission.level as 'level_1' | 'level_2' | 'level_3' | 'level_4',
+        amount: commission.amount,
+        currency: buyer?.currency || 'USD',
+        status: 'pending',
+      });
+      createdCommissions.push(comm);
+    }
+
+    return createdCommissions;
+  }
 }

--- a/backend/src/services/OrderService.ts
+++ b/backend/src/services/OrderService.ts
@@ -13,7 +13,7 @@
  * const order = await orderService.createOrder(userId, { productId, paymentMethod });
  */
 import { sequelize } from '../config/database';
-import { Order, Product, Purchase, User } from '../models';
+import { Order, Product, Purchase, User, VendorOrder } from '../models';
 import { AppError } from '../middleware/error.middleware';
 import { CommissionService } from './CommissionService';
 import { body } from 'express-validator';
@@ -155,7 +155,44 @@ export class OrderService {
         // Skip commission calculation to prevent timeouts in integration tests
       } else {
         try {
-          await commissionService.calculateCommissions(purchase.id);
+          // Calculate vendor commission split (3-way split)
+          const vendorId = (product as any).vendorId || null;
+          const commissionResult = await commissionService.calculateVendorCommission(
+            totalAmount,
+            vendorId,
+            userId,
+            'producto'
+          );
+
+          // Create vendor order record for vendor products
+          if (vendorId) {
+            await VendorOrder.create(
+              {
+                orderId: order.id,
+                vendorId,
+                subtotal: totalAmount,
+                vendorAmount: commissionResult.vendorAmount,
+                platformAmount: commissionResult.platformNet,
+                commissionAmount: commissionResult.mlmCommissions.reduce(
+                  (sum, c) => sum + c.amount,
+                  0
+                ),
+                status: 'completed',
+              },
+              { transaction }
+            );
+
+            // Create MLM commissions for uplines
+            await commissionService.createMlmCommissionsFromSplit(
+              commissionResult.mlmCommissions,
+              purchase.id,
+              userId,
+              totalAmount
+            );
+          } else {
+            // Platform product - use existing logic
+            await commissionService.calculateCommissions(purchase.id);
+          }
         } catch (commissionError) {
           // Log and throw AppError so that transaction is rolled back and error is propagated
           console.error('Commission calculation failed:', commissionError);

--- a/backend/src/services/VendorService.ts
+++ b/backend/src/services/VendorService.ts
@@ -1,0 +1,330 @@
+/**
+ * @fileoverview VendorService - Vendor management for multi-vendor marketplace
+ * @description Service for vendor registration, approval, dashboard, and payout management
+ * @module services/VendorService
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Register as vendor
+ * const vendor = await vendorService.register(userId, { businessName, contactEmail });
+ *
+ * // Español: Registrarse como vendedor
+ * const vendor = await vendorService.register(idUsuario, { businessName, contactEmail });
+ */
+import { sequelize } from '../config/database';
+import { Vendor, VendorPayout, Product, VendorOrder } from '../models';
+import { AppError } from '../middleware/error.middleware';
+import { Op } from 'sequelize';
+import type {
+  VendorAttributes,
+  VendorCreationAttributes,
+  VendorPayoutCreationAttributes,
+} from '../types';
+
+export class VendorService {
+  /**
+   * Register a new vendor
+   * Registrar un nuevo vendedor
+   *
+   * @param userId - User UUID
+   * @param data - Vendor registration data
+   * @returns Created vendor
+   */
+  async register(
+    userId: string,
+    data: {
+      businessName: string;
+      contactEmail: string;
+      contactPhone?: string;
+      description?: string;
+      address?: Record<string, unknown>;
+    }
+  ): Promise<Vendor> {
+    // Check if user already has a vendor profile
+    const existing = await Vendor.findOne({ where: { userId } });
+    if (existing) {
+      throw new AppError(400, 'VENDOR_EXISTS', 'User already has a vendor profile');
+    }
+
+    // Generate slug from business name
+    const slug = this.generateSlug(data.businessName);
+
+    // Check slug uniqueness
+    const slugExists = await Vendor.findOne({ where: { slug } });
+    if (slugExists) {
+      throw new AppError(400, 'SLUG_EXISTS', 'Business name slug already exists');
+    }
+
+    // Create vendor
+    const vendor = await Vendor.create({
+      userId,
+      businessName: data.businessName,
+      slug,
+      contactEmail: data.contactEmail,
+      contactPhone: data.contactPhone || null,
+      description: data.description || null,
+      address: data.address || null,
+      status: 'pending',
+      commissionRate: 0.7, // Default 70%
+    });
+
+    return vendor;
+  }
+
+  /**
+   * Approve a vendor
+   * Aprobar un vendedor
+   *
+   * @param vendorId - Vendor UUID
+   * @param adminId - Admin UUID who approved
+   * @returns Updated vendor
+   */
+  async approve(vendorId: string, adminId: string): Promise<Vendor> {
+    const vendor = await this.getById(vendorId);
+
+    if (vendor.status !== 'pending') {
+      throw new AppError(400, 'INVALID_STATUS', 'Only pending vendors can be approved');
+    }
+
+    vendor.status = 'approved';
+    vendor.approvedAt = new Date();
+    vendor.approvedBy = adminId;
+    await vendor.save();
+
+    return vendor;
+  }
+
+  /**
+   * Reject a vendor
+   * Rechazar un vendedor
+   *
+   * @param vendorId - Vendor UUID
+   * @param reason - Rejection reason
+   * @returns Updated vendor
+   */
+  async reject(vendorId: string, reason: string): Promise<Vendor> {
+    const vendor = await this.getById(vendorId);
+
+    if (vendor.status !== 'pending') {
+      throw new AppError(400, 'INVALID_STATUS', 'Only pending vendors can be rejected');
+    }
+
+    vendor.status = 'rejected';
+    vendor.metadata = {
+      ...((vendor.metadata as Record<string, unknown>) || {}),
+      rejectionReason: reason,
+    };
+    await vendor.save();
+
+    return vendor;
+  }
+
+  /**
+   * Suspend a vendor
+   * Suspender un vendedor
+   *
+   * @param vendorId - Vendor UUID
+   * @param reason - Suspension reason
+   * @returns Updated vendor
+   */
+  async suspend(vendorId: string, reason: string): Promise<Vendor> {
+    const vendor = await this.getById(vendorId);
+
+    if (vendor.status !== 'approved') {
+      throw new AppError(400, 'INVALID_STATUS', 'Only approved vendors can be suspended');
+    }
+
+    vendor.status = 'suspended';
+    vendor.metadata = {
+      ...((vendor.metadata as Record<string, unknown>) || {}),
+      suspensionReason: reason,
+    };
+    await vendor.save();
+
+    return vendor;
+  }
+
+  /**
+   * Get vendor by user ID
+   * Obtener vendedor por ID de usuario
+   *
+   * @param userId - User UUID
+   * @returns Vendor or null
+   */
+  async getByUserId(userId: string): Promise<Vendor | null> {
+    return Vendor.findOne({ where: { userId } });
+  }
+
+  /**
+   * Get vendor by ID
+   * Obtener vendedor por ID
+   *
+   * @param vendorId - Vendor UUID
+   * @returns Vendor
+   */
+  async getById(vendorId: string): Promise<Vendor> {
+    const vendor = await Vendor.findByPk(vendorId);
+    if (!vendor) {
+      throw new AppError(404, 'VENDOR_NOT_FOUND', 'Vendor not found');
+    }
+    return vendor;
+  }
+
+  /**
+   * List vendors with pagination and filters
+   * Listar vendedores con paginación y filtros
+   */
+  async list(options?: {
+    page?: number;
+    limit?: number;
+    status?: string;
+  }): Promise<{ rows: Vendor[]; count: number }> {
+    const page = options?.page || 1;
+    const limit = Math.min(options?.limit || 20, 100);
+    const offset = (page - 1) * limit;
+
+    const where: Record<string, unknown> = {};
+    if (options?.status) {
+      where.status = options.status;
+    }
+
+    return Vendor.findAndCountAll({
+      where,
+      limit,
+      offset,
+      order: [['createdAt', 'DESC']],
+    });
+  }
+
+  /**
+   * Get vendor dashboard data
+   * Obtener datos del panel del vendedor
+   *
+   * @param vendorId - Vendor UUID
+   * @returns Dashboard data
+   */
+  async getDashboard(vendorId: string): Promise<{
+    totalSales: number;
+    totalRevenue: number;
+    pendingPayouts: number;
+    productCount: number;
+    recentSales: Array<{
+      orderId: string;
+      amount: number;
+      status: string;
+      createdAt: Date;
+    }>;
+  }> {
+    // Get vendor's orders
+    const vendorOrders = await VendorOrder.findAll({
+      where: { vendorId, status: 'completed' },
+      order: [['createdAt', 'DESC']],
+      limit: 10,
+    });
+
+    // Calculate totals
+    const totalRevenue = vendorOrders.reduce((sum, order) => sum + Number(order.vendorAmount), 0);
+    const totalSales = vendorOrders.length;
+
+    // Get pending payouts
+    const pendingPayouts = await VendorPayout.sum('amount', {
+      where: { vendorId, status: 'pending' },
+    });
+
+    // Get product count
+    const productCount = await Product.count({
+      where: { vendorId },
+    });
+
+    // Get recent sales
+    const recentSales = vendorOrders.map((order) => ({
+      orderId: order.orderId,
+      amount: Number(order.vendorAmount),
+      status: order.status,
+      createdAt: order.createdAt,
+    }));
+
+    return {
+      totalSales,
+      totalRevenue,
+      pendingPayouts: pendingPayouts || 0,
+      productCount,
+      recentSales,
+    };
+  }
+
+  /**
+   * Request a payout
+   * Solicitar un pago
+   *
+   * @param vendorId - Vendor UUID
+   * @param amount - Payout amount
+   * @param paymentMethod - Payment method
+   * @returns Created payout
+   */
+  async requestPayout(
+    vendorId: string,
+    amount: number,
+    paymentMethod?: string
+  ): Promise<VendorPayout> {
+    const vendor = await this.getById(vendorId);
+
+    if (vendor.status !== 'approved') {
+      throw new AppError(400, 'INVALID_STATUS', 'Only approved vendors can request payouts');
+    }
+
+    // Get vendor's completed orders total
+    const completedOrders = await VendorOrder.findAll({
+      where: { vendorId, status: 'completed' },
+    });
+
+    const totalEarnings = completedOrders.reduce(
+      (sum, order) => sum + Number(order.vendorAmount),
+      0
+    );
+
+    // Get already paid payouts
+    const paidPayouts = await VendorPayout.sum('amount', {
+      where: { vendorId, status: { [Op.in]: ['completed', 'processing'] } },
+    });
+
+    const availableBalance = totalEarnings - (paidPayouts || 0);
+
+    if (amount > availableBalance) {
+      throw new AppError(400, 'INSUFFICIENT_BALANCE', 'Payout amount exceeds available balance');
+    }
+
+    // Calculate period (last 30 days by default)
+    const periodEnd = new Date();
+    const periodStart = new Date(periodEnd.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+    // Create payout request
+    const payout = await VendorPayout.create({
+      vendorId,
+      amount,
+      currency: 'USD',
+      status: 'pending',
+      paymentMethod: paymentMethod || null,
+      periodStart,
+      periodEnd,
+      requestedAt: new Date(),
+    });
+
+    return payout;
+  }
+
+  /**
+   * Generate a URL-safe slug from business name
+   * Generar slug URL-safe desde nombre de negocio
+   */
+  private generateSlug(name: string): string {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .substring(0, 255);
+  }
+}
+
+export const vendorService = new VendorService();

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -749,6 +749,7 @@ export interface GenericProductAttributes extends ProductAttributes {
   maxQuantityPerUser: number | null;
   metadata: Record<string, unknown> | null;
   images: string[];
+  vendorId: string | null;
 }
 
 export interface GenericProductCreationAttributes extends ProductCreationAttributes {
@@ -760,6 +761,7 @@ export interface GenericProductCreationAttributes extends ProductCreationAttribu
   maxQuantityPerUser?: number | null;
   metadata?: Record<string, unknown> | null;
   images?: string[];
+  vendorId?: string | null;
 }
 
 /**
@@ -1195,4 +1197,192 @@ export interface CreateCampaignDto {
   name: string;
   recipientSegment?: Record<string, unknown> | null;
   scheduledFor?: Date | null;
+}
+
+// ============================================
+// MARKETPLACE MULTI-VENDOR — Phase 2 (#25)
+// MULTI-VENDEDOR — Fase 2 (#25)
+// ============================================
+
+/**
+ * Vendor status lifecycle
+ * Ciclo de vida del estado del vendedor
+ */
+export const VENDOR_STATUS = {
+  PENDING: 'pending',
+  APPROVED: 'approved',
+  SUSPENDED: 'suspended',
+  REJECTED: 'rejected',
+} as const;
+
+export type VendorStatus = (typeof VENDOR_STATUS)[keyof typeof VENDOR_STATUS];
+
+/**
+ * Vendor order status
+ * Estado del pedido del vendedor
+ */
+export const VENDOR_ORDER_STATUS = {
+  PENDING: 'pending',
+  PROCESSING: 'processing',
+  COMPLETED: 'completed',
+  CANCELLED: 'cancelled',
+} as const;
+
+export type VendorOrderStatus = (typeof VENDOR_ORDER_STATUS)[keyof typeof VENDOR_ORDER_STATUS];
+
+/**
+ * Vendor payout status
+ * Estado del pago al vendedor
+ */
+export const VENDOR_PAYOUT_STATUS = {
+  PENDING: 'pending',
+  PROCESSING: 'processing',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+} as const;
+
+export type VendorPayoutStatus = (typeof VENDOR_PAYOUT_STATUS)[keyof typeof VENDOR_PAYOUT_STATUS];
+
+/**
+ * Vendor attributes
+ * Atributos del vendedor
+ */
+export interface VendorAttributes {
+  id: string;
+  userId: string;
+  businessName: string;
+  slug: string;
+  description: string | null;
+  logoUrl: string | null;
+  status: VendorStatus;
+  commissionRate: number; // DECIMAL(5,4) - default 0.7000 (70%)
+  contactEmail: string;
+  contactPhone: string | null;
+  address: Record<string, unknown> | null;
+  bankDetails: Record<string, unknown> | null; // Encrypted
+  metadata: Record<string, unknown> | null;
+  approvedAt: Date | null;
+  approvedBy: string | null;
+  deletedAt: Date | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * Vendor creation attributes
+ * Atributos para crear vendedor
+ */
+export interface VendorCreationAttributes {
+  userId: string;
+  businessName: string;
+  slug: string;
+  description?: string | null;
+  logoUrl?: string | null;
+  status?: VendorStatus;
+  commissionRate?: number;
+  contactEmail: string;
+  contactPhone?: string | null;
+  address?: Record<string, unknown> | null;
+  bankDetails?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+/**
+ * Vendor order attributes
+ * Atributos del pedido del vendedor
+ */
+export interface VendorOrderAttributes {
+  id: string;
+  orderId: string;
+  vendorId: string | null; // null for platform orders
+  subtotal: number;
+  commissionAmount: number; // DECIMAL(10,4)
+  vendorAmount: number; // DECIMAL(10,4)
+  platformAmount: number; // DECIMAL(10,4)
+  status: VendorOrderStatus;
+  notes: string | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * Vendor order creation attributes
+ * Atributos para crear pedido de vendedor
+ */
+export interface VendorOrderCreationAttributes {
+  orderId: string;
+  vendorId?: string | null;
+  subtotal: number;
+  commissionAmount?: number;
+  vendorAmount?: number;
+  platformAmount?: number;
+  status?: VendorOrderStatus;
+  notes?: string | null;
+}
+
+/**
+ * Vendor payout attributes
+ * Atributos del pago al vendedor
+ */
+export interface VendorPayoutAttributes {
+  id: string;
+  vendorId: string;
+  amount: number; // DECIMAL(10,2)
+  currency: string; // Default: 'USD'
+  status: VendorPayoutStatus;
+  paymentMethod: string | null;
+  paymentReference: string | null;
+  periodStart: Date | null;
+  periodEnd: Date | null;
+  requestedAt: Date;
+  processedAt: Date | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * Vendor payout creation attributes
+ * Atributos para crear pago al vendedor
+ */
+export interface VendorPayoutCreationAttributes {
+  vendorId: string;
+  amount: number;
+  currency?: string;
+  status?: VendorPayoutStatus;
+  paymentMethod?: string | null;
+  paymentReference?: string | null;
+  periodStart?: Date | null;
+  periodEnd?: Date | null;
+}
+
+/**
+ * Commission split result for vendor orders
+ * Resultado de división de comisiones para pedidos de vendedor
+ */
+export interface VendorCommissionSplit {
+  vendorAmount: number;
+  platformFee: number;
+  mlmCommissions: Array<{
+    userId: string;
+    level: string;
+    amount: number;
+  }>;
+  platformNet: number;
+}
+
+/**
+ * Vendor dashboard data
+ * Datos del panel del vendedor
+ */
+export interface VendorDashboardData {
+  totalSales: number;
+  totalRevenue: number;
+  pendingPayouts: number;
+  productCount: number;
+  recentSales: Array<{
+    orderId: string;
+    amount: number;
+    status: VendorOrderStatus;
+    createdAt: Date;
+  }>;
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -36,6 +36,10 @@ import type {
   InventoryReturnPayload,
   CreateCategoryPayload,
   UpdateCategoryPayload,
+  Vendor,
+  VendorRegistrationPayload,
+  VendorDashboard,
+  VendorPayoutRequest,
 } from '../types';
 
 /** @constant {string} API_URL - Backend base URL / URL base del backend */
@@ -954,6 +958,158 @@ export const walletService = {
    */
   getCryptoPrices: async (): Promise<CryptoPrices> => {
     const response = await api.get<{ success: boolean; data: CryptoPrices }>('/wallet/prices');
+    return response.data.data!;
+  },
+};
+
+/**
+ * @namespace vendorService
+ * @description Vendor API methods - Marketplace vendor operations
+ */
+export const vendorService = {
+  /**
+   * Register as a vendor
+   * Registrarse como vendedor
+   * @param {VendorRegistrationPayload} data - Vendor registration data
+   * @returns {Promise<Vendor>} Created vendor
+   */
+  register: async (data: VendorRegistrationPayload): Promise<Vendor> => {
+    const response = await api.post<{ success: boolean; data: Vendor }>('/vendors/register', data);
+    return response.data.data!;
+  },
+
+  /**
+   * Get current vendor profile
+   * Obtener perfil del vendedor actual
+   * @returns {Promise<Vendor>} Vendor profile
+   */
+  getProfile: async (): Promise<Vendor> => {
+    const response = await api.get<{ success: boolean; data: Vendor }>('/vendors/me');
+    return response.data.data!;
+  },
+
+  /**
+   * Get vendor products
+   * Obtener productos del vendedor
+   * @param {number} page - Page number
+   * @param {number} limit - Items per page
+   * @returns {Promise<{data: Product[]; pagination: any}>} Vendor products with pagination
+   */
+  getProducts: async (page?: number, limit?: number) => {
+    const response = await api.get('/vendors/me/products', { params: { page, limit } });
+    return response.data;
+  },
+
+  /**
+   * Get vendor dashboard
+   * Obtener panel del vendedor
+   * @returns {Promise<VendorDashboard>} Dashboard data
+   */
+  getDashboard: async (): Promise<VendorDashboard> => {
+    const response = await api.get<{ success: boolean; data: VendorDashboard }>(
+      '/vendors/me/dashboard'
+    );
+    return response.data.data!;
+  },
+
+  /**
+   * Request payout
+   * Solicitar pago
+   * @param {VendorPayoutRequest} data - Payout request data
+   * @returns {Promise<any>} Created payout
+   */
+  requestPayout: async (data: VendorPayoutRequest) => {
+    const response = await api.post<{ success: boolean; data: any }>('/vendors/me/payouts', data);
+    return response.data.data!;
+  },
+};
+
+/**
+ * @namespace adminVendorService
+ * @description Admin Vendor API methods - Vendor management for admins
+ */
+export const adminVendorService = {
+  /**
+   * List all vendors
+   * Listar todos los vendedores
+   * @param {number} page - Page number
+   * @param {number} limit - Items per page
+   * @param {string} status - Filter by status
+   * @returns {Promise<{data: Vendor[]; pagination: any}>} Vendor list with pagination
+   */
+  listVendors: async (page?: number, limit?: number, status?: string) => {
+    const response = await api.get('/admin/vendors', { params: { page, limit, status } });
+    return response.data;
+  },
+
+  /**
+   * Get vendor by ID
+   * Obtener vendedor por ID
+   * @param {string} vendorId - Vendor ID
+   * @returns {Promise<Vendor>} Vendor data
+   */
+  getVendor: async (vendorId: string): Promise<Vendor> => {
+    const response = await api.get<{ success: boolean; data: Vendor }>(
+      `/admin/vendors/${vendorId}`
+    );
+    return response.data.data!;
+  },
+
+  /**
+   * Approve vendor
+   * Aprobar vendedor
+   * @param {string} vendorId - Vendor ID
+   * @returns {Promise<Vendor>} Updated vendor
+   */
+  approveVendor: async (vendorId: string): Promise<Vendor> => {
+    const response = await api.post<{ success: boolean; data: Vendor }>(
+      `/admin/vendors/${vendorId}/approve`
+    );
+    return response.data.data!;
+  },
+
+  /**
+   * Reject vendor
+   * Rechazar vendedor
+   * @param {string} vendorId - Vendor ID
+   * @param {string} reason - Rejection reason
+   * @returns {Promise<Vendor>} Updated vendor
+   */
+  rejectVendor: async (vendorId: string, reason: string): Promise<Vendor> => {
+    const response = await api.post<{ success: boolean; data: Vendor }>(
+      `/admin/vendors/${vendorId}/reject`,
+      { reason }
+    );
+    return response.data.data!;
+  },
+
+  /**
+   * Suspend vendor
+   * Suspender vendedor
+   * @param {string} vendorId - Vendor ID
+   * @param {string} reason - Suspension reason
+   * @returns {Promise<Vendor>} Updated vendor
+   */
+  suspendVendor: async (vendorId: string, reason: string): Promise<Vendor> => {
+    const response = await api.post<{ success: boolean; data: Vendor }>(
+      `/admin/vendors/${vendorId}/suspend`,
+      { reason }
+    );
+    return response.data.data!;
+  },
+
+  /**
+   * Update vendor commission rate
+   * Actualizar tasa de comisión del vendedor
+   * @param {string} vendorId - Vendor ID
+   * @param {number} commissionRate - New commission rate (0-1)
+   * @returns {Promise<Vendor>} Updated vendor
+   */
+  updateCommissionRate: async (vendorId: string, commissionRate: number): Promise<Vendor> => {
+    const response = await api.patch<{ success: boolean; data: Vendor }>(
+      `/admin/vendors/${vendorId}/commission-rate`,
+      { commissionRate }
+    );
     return response.data.data!;
   },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -746,3 +746,126 @@ export type TemplateVariable = (typeof ALLOWED_TEMPLATE_VARIABLES)[number];
 
 // Push Notification Types
 export * from './push';
+
+// ============================================
+// MARKETPLACE MULTI-VENDOR — Phase 2 (#25)
+// MULTI-VENDEDOR — Fase 2 (#25)
+// ============================================
+
+/**
+ * Vendor status lifecycle
+ * Ciclo de vida del estado del vendedor
+ */
+export type VendorStatus = 'pending' | 'approved' | 'suspended' | 'rejected';
+
+/**
+ * Vendor order status
+ * Estado del pedido del vendedor
+ */
+export type VendorOrderStatus = 'pending' | 'processing' | 'completed' | 'cancelled';
+
+/**
+ * Vendor payout status
+ * Estado del pago al vendedor
+ */
+export type VendorPayoutStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+/**
+ * Vendor attributes
+ * Atributos del vendedor
+ */
+export interface Vendor {
+  id: string;
+  userId: string;
+  businessName: string;
+  slug: string;
+  description?: string | null;
+  logoUrl?: string | null;
+  status: VendorStatus;
+  commissionRate: number;
+  contactEmail: string;
+  contactPhone?: string | null;
+  address?: Record<string, unknown> | null;
+  bankDetails?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+  approvedAt?: string | null;
+  approvedBy?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Vendor creation payload
+ * Payload para crear vendedor
+ */
+export interface VendorRegistrationPayload {
+  businessName: string;
+  contactEmail: string;
+  contactPhone?: string;
+  description?: string;
+  address?: Record<string, unknown>;
+}
+
+/**
+ * Vendor order attributes
+ * Atributos del pedido del vendedor
+ */
+export interface VendorOrder {
+  id: string;
+  orderId: string;
+  vendorId?: string | null;
+  subtotal: number;
+  commissionAmount: number;
+  vendorAmount: number;
+  platformAmount: number;
+  status: VendorOrderStatus;
+  notes?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Vendor payout attributes
+ * Atributos del pago al vendedor
+ */
+export interface VendorPayout {
+  id: string;
+  vendorId: string;
+  amount: number;
+  currency: string;
+  status: VendorPayoutStatus;
+  paymentMethod?: string | null;
+  paymentReference?: string | null;
+  periodStart?: string | null;
+  periodEnd?: string | null;
+  requestedAt: string;
+  processedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Vendor payout request
+ * Solicitud de pago del vendedor
+ */
+export interface VendorPayoutRequest {
+  amount: number;
+  paymentMethod?: string;
+}
+
+/**
+ * Vendor dashboard data
+ * Datos del panel del vendedor
+ */
+export interface VendorDashboard {
+  totalSales: number;
+  totalRevenue: number;
+  pendingPayouts: number;
+  productCount: number;
+  recentSales: Array<{
+    orderId: string;
+    amount: number;
+    status: VendorOrderStatus;
+    createdAt: string;
+  }>;
+}


### PR DESCRIPTION
## Summary

- Added vendor, vendor_orders, vendor_payouts models and database migrations
- Implemented 3-way commission split: vendor amount + platform net + MLM commissions
- Added VendorService with registration, approval, rejection, suspension, dashboard, and payout request methods
- Created VendorController and AdminVendorController with full REST API routes
- Added frontend vendor types and API service methods
- Updated auth middleware with requireVendor, requireVendorOrAdmin, and canManageProduct helper
- Modified OrderService to split multi-vendor orders and calculate commissions atomically
- Added comprehensive unit tests for VendorService and CommissionService

## Changes

### Backend
- **Models**: Vendor, VendorOrder, VendorPayout with proper associations
- **Migrations**: 3 migration files for vendor role enum, vendor tables, and vendorId FK on products
- **Services**: VendorService (registration, approval, dashboard, payouts) + CommissionService methods (calculateVendorCommission, createMlmCommissionsFromSplit)
- **Controllers**: VendorController (register, profile, products, dashboard, payouts) + AdminVendorController (list, approve, reject, suspend)
- **Routes**: /api/vendors/* (vendor) and /api/admin/vendors/* (admin) with Swagger annotations

### Frontend
- **Types**: Vendor, VendorOrder, VendorPayout, VendorStatus, VendorOrderStatus, VendorPayoutStatus
- **API**: vendorService and adminVendorService methods

### Tests
- VendorService.test.ts: 20 tests for registration, approval, rejection, suspension, dashboard, payouts
- CommissionService.test.ts: 5 tests for vendor commission split logic
- OrderService.test.ts: Updated mocks for new commission methods

Closes #25