### PR TITLE
feat(delivery): shipping addresses, shipment tracking, webhooks

### DIFF
--- a/backend/database/migrations/20260404123835-add-shipping-fields-to-orders.js
+++ b/backend/database/migrations/20260404123835-add-shipping-fields-to-orders.js
@@ -1,0 +1,46 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add shipping fields to orders table
+    await queryInterface.addColumn('orders', 'shipping_address_id', {
+      type: Sequelize.UUID,
+      allowNull: true,
+      field: 'shipping_address_id',
+      comment: 'FK to shipping_addresses table',
+    });
+
+    await queryInterface.addColumn('orders', 'shipping_cost', {
+      type: Sequelize.DECIMAL(10, 2),
+      allowNull: true,
+      field: 'shipping_cost',
+      comment: 'Cost of shipping',
+    });
+
+    await queryInterface.addColumn('orders', 'shipping_status', {
+      type: Sequelize.ENUM(
+        'not_required',
+        'pending_shipment',
+        'shipped',
+        'in_transit',
+        'delivered'
+      ),
+      allowNull: true,
+      defaultValue: 'not_required',
+      field: 'shipping_status',
+      comment: 'Shipping status for the order',
+    });
+
+    // Add indexes for the new columns
+    await queryInterface.addIndex('orders', ['shipping_address_id']);
+    await queryInterface.addIndex('orders', ['shipping_status']);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeIndex('orders', ['shipping_status']);
+    await queryInterface.removeIndex('orders', ['shipping_address_id']);
+    await queryInterface.removeColumn('orders', 'shipping_status');
+    await queryInterface.removeColumn('orders', 'shipping_cost');
+    await queryInterface.removeColumn('orders', 'shipping_address_id');
+  },
+};

--- a/backend/database/migrations/20260404123836-create-shipping-addresses.js
+++ b/backend/database/migrations/20260404123836-create-shipping-addresses.js
@@ -1,0 +1,87 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('shipping_addresses', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        comment: 'FK to users table',
+      },
+      label: {
+        type: Sequelize.STRING(100),
+        allowNull: true,
+        comment: 'User-defined label (e.g., "Home", "Office")',
+      },
+      recipient_name: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+        field: 'recipient_name',
+      },
+      street: {
+        type: Sequelize.STRING(500),
+        allowNull: false,
+      },
+      city: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      state: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      postal_code: {
+        type: Sequelize.STRING(20),
+        allowNull: false,
+        field: 'postal_code',
+      },
+      country: {
+        type: Sequelize.STRING(3),
+        allowNull: false,
+        comment: 'ISO 3166-1 alpha-3 country code',
+      },
+      phone: {
+        type: Sequelize.STRING(50),
+        allowNull: true,
+      },
+      is_default: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        field: 'is_default',
+      },
+      instructions: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+        comment: 'Delivery instructions',
+      },
+      deleted_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+        field: 'deleted_at',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+      },
+    });
+
+    await queryInterface.addIndex('shipping_addresses', ['user_id']);
+    await queryInterface.addIndex('shipping_addresses', ['user_id', 'is_default']);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('shipping_addresses');
+  },
+};

--- a/backend/database/migrations/20260404123837-create-delivery-providers.js
+++ b/backend/database/migrations/20260404123837-create-delivery-providers.js
@@ -1,0 +1,63 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('delivery_providers', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+      },
+      name: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      slug: {
+        type: Sequelize.STRING(100),
+        allowNull: false,
+        unique: true,
+      },
+      tracking_url_template: {
+        type: Sequelize.STRING(500),
+        allowNull: true,
+        field: 'tracking_url_template',
+        comment: 'Template for tracking URL, e.g., https://example.com/track/{tracking}',
+      },
+      webhook_secret: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+        field: 'webhook_secret',
+        comment: 'Secret for webhook signature validation (HMAC-SHA256)',
+      },
+      is_active: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+        field: 'is_active',
+      },
+      metadata: {
+        type: Sequelize.JSONB,
+        allowNull: true,
+        defaultValue: null,
+        comment: 'Flexible metadata for provider-specific settings',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+      },
+    });
+
+    await queryInterface.addIndex('delivery_providers', ['slug'], { unique: true });
+    await queryInterface.addIndex('delivery_providers', ['is_active']);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('delivery_providers');
+  },
+};

--- a/backend/database/migrations/20260404123838-create-shipment-trackings.js
+++ b/backend/database/migrations/20260404123838-create-shipment-trackings.js
@@ -1,0 +1,85 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('shipment_trackings', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+      },
+      order_id: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        field: 'order_id',
+        comment: 'FK to orders table',
+      },
+      vendor_order_id: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        field: 'vendor_order_id',
+        comment: 'FK to vendor_orders table',
+      },
+      provider_id: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        field: 'provider_id',
+        comment: 'FK to delivery_providers table',
+      },
+      tracking_number: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+        field: 'tracking_number',
+      },
+      status: {
+        type: Sequelize.ENUM(
+          'pending',
+          'picked_up',
+          'in_transit',
+          'out_for_delivery',
+          'delivered',
+          'failed',
+          'returned'
+        ),
+        allowNull: false,
+        defaultValue: 'pending',
+      },
+      status_history: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+        defaultValue: '[]',
+        field: 'status_history',
+        comment: 'Array of status history entries [{ status, timestamp, details? }]',
+      },
+      estimated_delivery: {
+        type: Sequelize.DATE,
+        allowNull: true,
+        field: 'estimated_delivery',
+      },
+      actual_delivery: {
+        type: Sequelize.DATE,
+        allowNull: true,
+        field: 'actual_delivery',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+      },
+    });
+
+    await queryInterface.addIndex('shipment_trackings', ['order_id']);
+    await queryInterface.addIndex('shipment_trackings', ['vendor_order_id']);
+    await queryInterface.addIndex('shipment_trackings', ['tracking_number']);
+    await queryInterface.addIndex('shipment_trackings', ['status']);
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('shipment_trackings');
+  },
+};

--- a/backend/src/__tests__/unit/ShipmentTrackingService.test.ts
+++ b/backend/src/__tests__/unit/ShipmentTrackingService.test.ts
@@ -1,0 +1,284 @@
+/**
+ * @fileoverview ShipmentTrackingService Unit Tests
+ * @description Tests for shipment tracking, status updates, and idempotency.
+ * @module __tests__/unit/ShipmentTrackingService.test
+ */
+
+// Mock sequelize first
+const mockTransaction = {
+  commit: jest.fn().mockResolvedValue(undefined),
+  rollback: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock('../../config/database', () => ({
+  sequelize: {
+    transaction: jest.fn().mockImplementation(() => Promise.resolve(mockTransaction)),
+    query: jest.fn(),
+    sync: jest.fn().mockResolvedValue({}),
+    authenticate: jest.fn().mockResolvedValue(undefined),
+  },
+  resetSequelize: jest.fn(),
+}));
+
+// Mock all models needed by the service
+const mockShipmentTracking = {
+  create: jest.fn(),
+  findOne: jest.fn(),
+  init: jest.fn(),
+  hasMany: jest.fn(),
+  belongsTo: jest.fn(),
+};
+
+const mockOrder = {
+  findByPk: jest.fn(),
+  init: jest.fn(),
+  hasMany: jest.fn(),
+  belongsTo: jest.fn(),
+};
+
+jest.mock('../../models', () => ({
+  ShipmentTracking: mockShipmentTracking,
+  Order: mockOrder,
+  VendorOrder: {
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  DeliveryProvider: {
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+}));
+
+// Mock AppError
+jest.mock('../../middleware/error.middleware', () => ({
+  AppError: class AppError extends Error {
+    constructor(
+      public statusCode: number,
+      public code: string,
+      message: string
+    ) {
+      super(message);
+      this.name = 'AppError';
+    }
+  },
+}));
+
+// Now import after mocks are in place
+import { ShipmentTrackingService } from '../../services/ShipmentTrackingService';
+
+describe('ShipmentTrackingService', () => {
+  let service: ShipmentTrackingService;
+
+  beforeEach(() => {
+    service = new ShipmentTrackingService();
+    jest.clearAllMocks();
+  });
+
+  describe('addTracking', () => {
+    it('should create tracking record for order', async () => {
+      const mockOrderInstance = { id: 'order-uuid', update: jest.fn() };
+      const mockTracking = {
+        id: 'tracking-uuid',
+        orderId: 'order-uuid',
+        trackingNumber: 'TRACK123',
+        status: 'picked_up',
+      };
+
+      (mockOrder.findByPk as jest.Mock).mockResolvedValue(mockOrderInstance);
+      (mockShipmentTracking.create as jest.Mock).mockResolvedValue(mockTracking);
+
+      const result = await service.addTracking('order-uuid', {
+        trackingNumber: 'TRACK123',
+      });
+
+      expect(result.trackingNumber).toBe('TRACK123');
+      expect(mockOrderInstance.update).toHaveBeenCalledWith({ shippingStatus: 'shipped' });
+    });
+
+    it('should throw error when order not found', async () => {
+      (mockOrder.findByPk as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.addTracking('non-existent', {
+          trackingNumber: 'TRACK123',
+        })
+      ).rejects.toThrow('Order not found');
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('should append new status to statusHistory', async () => {
+      const mockTrackingInstance = {
+        id: 'tracking-uuid',
+        trackingNumber: 'TRACK123',
+        statusHistory: [{ status: 'pending', timestamp: new Date() }],
+        orderId: 'order-uuid',
+        update: jest.fn(),
+        reload: jest.fn().mockResolvedValue({
+          id: 'tracking-uuid',
+          status: 'in_transit',
+        }),
+      };
+
+      const mockOrderInstance = {
+        id: 'order-uuid',
+        update: jest.fn(),
+      };
+
+      (mockShipmentTracking.findOne as jest.Mock).mockResolvedValue(mockTrackingInstance);
+      (mockOrder.findByPk as jest.Mock).mockResolvedValue(mockOrderInstance);
+
+      const result = await service.updateStatus('TRACK123', 'in_transit', 'Package in transit');
+
+      expect(result.status).toBe('in_transit');
+    });
+
+    it('should update order shipping status based on tracking status', async () => {
+      const mockOrderInstance = {
+        id: 'order-uuid',
+        update: jest.fn(),
+      };
+
+      const mockTrackingInstance = {
+        id: 'tracking-uuid',
+        trackingNumber: 'TRACK123',
+        statusHistory: [],
+        orderId: 'order-uuid',
+        update: jest.fn(),
+        reload: jest.fn().mockResolvedValue({
+          id: 'tracking-uuid',
+          status: 'delivered',
+        }),
+      };
+
+      (mockShipmentTracking.findOne as jest.Mock).mockResolvedValue(mockTrackingInstance);
+      (mockOrder.findByPk as jest.Mock).mockResolvedValue(mockOrderInstance);
+
+      await service.updateStatus('TRACK123', 'delivered');
+
+      expect(mockOrderInstance.update).toHaveBeenCalledWith({ shippingStatus: 'delivered' });
+    });
+
+    it('should throw error when tracking not found', async () => {
+      (mockShipmentTracking.findOne as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.updateStatus('NONEXISTENT', 'delivered')).rejects.toThrow(
+        'Shipment tracking not found'
+      );
+    });
+  });
+
+  describe('isDuplicateUpdate', () => {
+    it('should return true if same status and timestamp exists', async () => {
+      const timestamp = new Date('2024-01-01T10:00:00Z');
+      const mockTracking = {
+        trackingNumber: 'TRACK123',
+        statusHistory: [{ status: 'in_transit', timestamp }],
+      };
+
+      (mockShipmentTracking.findOne as jest.Mock).mockResolvedValue(mockTracking);
+
+      const result = await service.isDuplicateUpdate('TRACK123', 'in_transit', timestamp);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if status does not exist', async () => {
+      const timestamp = new Date('2024-01-01T10:00:00Z');
+      const mockTracking = {
+        trackingNumber: 'TRACK123',
+        statusHistory: [{ status: 'pending', timestamp }],
+      };
+
+      (mockShipmentTracking.findOne as jest.Mock).mockResolvedValue(mockTracking);
+
+      const result = await service.isDuplicateUpdate('TRACK123', 'in_transit', timestamp);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if tracking not found', async () => {
+      (mockShipmentTracking.findOne as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.isDuplicateUpdate('TRACK123', 'delivered', new Date());
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('handleWebhookUpdate', () => {
+    it('should add new status to history (not duplicate)', async () => {
+      const mockTrackingInstance = {
+        id: 'tracking-uuid',
+        trackingNumber: 'TRACK123',
+        status: 'pending',
+        statusHistory: [{ status: 'pending', timestamp: new Date() }],
+        orderId: 'order-uuid',
+        update: jest.fn(),
+        reload: jest.fn().mockResolvedValue({
+          id: 'tracking-uuid',
+          status: 'in_transit',
+          statusHistory: [
+            { status: 'pending', timestamp: new Date() },
+            { status: 'in_transit', timestamp: new Date() },
+          ],
+        }),
+      };
+
+      (mockShipmentTracking.findOne as jest.Mock).mockResolvedValue(mockTrackingInstance);
+
+      const result = await service.handleWebhookUpdate('TRACK123', 'in_transit');
+
+      expect(result.isNew).toBe(true);
+    });
+
+    it('should return isNew=false for duplicate status', async () => {
+      const existingTimestamp = new Date('2024-01-01T10:00:00Z');
+      const mockTrackingInstance = {
+        id: 'tracking-uuid',
+        trackingNumber: 'TRACK123',
+        status: 'in_transit',
+        statusHistory: [
+          { status: 'pending', timestamp: existingTimestamp },
+          { status: 'in_transit', timestamp: existingTimestamp },
+        ],
+        orderId: null,
+        update: jest.fn(),
+        reload: jest.fn(),
+      };
+
+      (mockShipmentTracking.findOne as jest.Mock).mockResolvedValue(mockTrackingInstance);
+
+      const result = await service.handleWebhookUpdate('TRACK123', 'in_transit');
+
+      expect(result.isNew).toBe(false);
+      expect(mockTrackingInstance.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getByOrder', () => {
+    it('should return tracking for order', async () => {
+      const mockTracking = { id: 'tracking-uuid', orderId: 'order-uuid' };
+      const mockProvider = { id: 'provider-uuid', name: 'Test Provider' };
+
+      (mockShipmentTracking.findOne as jest.Mock).mockResolvedValue({
+        ...mockTracking,
+        provider: mockProvider,
+      });
+
+      const result = await service.getByOrder('order-uuid');
+
+      expect(result).toBeDefined();
+    });
+
+    it('should return null when no tracking exists', async () => {
+      (mockShipmentTracking.findOne as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.getByOrder('order-uuid');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/backend/src/__tests__/unit/ShippingAddressService.test.ts
+++ b/backend/src/__tests__/unit/ShippingAddressService.test.ts
@@ -1,0 +1,255 @@
+/**
+ * @fileoverview ShippingAddressService Unit Tests
+ * @description Tests for shipping address CRUD and default management.
+ * @module __tests__/unit/ShippingAddressService.test
+ */
+
+// Mock sequelize
+jest.mock('../../config/database', () => ({
+  sequelize: {
+    transaction: jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        commit: jest.fn().mockResolvedValue(undefined),
+        rollback: jest.fn().mockResolvedValue(undefined),
+      })
+    ),
+    query: jest.fn(),
+    sync: jest.fn().mockResolvedValue({}),
+    authenticate: jest.fn().mockResolvedValue(undefined),
+  },
+  resetSequelize: jest.fn(),
+}));
+
+// Mock models
+jest.mock('../../models/ShippingAddress', () => ({
+  ShippingAddress: {
+    count: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+}));
+
+// Mock AppError
+jest.mock('../../middleware/error.middleware', () => ({
+  AppError: class AppError extends Error {
+    constructor(
+      public statusCode: number,
+      public code: string,
+      message: string
+    ) {
+      super(message);
+      this.name = 'AppError';
+    }
+  },
+}));
+
+import { ShippingAddressService } from '../../services/ShippingAddressService';
+const { ShippingAddress } = require('../../models/ShippingAddress');
+
+describe('ShippingAddressService', () => {
+  let service: ShippingAddressService;
+
+  beforeEach(() => {
+    service = new ShippingAddressService();
+    jest.clearAllMocks();
+    // Reset mock implementations to prevent state pollution
+    (ShippingAddress.update as jest.Mock).mockReset();
+  });
+
+  describe('create', () => {
+    it('should create first address as default', async () => {
+      const mockAddress = {
+        id: 'test-uuid',
+        userId: 'user-uuid',
+        recipientName: 'John Doe',
+        street: '123 Main St',
+        city: 'Bogota',
+        state: 'Cundinamarca',
+        postalCode: '110111',
+        country: 'COL',
+        isDefault: true,
+      };
+
+      (ShippingAddress.count as jest.Mock).mockResolvedValue(0);
+      (ShippingAddress.create as jest.Mock).mockResolvedValue(mockAddress);
+
+      const result = await service.create('user-uuid', {
+        recipientName: 'John Doe',
+        street: '123 Main St',
+        city: 'Bogota',
+        state: 'Cundinamarca',
+        postalCode: '110111',
+        country: 'COL',
+      });
+
+      expect(result.isDefault).toBe(true);
+      expect(ShippingAddress.create).toHaveBeenCalled();
+    });
+
+    it('should throw error when user has reached address limit', async () => {
+      (ShippingAddress.count as jest.Mock).mockResolvedValue(10);
+
+      await expect(
+        service.create('user-uuid', {
+          recipientName: 'John Doe',
+          street: '123 Main St',
+          city: 'Bogota',
+          state: 'Cundinamarca',
+          postalCode: '110111',
+          country: 'COL',
+        })
+      ).rejects.toThrow('Maximum of 10 addresses per user reached');
+
+      expect.assertions(1);
+    });
+
+    it('should set isDefault true when explicitly set', async () => {
+      const mockAddress = {
+        id: 'test-uuid',
+        userId: 'user-uuid',
+        recipientName: 'John Doe',
+        isDefault: true,
+      };
+
+      (ShippingAddress.count as jest.Mock).mockResolvedValue(2);
+      (ShippingAddress.update as jest.Mock).mockResolvedValue([1]);
+      (ShippingAddress.create as jest.Mock).mockResolvedValue(mockAddress);
+
+      const result = await service.create('user-uuid', {
+        recipientName: 'John Doe',
+        street: '123 Main St',
+        city: 'Bogota',
+        state: 'Cundinamarca',
+        postalCode: '110111',
+        country: 'COL',
+        isDefault: true,
+      });
+
+      expect(result.isDefault).toBe(true);
+    });
+  });
+
+  describe('findAllByUser', () => {
+    it('should return all addresses for user sorted by default first', async () => {
+      const mockAddresses = [
+        { id: 'addr-1', isDefault: true },
+        { id: 'addr-2', isDefault: false },
+      ];
+
+      (ShippingAddress.findAll as jest.Mock).mockResolvedValue(mockAddresses);
+
+      const result = await service.findAllByUser('user-uuid');
+
+      expect(result).toEqual(mockAddresses);
+      expect(ShippingAddress.findAll).toHaveBeenCalledWith({
+        where: { userId: 'user-uuid' },
+        order: [
+          ['isDefault', 'DESC'],
+          ['createdAt', 'DESC'],
+        ],
+      });
+    });
+  });
+
+  describe('findById', () => {
+    it('should return address when owned by user', async () => {
+      const mockAddress = { id: 'addr-uuid', userId: 'user-uuid' };
+
+      (ShippingAddress.findOne as jest.Mock).mockResolvedValue(mockAddress);
+      (ShippingAddress.update as jest.Mock).mockReset();
+
+      const result = await service.findById('addr-uuid', 'user-uuid');
+
+      expect(result).toEqual(mockAddress);
+    });
+
+    it('should throw error when address not found', async () => {
+      (ShippingAddress.findOne as jest.Mock).mockResolvedValue(null);
+      (ShippingAddress.update as jest.Mock).mockReset();
+
+      await expect(service.findById('non-existent', 'user-uuid')).rejects.toThrow(
+        'Shipping address not found'
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('should throw error when deleting default address', async () => {
+      const mockAddress = { id: 'addr-uuid', isDefault: true, destroy: jest.fn() };
+
+      (ShippingAddress.findOne as jest.Mock).mockResolvedValue(mockAddress);
+
+      await expect(service.delete('addr-uuid', 'user-uuid')).rejects.toThrow(
+        'Cannot delete default shipping address'
+      );
+
+      expect(mockAddress.destroy).not.toHaveBeenCalled();
+    });
+
+    it('should delete non-default address', async () => {
+      const mockAddress = { id: 'addr-uuid', isDefault: false, destroy: jest.fn() };
+
+      (ShippingAddress.findOne as jest.Mock).mockResolvedValue(mockAddress);
+
+      await service.delete('addr-uuid', 'user-uuid');
+
+      expect(mockAddress.destroy).toHaveBeenCalled();
+    });
+  });
+
+  describe('setDefault', () => {
+    it('should set new default and unset previous', async () => {
+      const mockAddress = {
+        id: 'addr-uuid',
+        isDefault: false,
+        update: jest.fn().mockResolvedValue(true),
+        reload: jest.fn().mockResolvedValue({ id: 'addr-uuid', isDefault: true }),
+      };
+
+      (ShippingAddress.findOne as jest.Mock).mockResolvedValue(mockAddress);
+      (ShippingAddress.update as jest.Mock).mockResolvedValue([1]);
+
+      const result = await service.setDefault('addr-uuid', 'user-uuid');
+
+      // Just verify the methods were called (don't check exact arguments due to transaction mocking)
+      expect(ShippingAddress.update).toHaveBeenCalled();
+      expect(mockAddress.update).toHaveBeenCalled();
+    });
+
+    it('should return same address if already default', async () => {
+      const mockAddress = { id: 'addr-uuid', isDefault: true };
+
+      (ShippingAddress.findOne as jest.Mock).mockResolvedValue(mockAddress);
+
+      const result = await service.setDefault('addr-uuid', 'user-uuid');
+
+      expect(result).toEqual(mockAddress);
+      expect(ShippingAddress.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getDefault', () => {
+    it('should return default address', async () => {
+      const mockAddress = { id: 'addr-uuid', isDefault: true };
+
+      (ShippingAddress.findOne as jest.Mock).mockResolvedValue(mockAddress);
+
+      const result = await service.getDefault('user-uuid');
+
+      expect(result).toEqual(mockAddress);
+    });
+
+    it('should return null when no default address', async () => {
+      (ShippingAddress.findOne as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.getDefault('user-uuid');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/backend/src/controllers/ShipmentTrackingController.ts
+++ b/backend/src/controllers/ShipmentTrackingController.ts
@@ -1,0 +1,177 @@
+/**
+ * @fileoverview ShipmentTrackingController - HTTP controller for shipment tracking
+ * @description Express controller for shipment tracking and webhook operations.
+ *             Controlador Express para seguimiento de envíos y operaciones webhook.
+ * @module controllers/ShipmentTrackingController
+ * @author MLM Development Team
+ */
+import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
+import { ShipmentTrackingService } from '../services/ShipmentTrackingService';
+import { DeliveryProvider } from '../models/DeliveryProvider';
+import { Order, Product, User } from '../models';
+import { AppError } from '../middleware/error.middleware';
+import { ApiResponse, ShipmentTrackingStatus } from '../types';
+
+const shipmentTrackingService = new ShipmentTrackingService();
+
+/**
+ * Validate webhook signature
+ * Validar firma del webhook
+ */
+function validateWebhookSignature(
+  payload: string,
+  signature: string | undefined,
+  secret: string | null
+): boolean {
+  if (!secret || !signature) {
+    return false;
+  }
+
+  const hmac = crypto.createHmac('sha256', secret);
+  const digest = hmac.update(payload).digest('hex');
+
+  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(digest));
+}
+
+/**
+ * Add tracking to an order (vendor/admin only)
+ * PUT /api/orders/:id/shipping
+ */
+export async function addTracking(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { id } = req.params;
+    const { trackingNumber, providerId, estimatedDelivery } = req.body;
+
+    // Verify order exists
+    const order = await Order.findByPk(id, {
+      include: [{ model: Product, as: 'product' }],
+    });
+
+    if (!order) {
+      throw new AppError(404, 'ORDER_NOT_FOUND', 'Order not found');
+    }
+
+    // Check if user owns the order or is admin
+    const userId = req.user!.id;
+    const isAdmin = req.user!.role === 'admin';
+
+    if (!isAdmin && order.userId !== userId) {
+      throw new AppError(403, 'FORBIDDEN', 'Not authorized to add tracking to this order');
+    }
+
+    const tracking = await shipmentTrackingService.addTracking(id, {
+      trackingNumber,
+      providerId,
+      estimatedDelivery,
+    });
+
+    const response: ApiResponse<typeof tracking> = {
+      success: true,
+      data: tracking,
+    };
+
+    res.status(201).json(response);
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * Get tracking for an order
+ * GET /api/orders/:id/tracking
+ */
+export async function getTracking(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { id } = req.params;
+
+    // Verify order exists
+    const order = await Order.findByPk(id);
+
+    if (!order) {
+      throw new AppError(404, 'ORDER_NOT_FOUND', 'Order not found');
+    }
+
+    // Check if user owns the order or is admin
+    const userId = req.user!.id;
+    const isAdmin = req.user!.role === 'admin';
+
+    if (!isAdmin && order.userId !== userId) {
+      throw new AppError(403, 'FORBIDDEN', 'Not authorized to view tracking for this order');
+    }
+
+    const tracking = await shipmentTrackingService.getByOrder(id);
+
+    const response: ApiResponse<typeof tracking> = {
+      success: true,
+      data: tracking,
+    };
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * Handle shipping webhook from delivery provider
+ * POST /api/webhooks/shipping/:providerId
+ */
+export async function webhookUpdate(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const { providerId } = req.params;
+    const signature = req.headers['x-webhook-signature'] as string | undefined;
+
+    // Get provider for signature validation
+    const provider = await DeliveryProvider.findByPk(providerId);
+
+    if (!provider) {
+      throw new AppError(404, 'PROVIDER_NOT_FOUND', 'Delivery provider not found');
+    }
+
+    if (!provider.isActive) {
+      throw new AppError(400, 'PROVIDER_INACTIVE', 'Delivery provider is not active');
+    }
+
+    // Validate webhook signature
+    const rawBody = JSON.stringify(req.body);
+    const isValid = validateWebhookSignature(rawBody, signature, provider.webhookSecret);
+
+    if (!isValid) {
+      throw new AppError(401, 'INVALID_SIGNATURE', 'Webhook signature validation failed');
+    }
+
+    // Extract tracking data from webhook payload
+    const { tracking_number, status, details } = req.body;
+
+    if (!tracking_number || !status) {
+      throw new AppError(400, 'INVALID_PAYLOAD', 'Missing tracking_number or status');
+    }
+
+    // Handle the webhook update (idempotent)
+    const result = await shipmentTrackingService.handleWebhookUpdate(
+      tracking_number,
+      status as ShipmentTrackingStatus,
+      details
+    );
+
+    const response: ApiResponse<{
+      tracking: typeof result.tracking;
+      isNew: boolean;
+    }> = {
+      success: true,
+      data: {
+        tracking: result.tracking,
+        isNew: result.isNew,
+      },
+    };
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/controllers/ShippingAddressController.ts
+++ b/backend/src/controllers/ShippingAddressController.ts
@@ -1,0 +1,185 @@
+/**
+ * @fileoverview ShippingAddressController - HTTP controller for shipping addresses
+ * @description Express controller for shipping address CRUD operations.
+ *             Controlador Express para operaciones CRUD de direcciones de envío.
+ * @module controllers/ShippingAddressController
+ * @author MLM Development Team
+ */
+import { Request, Response, NextFunction } from 'express';
+import {
+  ShippingAddressService,
+  CreateAddressData,
+  UpdateAddressData,
+} from '../services/ShippingAddressService';
+import { ApiResponse } from '../types';
+
+const shippingAddressService = new ShippingAddressService();
+
+/**
+ * Create a new shipping address
+ * POST /api/addresses
+ */
+export async function createAddress(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const userId = req.user!.id;
+    const data: CreateAddressData = {
+      label: req.body.label,
+      recipientName: req.body.recipientName,
+      street: req.body.street,
+      city: req.body.city,
+      state: req.body.state,
+      postalCode: req.body.postalCode,
+      country: req.body.country,
+      phone: req.body.phone,
+      isDefault: req.body.isDefault,
+      instructions: req.body.instructions,
+    };
+
+    const address = await shippingAddressService.create(userId, data);
+
+    const response: ApiResponse<typeof address> = {
+      success: true,
+      data: address,
+    };
+
+    res.status(201).json(response);
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * Get all shipping addresses for the authenticated user
+ * GET /api/addresses
+ */
+export async function getAddresses(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const userId = req.user!.id;
+    const addresses = await shippingAddressService.findAllByUser(userId);
+
+    const response: ApiResponse<typeof addresses> = {
+      success: true,
+      data: addresses,
+    };
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * Get a specific shipping address by ID
+ * GET /api/addresses/:id
+ */
+export async function getAddress(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const userId = req.user!.id;
+    const { id } = req.params;
+
+    const address = await shippingAddressService.findById(id, userId);
+
+    const response: ApiResponse<typeof address> = {
+      success: true,
+      data: address,
+    };
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * Update a shipping address
+ * PUT /api/addresses/:id
+ */
+export async function updateAddress(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const userId = req.user!.id;
+    const { id } = req.params;
+    const data: UpdateAddressData = {
+      label: req.body.label,
+      recipientName: req.body.recipientName,
+      street: req.body.street,
+      city: req.body.city,
+      state: req.body.state,
+      postalCode: req.body.postalCode,
+      country: req.body.country,
+      phone: req.body.phone,
+      isDefault: req.body.isDefault,
+      instructions: req.body.instructions,
+    };
+
+    const address = await shippingAddressService.update(id, userId, data);
+
+    const response: ApiResponse<typeof address> = {
+      success: true,
+      data: address,
+    };
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * Delete a shipping address
+ * DELETE /api/addresses/:id
+ */
+export async function deleteAddress(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const userId = req.user!.id;
+    const { id } = req.params;
+
+    await shippingAddressService.delete(id, userId);
+
+    const response: ApiResponse<null> = {
+      success: true,
+      data: null,
+    };
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+}
+
+/**
+ * Set an address as default
+ * PUT /api/addresses/:id/default
+ */
+export async function setDefaultAddress(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const userId = req.user!.id;
+    const { id } = req.params;
+
+    const address = await shippingAddressService.setDefault(id, userId);
+
+    const response: ApiResponse<typeof address> = {
+      success: true,
+      data: address,
+    };
+
+    res.json(response);
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/models/DeliveryProvider.ts
+++ b/backend/src/models/DeliveryProvider.ts
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview DeliveryProvider - Delivery provider model for shipment tracking
+ * @description Sequelize model for delivery service providers (e.g., FedEx, UPS, DHL).
+ *             Modelo Sequelize para proveedores de envío.
+ * @module models/DeliveryProvider
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Get all active delivery providers
+ * const providers = await DeliveryProvider.findAll({ where: { isActive: true } });
+ *
+ * // Español: Obtener todos los proveedores de envío activos
+ * const providers = await DeliveryProvider.findAll({ where: { isActive: true } });
+ */
+import { DataTypes, Model, Optional } from 'sequelize';
+import { sequelize } from '../config/database';
+import type { DeliveryProviderAttributes, DeliveryProviderCreationAttributes } from '../types';
+
+type DeliveryProviderCreation = Optional<
+  DeliveryProviderAttributes,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+
+/**
+ * DeliveryProvider Model - Represents delivery service providers
+ * DeliveryProvider Modelo - Representa proveedores de servicios de envío
+ */
+export class DeliveryProvider
+  extends Model<DeliveryProviderAttributes, DeliveryProviderCreation>
+  implements DeliveryProviderAttributes
+{
+  declare id: string;
+  declare name: string;
+  declare slug: string;
+  declare trackingUrlTemplate: string | null;
+  declare webhookSecret: string | null;
+  declare isActive: boolean;
+  declare metadata: Record<string, unknown> | null;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
+}
+
+DeliveryProvider.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    slug: {
+      type: DataTypes.STRING(100),
+      allowNull: false,
+      unique: true,
+    },
+    trackingUrlTemplate: {
+      type: DataTypes.STRING(500),
+      allowNull: true,
+      field: 'tracking_url_template',
+      comment: 'Template for tracking URL, e.g., https://example.com/track/{tracking}',
+    },
+    webhookSecret: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+      field: 'webhook_secret',
+      comment: 'Secret for webhook signature validation (HMAC-SHA256)',
+    },
+    isActive: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+      field: 'is_active',
+    },
+    metadata: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      defaultValue: null,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'delivery_providers',
+    timestamps: true,
+    underscored: true,
+    indexes: [{ fields: ['slug'], unique: true }, { fields: ['is_active'] }],
+  }
+);

--- a/backend/src/models/Order.ts
+++ b/backend/src/models/Order.ts
@@ -23,7 +23,7 @@ import { sequelize } from '../config/database';
 import { User } from './User';
 import { Product } from './Product';
 import { Purchase } from './Purchase';
-import type { OrderAttributes, OrderCreationAttributes } from '../types';
+import type { OrderAttributes, OrderCreationAttributes, ShippingStatus } from '../types';
 
 type OrderCreation = Optional<OrderAttributes, 'id' | 'createdAt' | 'updatedAt'>;
 
@@ -42,6 +42,10 @@ export class Order extends Model<OrderAttributes, OrderCreation> {
   declare status: 'pending' | 'completed' | 'failed';
   declare paymentMethod: 'manual' | 'simulated';
   declare notes: string | null;
+  // Shipping fields (Phase 3)
+  declare shippingAddressId: string | null;
+  declare shippingCost: number | null;
+  declare shippingStatus: ShippingStatus;
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
 
@@ -103,6 +107,32 @@ Order.init(
       type: DataTypes.TEXT,
       allowNull: true,
     },
+    // Shipping fields (Phase 3 - Delivery Integration)
+    shippingAddressId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      field: 'shipping_address_id',
+      comment: 'FK to shipping_addresses table',
+    },
+    shippingCost: {
+      type: DataTypes.DECIMAL(10, 2),
+      allowNull: true,
+      field: 'shipping_cost',
+      comment: 'Cost of shipping',
+    },
+    shippingStatus: {
+      type: DataTypes.ENUM(
+        'not_required',
+        'pending_shipment',
+        'shipped',
+        'in_transit',
+        'delivered'
+      ),
+      allowNull: true,
+      defaultValue: 'not_required',
+      field: 'shipping_status',
+      comment: 'Shipping status for the order',
+    },
   },
   {
     sequelize,
@@ -115,6 +145,8 @@ Order.init(
       { fields: ['product_id'] },
       { fields: ['purchase_id'] },
       { fields: ['status'] },
+      { fields: ['shipping_address_id'] },
+      { fields: ['shipping_status'] },
     ],
   }
 );

--- a/backend/src/models/ShipmentTracking.ts
+++ b/backend/src/models/ShipmentTracking.ts
@@ -1,0 +1,119 @@
+/**
+ * @fileoverview ShipmentTracking - Shipment tracking model for delivery status
+ * @description Sequelize model for tracking shipments with status history.
+ *             Modelo Sequelize para seguimiento de envíos con historial de estados.
+ * @module models/ShipmentTracking
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Get tracking for an order
+ * const tracking = await ShipmentTracking.findOne({ where: { orderId } });
+ *
+ * // Español: Obtener seguimiento de un pedido
+ * const tracking = await ShipmentTracking.findOne({ where: { orderId } });
+ */
+import { DataTypes, Model, Optional, ForeignKey } from 'sequelize';
+import { sequelize } from '../config/database';
+import type {
+  ShipmentTrackingAttributes,
+  ShipmentTrackingCreationAttributes,
+  ShipmentStatusHistoryEntry,
+} from '../types';
+
+type ShipmentTrackingCreation = Optional<
+  ShipmentTrackingAttributes,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+
+/**
+ * ShipmentTracking Model - Represents shipment tracking information
+ * ShipmentTracking Modelo - Representa información de seguimiento de envío
+ */
+export class ShipmentTracking
+  extends Model<ShipmentTrackingAttributes, ShipmentTrackingCreation>
+  implements ShipmentTrackingAttributes
+{
+  declare id: string;
+  declare orderId: ForeignKey<string> | null;
+  declare vendorOrderId: ForeignKey<string> | null;
+  declare providerId: ForeignKey<string> | null;
+  declare trackingNumber: string;
+  declare status: string;
+  declare statusHistory: ShipmentStatusHistoryEntry[];
+  declare estimatedDelivery: Date | null;
+  declare actualDelivery: Date | null;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
+}
+
+ShipmentTracking.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    orderId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      field: 'order_id',
+    },
+    vendorOrderId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      field: 'vendor_order_id',
+    },
+    providerId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      field: 'provider_id',
+    },
+    trackingNumber: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      field: 'tracking_number',
+    },
+    status: {
+      type: DataTypes.ENUM(
+        'pending',
+        'picked_up',
+        'in_transit',
+        'out_for_delivery',
+        'delivered',
+        'failed',
+        'returned'
+      ),
+      allowNull: false,
+      defaultValue: 'pending',
+    },
+    statusHistory: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+      field: 'status_history',
+      comment: 'Array of status history entries [{ status, timestamp, details? }]',
+    },
+    estimatedDelivery: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'estimated_delivery',
+    },
+    actualDelivery: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'actual_delivery',
+    },
+  },
+  {
+    sequelize,
+    tableName: 'shipment_trackings',
+    timestamps: true,
+    underscored: true,
+    indexes: [
+      { fields: ['order_id'] },
+      { fields: ['vendor_order_id'] },
+      { fields: ['tracking_number'] },
+      { fields: ['status'] },
+    ],
+  }
+);

--- a/backend/src/models/ShippingAddress.ts
+++ b/backend/src/models/ShippingAddress.ts
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview ShippingAddress - Shipping address model for delivery integration
+ * @description Sequelize model for user shipping addresses with paranoid soft-delete.
+ *             Modelo Sequelize para direcciones de envío de usuarios.
+ * @module models/ShippingAddress
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Get user's default shipping address
+ * const address = await ShippingAddress.findOne({ where: { userId, isDefault: true } });
+ *
+ * // Español: Obtener dirección de envío predeterminada del usuario
+ * const address = await ShippingAddress.findOne({ where: { userId, isDefault: true } });
+ */
+import { DataTypes, Model, Optional, ForeignKey } from 'sequelize';
+import { sequelize } from '../config/database';
+import type { ShippingAddressAttributes, ShippingAddressCreationAttributes } from '../types';
+
+type ShippingAddressCreation = Optional<
+  ShippingAddressAttributes,
+  'id' | 'createdAt' | 'updatedAt'
+>;
+
+/**
+ * ShippingAddress Model - Represents user shipping addresses
+ * ShippingAddress Modelo - Representa direcciones de envío de usuarios
+ */
+export class ShippingAddress
+  extends Model<ShippingAddressAttributes, ShippingAddressCreation>
+  implements ShippingAddressAttributes
+{
+  declare id: string;
+  declare userId: ForeignKey<string>;
+  declare label: string | null;
+  declare recipientName: string;
+  declare street: string;
+  declare city: string;
+  declare state: string;
+  declare postalCode: string;
+  declare country: string;
+  declare phone: string | null;
+  declare isDefault: boolean;
+  declare instructions: string | null;
+  declare deletedAt: Date | null;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
+}
+
+ShippingAddress.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    userId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      field: 'user_id',
+    },
+    label: {
+      type: DataTypes.STRING(100),
+      allowNull: true,
+    },
+    recipientName: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      field: 'recipient_name',
+    },
+    street: {
+      type: DataTypes.STRING(500),
+      allowNull: false,
+    },
+    city: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    state: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    postalCode: {
+      type: DataTypes.STRING(20),
+      allowNull: false,
+      field: 'postal_code',
+    },
+    country: {
+      type: DataTypes.STRING(3),
+      allowNull: false,
+      comment: 'ISO 3166-1 alpha-3 country code',
+    },
+    phone: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+    },
+    isDefault: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+      field: 'is_default',
+    },
+    instructions: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'deleted_at',
+    },
+  },
+  {
+    sequelize,
+    tableName: 'shipping_addresses',
+    timestamps: true,
+    underscored: true,
+    paranoid: true,
+    indexes: [{ fields: ['user_id'] }, { fields: ['user_id', 'is_default'] }],
+  }
+);

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -30,6 +30,9 @@ import { InventoryMovement } from './InventoryMovement';
 import { Vendor } from './Vendor';
 import { VendorOrder } from './VendorOrder';
 import { VendorPayout } from './VendorPayout';
+import { ShippingAddress } from './ShippingAddress';
+import { DeliveryProvider } from './DeliveryProvider';
+import { ShipmentTracking } from './ShipmentTracking';
 
 // User relationships
 User.hasMany(User, { as: 'children', foreignKey: 'sponsorId', sourceKey: 'id' });
@@ -324,6 +327,53 @@ VendorPayout.belongsTo(Vendor, { as: 'vendor', foreignKey: 'vendorId', targetKey
 Vendor.hasMany(Product, { as: 'products', foreignKey: 'vendorId', sourceKey: 'id' });
 Product.belongsTo(Vendor, { as: 'vendor', foreignKey: 'vendorId', targetKey: 'id' });
 
+// ============================================
+// DELIVERY INTEGRATION — Shipping & Tracking (#26)
+// ============================================
+
+// User - ShippingAddress
+User.hasMany(ShippingAddress, { foreignKey: 'userId', sourceKey: 'id' });
+ShippingAddress.belongsTo(User, { as: 'user', foreignKey: 'userId', targetKey: 'id' });
+
+// Order - ShipmentTracking
+Order.hasMany(ShipmentTracking, {
+  as: 'shipmentTrackings',
+  foreignKey: 'orderId',
+  sourceKey: 'id',
+});
+ShipmentTracking.belongsTo(Order, { as: 'order', foreignKey: 'orderId', targetKey: 'id' });
+
+// VendorOrder - ShipmentTracking
+VendorOrder.hasMany(ShipmentTracking, {
+  as: 'shipmentTrackings',
+  foreignKey: 'vendorOrderId',
+  sourceKey: 'id',
+});
+ShipmentTracking.belongsTo(VendorOrder, {
+  as: 'vendorOrder',
+  foreignKey: 'vendorOrderId',
+  targetKey: 'id',
+});
+
+// DeliveryProvider - ShipmentTracking
+DeliveryProvider.hasMany(ShipmentTracking, {
+  as: 'shipmentTrackings',
+  foreignKey: 'providerId',
+  sourceKey: 'id',
+});
+ShipmentTracking.belongsTo(DeliveryProvider, {
+  as: 'provider',
+  foreignKey: 'providerId',
+  targetKey: 'id',
+});
+
+// Order - ShippingAddress
+Order.belongsTo(ShippingAddress, {
+  as: 'shippingAddress',
+  foreignKey: 'shippingAddressId',
+  targetKey: 'id',
+});
+
 export {
   sequelize,
   User,
@@ -358,6 +408,9 @@ export {
   Vendor,
   VendorOrder,
   VendorPayout,
+  ShippingAddress,
+  DeliveryProvider,
+  ShipmentTracking,
 };
 
 export function initModels(): void {

--- a/backend/src/routes/address.routes.ts
+++ b/backend/src/routes/address.routes.ts
@@ -1,0 +1,56 @@
+import { Router } from 'express';
+import { body } from 'express-validator';
+import * as ShippingAddressController from '../controllers/ShippingAddressController';
+import { authenticate, requireUser } from '../middleware/auth.middleware';
+
+const router = Router();
+
+// Validation rules
+const addressValidationRules = {
+  create: [
+    body('recipientName').notEmpty().withMessage('Recipient name is required'),
+    body('street').notEmpty().withMessage('Street is required'),
+    body('city').notEmpty().withMessage('City is required'),
+    body('state').notEmpty().withMessage('State is required'),
+    body('postalCode').notEmpty().withMessage('Postal code is required'),
+    body('country').isLength({ min: 2, max: 3 }).withMessage('Country must be 2-3 characters'),
+    body('label').optional().isString().isLength({ max: 100 }),
+    body('phone').optional().isString().isLength({ max: 50 }),
+    body('instructions').optional().isString(),
+    body('isDefault').optional().isBoolean(),
+  ],
+  update: [
+    body('recipientName').optional().notEmpty().withMessage('Recipient name cannot be empty'),
+    body('street').optional().notEmpty().withMessage('Street cannot be empty'),
+    body('city').optional().notEmpty().withMessage('City cannot be empty'),
+    body('state').optional().notEmpty().withMessage('State cannot be empty'),
+    body('postalCode').optional().notEmpty().withMessage('Postal code cannot be empty'),
+    body('country')
+      .optional()
+      .isLength({ min: 2, max: 3 })
+      .withMessage('Country must be 2-3 characters'),
+    body('label').optional().isString().isLength({ max: 100 }),
+    body('phone').optional().isString().isLength({ max: 50 }),
+    body('instructions').optional().isString(),
+    body('isDefault').optional().isBoolean(),
+  ],
+};
+
+// All routes require authentication
+router.use(authenticate);
+router.use(requireUser);
+
+// CRUD routes
+router.post('/', addressValidationRules.create, ShippingAddressController.createAddress);
+
+router.get('/', ShippingAddressController.getAddresses);
+
+router.get('/:id', ShippingAddressController.getAddress);
+
+router.put('/:id', addressValidationRules.update, ShippingAddressController.updateAddress);
+
+router.delete('/:id', ShippingAddressController.deleteAddress);
+
+router.put('/:id/default', ShippingAddressController.setDefaultAddress);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -21,6 +21,8 @@ import adminCategoryRoutes from './admin-category.routes';
 import categoryRoutes from './category.routes';
 import vendorRoutes from './vendor.routes';
 import adminVendorRoutes from './admin-vendor.routes';
+import addressRoutes from './address.routes';
+import shippingRoutes from './shipping.routes';
 
 const router: ExpressRouter = Router();
 
@@ -53,6 +55,12 @@ router.use('/vendors', vendorRoutes);
 
 // Admin vendor routes
 router.use('/admin/vendors', adminVendorRoutes);
+
+// Shipping address routes (user)
+router.use('/addresses', addressRoutes);
+
+// Shipping and tracking routes
+router.use('/', shippingRoutes);
 
 // Profile public routes (MUST be before publicRoutes to avoid /profile/:code conflict)
 import profilePublicRoutes from './profile-public.routes';

--- a/backend/src/routes/shipping.routes.ts
+++ b/backend/src/routes/shipping.routes.ts
@@ -1,0 +1,52 @@
+import { Router } from 'express';
+import { body } from 'express-validator';
+import * as ShipmentTrackingController from '../controllers/ShipmentTrackingController';
+import { authenticate, requireUser, requireAdmin } from '../middleware/auth.middleware';
+
+const router = Router();
+
+// Validation rules
+const trackingValidationRules = {
+  addTracking: [
+    body('trackingNumber').notEmpty().withMessage('Tracking number is required'),
+    body('providerId').optional().isUUID().withMessage('Provider ID must be a valid UUID'),
+    body('estimatedDelivery')
+      .optional()
+      .isISO8601()
+      .withMessage('Estimated delivery must be a valid date'),
+  ],
+  webhook: [
+    body('tracking_number').notEmpty().withMessage('Tracking number is required'),
+    body('status')
+      .isIn([
+        'pending',
+        'picked_up',
+        'in_transit',
+        'out_for_delivery',
+        'delivered',
+        'failed',
+        'returned',
+      ])
+      .withMessage('Invalid status'),
+    body('details').optional().isString(),
+  ],
+};
+
+// Order shipping routes (require authentication)
+router.put(
+  '/orders/:id/shipping',
+  authenticate,
+  trackingValidationRules.addTracking,
+  ShipmentTrackingController.addTracking
+);
+
+router.get('/orders/:id/tracking', authenticate, ShipmentTrackingController.getTracking);
+
+// Webhook route (public but signature-validated)
+router.post(
+  '/webhooks/shipping/:providerId',
+  trackingValidationRules.webhook,
+  ShipmentTrackingController.webhookUpdate
+);
+
+export default router;

--- a/backend/src/services/OrderService.ts
+++ b/backend/src/services/OrderService.ts
@@ -13,11 +13,11 @@
  * const order = await orderService.createOrder(userId, { productId, paymentMethod });
  */
 import { sequelize } from '../config/database';
-import { Order, Product, Purchase, User, VendorOrder } from '../models';
+import { Order, Product, Purchase, User, VendorOrder, ShippingAddress } from '../models';
 import { AppError } from '../middleware/error.middleware';
 import { CommissionService } from './CommissionService';
 import { body } from 'express-validator';
-import type { OrderAttributes } from '../types';
+import type { OrderAttributes, ProductType, ShippingStatus } from '../types';
 
 // Express-validator validation chains (reusable in controllers)
 export const orderValidationRules = {
@@ -38,6 +38,7 @@ export type CreateOrderData = {
   productId: string;
   paymentMethod?: 'manual' | 'simulated';
   notes?: string;
+  shippingAddressId?: string;
 };
 
 const commissionService = new CommissionService();
@@ -110,6 +111,32 @@ export class OrderService {
       throw new AppError(400, 'PRODUCT_INACTIVE', 'Product is not available for purchase');
     }
 
+    // Validate shipping address for physical products
+    const productType = (product as any).type as ProductType | undefined;
+    const isPhysical = productType === 'physical';
+
+    if (isPhysical && !data.shippingAddressId) {
+      throw new AppError(
+        400,
+        'SHIPPING_ADDRESS_REQUIRED',
+        'Shipping address is required for physical products'
+      );
+    }
+
+    // Validate shipping address exists and belongs to user
+    if (data.shippingAddressId) {
+      const address = await ShippingAddress.findOne({
+        where: { id: data.shippingAddressId, userId },
+      });
+      if (!address) {
+        throw new AppError(
+          400,
+          'INVALID_SHIPPING_ADDRESS',
+          'Shipping address not found or does not belong to user'
+        );
+      }
+    }
+
     const totalAmount = Number(product.price);
     const orderNumber = this.generateOrderNumber();
 
@@ -132,6 +159,12 @@ export class OrderService {
       );
 
       // Create Order record
+      // Set shippingStatus based on product type
+      let shippingStatusValue: ShippingStatus = 'not_required';
+      if (isPhysical) {
+        shippingStatusValue = 'pending_shipment';
+      }
+
       const order = await Order.create(
         {
           orderNumber,
@@ -143,6 +176,9 @@ export class OrderService {
           status: 'completed',
           paymentMethod: data.paymentMethod || 'simulated',
           notes: data.notes || null,
+          shippingAddressId: data.shippingAddressId ?? null,
+          shippingCost: null,
+          shippingStatus: shippingStatusValue,
         },
         { transaction }
       );

--- a/backend/src/services/ShipmentTrackingService.ts
+++ b/backend/src/services/ShipmentTrackingService.ts
@@ -1,0 +1,268 @@
+/**
+ * @fileoverview ShipmentTrackingService - Shipment tracking management
+ * @description Service for managing shipment tracking with status history.
+ *             Servicio para gestionar seguimiento de envíos con historial de estados.
+ * @module services/ShipmentTrackingService
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Add tracking to an order
+ * const tracking = await shipmentTrackingService.addTracking(orderId, trackingData);
+ *
+ * // Español: Agregar seguimiento a un pedido
+ * const tracking = await shipmentTrackingService.addTracking(uuid-pedido, datosSeguimiento);
+ */
+import { sequelize } from '../config/database';
+import { ShipmentTracking, Order, VendorOrder } from '../models';
+import { AppError } from '../middleware/error.middleware';
+import type {
+  ShipmentTrackingAttributes,
+  ShipmentTrackingCreationAttributes,
+  ShipmentStatusHistoryEntry,
+  ShipmentTrackingStatus,
+  AddTrackingDto,
+} from '../types';
+
+/**
+ * ShipmentTrackingService - Handles shipment tracking operations
+ * ShipmentTrackingService - Maneja operaciones de seguimiento de envíos
+ */
+export class ShipmentTrackingService {
+  /**
+   * Add tracking information to an order
+   * Agregar información de seguimiento a un pedido
+   *
+   * @param {string} orderId - Order UUID
+   * @param {AddTrackingDto} data - Tracking data
+   * @returns {Promise<ShipmentTracking>} Created tracking record
+   * @throws {AppError} 404 if order not found
+   */
+  async addTracking(orderId: string, data: AddTrackingDto): Promise<ShipmentTracking> {
+    const order = await Order.findByPk(orderId);
+    if (!order) {
+      throw new AppError(404, 'ORDER_NOT_FOUND', 'Order not found');
+    }
+
+    // Build initial status history entry
+    const statusHistory: ShipmentStatusHistoryEntry[] = [
+      {
+        status: 'picked_up' as ShipmentTrackingStatus,
+        timestamp: new Date(),
+        details: 'Shipment created',
+      },
+    ];
+
+    const tracking = await ShipmentTracking.create({
+      orderId,
+      trackingNumber: data.trackingNumber,
+      providerId: data.providerId ?? null,
+      status: 'picked_up' as ShipmentTrackingStatus,
+      statusHistory,
+      estimatedDelivery: data.estimatedDelivery ? new Date(data.estimatedDelivery) : null,
+    });
+
+    // Update order shipping status
+    await order.update({ shippingStatus: 'shipped' as const });
+
+    return tracking;
+  }
+
+  /**
+   * Update tracking status (append-only status history)
+   * Actualizar estado de seguimiento (historial de estados append-only)
+   *
+   * @param {string} trackingNumber - Tracking number
+   * @param {ShipmentTrackingStatus} status - New status
+   * @param {string} [details] - Optional details about the status update
+   * @returns {Promise<ShipmentTracking>} Updated tracking record
+   * @throws {AppError} 404 if tracking not found
+   */
+  async updateStatus(
+    trackingNumber: string,
+    status: ShipmentTrackingStatus,
+    details?: string
+  ): Promise<ShipmentTracking> {
+    const tracking = await ShipmentTracking.findOne({
+      where: { trackingNumber },
+    });
+
+    if (!tracking) {
+      throw new AppError(404, 'TRACKING_NOT_FOUND', 'Shipment tracking not found');
+    }
+
+    // Build new status history entry
+    const newEntry: ShipmentStatusHistoryEntry = {
+      status,
+      timestamp: new Date(),
+      details,
+    };
+
+    // Append to status history (append-only)
+    const currentHistory = tracking.statusHistory || [];
+    const updatedHistory = [...currentHistory, newEntry];
+
+    // Update tracking
+    await tracking.update({
+      status,
+      statusHistory: updatedHistory,
+    });
+
+    // If delivered, set actual delivery date
+    if (status === 'delivered') {
+      await tracking.update({ actualDelivery: new Date() });
+    }
+
+    // Update order shipping status based on tracking status
+    if (tracking.orderId) {
+      const order = await Order.findByPk(tracking.orderId);
+      if (order) {
+        let shippingStatus:
+          | 'not_required'
+          | 'pending_shipment'
+          | 'shipped'
+          | 'in_transit'
+          | 'delivered';
+        switch (status) {
+          case 'delivered':
+            shippingStatus = 'delivered';
+            break;
+          case 'in_transit':
+          case 'out_for_delivery':
+          case 'picked_up':
+            shippingStatus = 'in_transit';
+            break;
+          default:
+            shippingStatus = 'shipped';
+        }
+        await order.update({ shippingStatus });
+      }
+    }
+
+    return tracking.reload();
+  }
+
+  /**
+   * Get tracking information for an order
+   * Obtener información de seguimiento de un pedido
+   *
+   * @param {string} orderId - Order UUID
+   * @returns {Promise<ShipmentTracking | null>} Tracking record or null
+   */
+  async getByOrder(orderId: string): Promise<ShipmentTracking | null> {
+    const tracking = await ShipmentTracking.findOne({
+      where: { orderId },
+      include: ['provider'],
+    });
+    return tracking;
+  }
+
+  /**
+   * Check if this status update is a duplicate (idempotency)
+   * Verificar si esta actualización de estado es un duplicado (idempotencia)
+   *
+   * @param {string} trackingNumber - Tracking number
+   * @param {ShipmentTrackingStatus} status - Status to check
+   * @param {Date} timestamp - Timestamp of the update
+   * @returns {Promise<boolean>} True if duplicate
+   */
+  async isDuplicateUpdate(
+    trackingNumber: string,
+    status: ShipmentTrackingStatus,
+    timestamp: Date
+  ): Promise<boolean> {
+    const tracking = await ShipmentTracking.findOne({
+      where: { trackingNumber },
+    });
+
+    if (!tracking) {
+      return false;
+    }
+
+    const history = tracking.statusHistory || [];
+    // Check if same status with same timestamp already exists
+    const exists = history.some(
+      (entry) => entry.status === status && entry.timestamp.getTime() === timestamp.getTime()
+    );
+
+    return exists;
+  }
+
+  /**
+   * Handle webhook status update (idempotent)
+   * Manejar actualización de estado por webhook (idempotente)
+   *
+   * @param {string} trackingNumber - Tracking number
+   * @param {ShipmentTrackingStatus} status - Status from webhook
+   * @param {string} [details] - Optional details
+   * @returns {Promise<{ tracking: ShipmentTracking; isNew: boolean }>} Tracking and whether status was new
+   */
+  async handleWebhookUpdate(
+    trackingNumber: string,
+    status: ShipmentTrackingStatus,
+    details?: string
+  ): Promise<{ tracking: ShipmentTracking; isNew: boolean }> {
+    const tracking = await ShipmentTracking.findOne({
+      where: { trackingNumber },
+    });
+
+    if (!tracking) {
+      throw new AppError(404, 'TRACKING_NOT_FOUND', 'Shipment tracking not found');
+    }
+
+    // Check if this status already exists in history (idempotency)
+    const currentHistory = tracking.statusHistory || [];
+    const statusExists = currentHistory.some((entry) => entry.status === status);
+
+    if (statusExists) {
+      // Idempotent: same status already recorded, return without adding
+      return { tracking, isNew: false };
+    }
+
+    // Add new status to history
+    const newEntry: ShipmentStatusHistoryEntry = {
+      status,
+      timestamp: new Date(),
+      details,
+    };
+
+    const updatedHistory = [...currentHistory, newEntry];
+
+    await tracking.update({
+      status,
+      statusHistory: updatedHistory,
+    });
+
+    // If delivered, set actual delivery date
+    if (status === 'delivered') {
+      await tracking.update({ actualDelivery: new Date() });
+    }
+
+    // Update order shipping status
+    if (tracking.orderId) {
+      const order = await Order.findByPk(tracking.orderId);
+      if (order) {
+        let shippingStatus:
+          | 'not_required'
+          | 'pending_shipment'
+          | 'shipped'
+          | 'in_transit'
+          | 'delivered';
+        switch (status) {
+          case 'delivered':
+            shippingStatus = 'delivered';
+            break;
+          case 'in_transit':
+          case 'out_for_delivery':
+          case 'picked_up':
+            shippingStatus = 'in_transit';
+            break;
+          default:
+            shippingStatus = 'shipped';
+        }
+        await order.update({ shippingStatus });
+      }
+    }
+
+    return { tracking: tracking.reload(), isNew: true };
+  }
+}

--- a/backend/src/services/ShippingAddressService.ts
+++ b/backend/src/services/ShippingAddressService.ts
@@ -1,0 +1,230 @@
+/**
+ * @fileoverview ShippingAddressService - Shipping address management
+ * @description Service for managing user shipping addresses with default address logic.
+ *             Servicio para gestionar direcciones de envío de usuarios.
+ * @module services/ShippingAddressService
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Create a new shipping address
+ * const address = await shippingAddressService.create(userId, addressData);
+ *
+ * // Español: Crear nueva dirección de envío
+ * const address = await shippingAddressService.create(uuid-usuario, datosDireccion);
+ */
+import { sequelize } from '../config/database';
+import { ShippingAddress } from '../models/ShippingAddress';
+import { AppError } from '../middleware/error.middleware';
+import type { ShippingAddressAttributes, ShippingAddressCreationAttributes } from '../types';
+
+const MAX_ADDRESSES_PER_USER = 10;
+
+export type CreateAddressData = Omit<ShippingAddressCreationAttributes, 'userId'>;
+export type UpdateAddressData = Partial<Omit<ShippingAddressCreationAttributes, 'userId'>>;
+
+/**
+ * ShippingAddressService - Handles shipping address CRUD operations
+ * ShippingAddressService - Maneja operaciones CRUD de direcciones de envío
+ */
+export class ShippingAddressService {
+  /**
+   * Create a new shipping address for a user
+   * Crear nueva dirección de envío para un usuario
+   *
+   * @param {string} userId - User UUID
+   * @param {CreateAddressData} data - Address creation data
+   * @returns {Promise<ShippingAddress>} Created address
+   * @throws {AppError} 400 if user already has max addresses (10)
+   */
+  async create(userId: string, data: CreateAddressData): Promise<ShippingAddress> {
+    // Check address limit
+    const count = await ShippingAddress.count({ where: { userId } });
+    if (count >= MAX_ADDRESSES_PER_USER) {
+      throw new AppError(
+        400,
+        'ADDRESS_LIMIT_EXCEEDED',
+        `Maximum of ${MAX_ADDRESSES_PER_USER} addresses per user reached`
+      );
+    }
+
+    const transaction = await sequelize.transaction();
+
+    try {
+      // If this is the first address or isDefault is true, set as default
+      let shouldBeDefault = data.isDefault ?? false;
+      if (count === 0) {
+        shouldBeDefault = true;
+      }
+
+      // If setting as default, unset previous default
+      if (shouldBeDefault) {
+        await ShippingAddress.update(
+          { isDefault: false },
+          { where: { userId, isDefault: true }, transaction }
+        );
+      }
+
+      const address = await ShippingAddress.create(
+        {
+          userId,
+          label: data.label ?? null,
+          recipientName: data.recipientName,
+          street: data.street,
+          city: data.city,
+          state: data.state,
+          postalCode: data.postalCode,
+          country: data.country,
+          phone: data.phone ?? null,
+          isDefault: shouldBeDefault,
+          instructions: data.instructions ?? null,
+        },
+        { transaction }
+      );
+
+      await transaction.commit();
+      return address;
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+
+  /**
+   * Get all shipping addresses for a user (default first)
+   * Obtener todas las direcciones de envío de un usuario (predeterminada primero)
+   *
+   * @param {string} userId - User UUID
+   * @returns {Promise<ShippingAddress[]>} Array of addresses
+   */
+  async findAllByUser(userId: string): Promise<ShippingAddress[]> {
+    const addresses = await ShippingAddress.findAll({
+      where: { userId },
+      order: [
+        ['isDefault', 'DESC'],
+        ['createdAt', 'DESC'],
+      ],
+    });
+    return addresses;
+  }
+
+  /**
+   * Get a specific shipping address by ID
+   * Obtener dirección de envío específica por ID
+   *
+   * @param {string} id - Address UUID
+   * @param {string} userId - User UUID (for ownership check)
+   * @returns {Promise<ShippingAddress>} Address instance
+   * @throws {AppError} 404 if address not found or not owned by user
+   */
+  async findById(id: string, userId: string): Promise<ShippingAddress> {
+    const address = await ShippingAddress.findOne({
+      where: { id, userId },
+    });
+
+    if (!address) {
+      throw new AppError(404, 'ADDRESS_NOT_FOUND', 'Shipping address not found');
+    }
+
+    return address;
+  }
+
+  /**
+   * Update a shipping address
+   * Actualizar dirección de envío
+   *
+   * @param {string} id - Address UUID
+   * @param {string} userId - User UUID (for ownership check)
+   * @param {UpdateAddressData} data - Address update data
+   * @returns {Promise<ShippingAddress>} Updated address
+   */
+  async update(id: string, userId: string, data: UpdateAddressData): Promise<ShippingAddress> {
+    const address = await this.findById(id, userId);
+
+    const transaction = await sequelize.transaction();
+
+    try {
+      // If setting as default, unset previous default
+      if (data.isDefault === true && !address.isDefault) {
+        await ShippingAddress.update(
+          { isDefault: false },
+          { where: { userId, isDefault: true }, transaction }
+        );
+      }
+
+      await address.update(data, { transaction });
+      await transaction.commit();
+      return address.reload();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+
+  /**
+   * Delete a shipping address (soft delete)
+   * Eliminar dirección de envío (soft delete)
+   *
+   * @param {string} id - Address UUID
+   * @param {string} userId - User UUID (for ownership check)
+   * @returns {Promise<void>}
+   * @throws {AppError} 400 if trying to delete default address
+   */
+  async delete(id: string, userId: string): Promise<void> {
+    const address = await this.findById(id, userId);
+
+    if (address.isDefault) {
+      throw new AppError(400, 'CANNOT_DELETE_DEFAULT', 'Cannot delete default shipping address');
+    }
+
+    await address.destroy();
+  }
+
+  /**
+   * Set an address as default (unset previous default atomically)
+   * Establecer dirección como predeterminada (desactivar anterior atómicamente)
+   *
+   * @param {string} id - Address UUID
+   * @param {string} userId - User UUID (for ownership check)
+   * @returns {Promise<ShippingAddress>} Updated address
+   */
+  async setDefault(id: string, userId: string): Promise<ShippingAddress> {
+    const address = await this.findById(id, userId);
+
+    if (address.isDefault) {
+      return address; // Already default
+    }
+
+    const transaction = await sequelize.transaction();
+
+    try {
+      // Unset previous default
+      await ShippingAddress.update(
+        { isDefault: false },
+        { where: { userId, isDefault: true }, transaction }
+      );
+
+      // Set new default
+      await address.update({ isDefault: true }, { transaction });
+
+      await transaction.commit();
+      return address.reload();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  }
+
+  /**
+   * Get default shipping address for a user
+   * Obtener dirección de envío predeterminada de un usuario
+   *
+   * @param {string} userId - User UUID
+   * @returns {Promise<ShippingAddress | null>} Default address or null
+   */
+  async getDefault(userId: string): Promise<ShippingAddress | null> {
+    const address = await ShippingAddress.findOne({
+      where: { userId, isDefault: true },
+    });
+    return address;
+  }
+}

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -245,6 +245,10 @@ export interface OrderAttributes {
   status: 'pending' | 'completed' | 'failed';
   paymentMethod: 'manual' | 'simulated'; // MVP: only simulated
   notes: string | null; // Optional internal notes
+  // Shipping fields (Phase 3 - Delivery Integration)
+  shippingAddressId: string | null;
+  shippingCost: number | null;
+  shippingStatus: ShippingStatus;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -1385,4 +1389,146 @@ export interface VendorDashboardData {
     status: VendorOrderStatus;
     createdAt: Date;
   }>;
+}
+
+// ============================================
+// DELIVERY INTEGRATION — Phase 3 (#26)
+// ENVÍOS — Fase 3 (#26)
+// ============================================
+
+/**
+ * Shipping status for orders
+ * Estado de envío para pedidos
+ */
+export const SHIPPING_STATUS = {
+  NOT_REQUIRED: 'not_required',
+  PENDING_SHIPMENT: 'pending_shipment',
+  SHIPPED: 'shipped',
+  IN_TRANSIT: 'in_transit',
+  DELIVERED: 'delivered',
+} as const;
+
+export type ShippingStatus = (typeof SHIPPING_STATUS)[keyof typeof SHIPPING_STATUS];
+
+/**
+ * Shipment tracking status
+ * Estado de seguimiento de envío
+ */
+export const SHIPMENT_TRACKING_STATUS = {
+  PENDING: 'pending',
+  PICKED_UP: 'picked_up',
+  IN_TRANSIT: 'in_transit',
+  OUT_FOR_DELIVERY: 'out_for_delivery',
+  DELIVERED: 'delivered',
+  FAILED: 'failed',
+  RETURNED: 'returned',
+} as const;
+
+export type ShipmentTrackingStatus =
+  (typeof SHIPMENT_TRACKING_STATUS)[keyof typeof SHIPMENT_TRACKING_STATUS];
+
+/**
+ * Status history entry for shipment tracking
+ * Entrada de historial de estado para seguimiento de envío
+ */
+export interface ShipmentStatusHistoryEntry {
+  status: ShipmentTrackingStatus;
+  timestamp: Date;
+  details?: string;
+}
+
+/**
+ * Shipping address attributes
+ * Atributos de dirección de envío
+ */
+export interface ShippingAddressAttributes {
+  id: string;
+  userId: string;
+  label: string | null;
+  recipientName: string;
+  street: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+  phone: string | null;
+  isDefault: boolean;
+  instructions: string | null;
+  deletedAt: Date | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface ShippingAddressCreationAttributes {
+  userId: string;
+  label?: string | null;
+  recipientName: string;
+  street: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+  phone?: string | null;
+  isDefault?: boolean;
+  instructions?: string | null;
+}
+
+/**
+ * Delivery provider attributes
+ * Atributos del proveedor de envíos
+ */
+export interface DeliveryProviderAttributes {
+  id: string;
+  name: string;
+  slug: string;
+  trackingUrlTemplate: string | null;
+  webhookSecret: string | null;
+  isActive: boolean;
+  metadata: Record<string, unknown> | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface DeliveryProviderCreationAttributes {
+  name: string;
+  slug: string;
+  trackingUrlTemplate?: string | null;
+  webhookSecret?: string | null;
+  isActive?: boolean;
+  metadata?: Record<string, unknown> | null;
+}
+
+/**
+ * Shipment tracking attributes
+ * Atributos de seguimiento de envío
+ */
+export interface ShipmentTrackingAttributes {
+  id: string;
+  orderId: string | null;
+  vendorOrderId: string | null;
+  providerId: string | null;
+  trackingNumber: string;
+  status: ShipmentTrackingStatus;
+  statusHistory: ShipmentStatusHistoryEntry[];
+  estimatedDelivery: Date | null;
+  actualDelivery: Date | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export interface ShipmentTrackingCreationAttributes {
+  orderId?: string | null;
+  vendorOrderId?: string | null;
+  providerId?: string | null;
+  trackingNumber: string;
+  status?: ShipmentTrackingStatus;
+  statusHistory?: ShipmentStatusHistoryEntry[];
+  estimatedDelivery?: Date | null;
+  actualDelivery?: Date | null;
+}
+
+export interface AddTrackingDto {
+  trackingNumber: string;
+  providerId?: string;
+  estimatedDelivery?: string;
 }


### PR DESCRIPTION
## Summary
- ShippingAddress CRUD with default management (max 10 per user)
- ShipmentTracking with statusHistory (append-only)
- Webhook endpoint with HMAC-SHA256 signature validation and idempotency
- Order extensions for physical products (requires shippingAddressId)
- 24 unit tests for shipping services

### Changes
- New models: ShippingAddress, DeliveryProvider, ShipmentTracking
- Order model extended with shippingAddressId, shippingCost, shippingStatus
- 4 new migrations for shipping tables
- OrderService validates shipping address for physical products
- Order shippingStatus set based on product type (physical/digital)

### API Endpoints
- `POST /api/addresses` - Create shipping address
- `GET /api/addresses` - List user addresses
- `PUT /api/addresses/:id` - Update address
- `DELETE /api/addresses/:id` - Delete address
- `PUT /api/addresses/:id/default` - Set default
- `PUT /api/orders/:id/shipping` - Add tracking (vendor/admin)
- `GET /api/orders/:id/tracking` - Get tracking
- `POST /api/webhooks/shipping/:providerId` - Webhook receiver

Closes #26