### PR TITLE
feat(property-listings): Property module — model, CRUD, search, tests (#59)

### DIFF
--- a/backend/src/__tests__/PropertyService.test.ts
+++ b/backend/src/__tests__/PropertyService.test.ts
@@ -1,0 +1,429 @@
+/**
+ * @fileoverview Unit tests for PropertyService
+ * @description Tests for PropertyService CRUD operations including:
+ *              - Pagination, type filter, city filter, price range, status filter
+ *              - Find by ID success and not found scenarios
+ *              - Create, update, soft-delete operations
+ * @module __tests__/PropertyService
+ */
+
+// Mock sequelize before importing models
+jest.mock('../config/database', () => {
+  const mockTransaction = {
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    sequelize: {
+      transaction: jest.fn().mockResolvedValue(mockTransaction),
+      query: jest.fn(),
+      sync: jest.fn().mockResolvedValue({}),
+      authenticate: jest.fn().mockResolvedValue(undefined),
+    },
+    resetSequelize: jest.fn(),
+  };
+});
+
+// Mock all models
+jest.mock('../models', () => ({
+  Property: {
+    findAndCountAll: jest.fn(),
+    findByPk: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  Vendor: {
+    findByPk: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  User: {
+    findByPk: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+}));
+
+import { PropertyService } from '../services/PropertyService';
+import { Property } from '../models';
+
+describe('PropertyService', () => {
+  let propertyService: PropertyService;
+
+  // Mock properties for testing
+  const mockProperties = [
+    {
+      id: 'property-1',
+      type: 'rental',
+      title: 'Apartamento en El Poblado',
+      titleEn: 'Apartment in El Poblado',
+      description: 'Hermoso apartamento de 2 habitaciones',
+      descriptionEn: 'Beautiful 2-bedroom apartment',
+      price: 1500000,
+      currency: 'COP',
+      priceNegotiable: false,
+      bedrooms: 2,
+      bathrooms: 1,
+      areaM2: 65.5,
+      address: 'Cra 40 # 10-15',
+      city: 'Medellín',
+      country: 'Colombia',
+      lat: 6.2086,
+      lng: -75.5657,
+      amenities: ['parking', 'gym'],
+      images: ['https://example.com/img1.jpg'],
+      status: 'available',
+      vendorId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    },
+    {
+      id: 'property-2',
+      type: 'sale',
+      title: 'Casa en La Calera',
+      titleEn: 'House in La Calera',
+      description: 'Casa campestre con vista a la montaña',
+      descriptionEn: 'Country house with mountain view',
+      price: 850000000,
+      currency: 'COP',
+      priceNegotiable: true,
+      bedrooms: 4,
+      bathrooms: 3,
+      areaM2: 250,
+      address: 'Vía La Calera Km 5',
+      city: 'Bogotá',
+      country: 'Colombia',
+      lat: 4.7711,
+      lng: -73.9702,
+      amenities: ['garden', 'pool'],
+      images: [],
+      status: 'available',
+      vendorId: 'vendor-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    },
+    {
+      id: 'property-3',
+      type: 'management',
+      title: 'Oficina en Centro',
+      titleEn: null,
+      description: 'Oficina corporativa 80m2',
+      descriptionEn: null,
+      price: 3000000,
+      currency: 'COP',
+      priceNegotiable: false,
+      bedrooms: null,
+      bathrooms: 1,
+      areaM2: 80,
+      address: 'Calle 100 # 15-20',
+      city: 'Bogotá',
+      country: 'Colombia',
+      lat: null,
+      lng: null,
+      amenities: [],
+      images: [],
+      status: 'paused',
+      vendorId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    propertyService = new PropertyService();
+  });
+
+  // ============================================================
+  // findAll
+  // ============================================================
+  describe('findAll', () => {
+    /**
+     * Test 1: Default pagination
+     * Verifies that default page=1 and limit=20 are applied
+     */
+    it('should return paginated properties with default params', async () => {
+      const mockResult = {
+        rows: [mockProperties[0], mockProperties[1]],
+        count: 2,
+      };
+      (Property.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await propertyService.findAll();
+
+      expect(result.count).toBe(2);
+      expect(result.rows).toHaveLength(2);
+      expect(Property.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 20,
+          offset: 0,
+        })
+      );
+    });
+
+    /**
+     * Test 2: Filter by type
+     * Verifies that type filter is correctly passed to query
+     */
+    it('should filter properties by type', async () => {
+      const mockResult = { rows: [mockProperties[0]], count: 1 };
+      (Property.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await propertyService.findAll({ type: 'rental' });
+
+      expect(Property.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            type: 'rental',
+          }),
+        })
+      );
+    });
+
+    /**
+     * Test 3: Filter by city
+     * Verifies that city filter is correctly passed to query
+     */
+    it('should filter properties by city', async () => {
+      const mockResult = { rows: [mockProperties[1], mockProperties[2]], count: 2 };
+      (Property.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await propertyService.findAll({ city: 'Bogotá' });
+
+      expect(Property.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            city: 'Bogotá',
+          }),
+        })
+      );
+    });
+
+    /**
+     * Test 4: Filter by price range
+     * Verifies that minPrice and maxPrice are applied as Op.gte / Op.lte
+     */
+    it('should filter properties by price range', async () => {
+      const mockResult = { rows: [mockProperties[0]], count: 1 };
+      (Property.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await propertyService.findAll({ minPrice: 1000000, maxPrice: 2000000 });
+
+      expect(Property.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            price: expect.any(Object),
+          }),
+        })
+      );
+    });
+
+    /**
+     * Test 5: Filter by status
+     * Verifies that status filter is correctly passed to query
+     */
+    it('should filter properties by status', async () => {
+      const mockResult = { rows: [mockProperties[2]], count: 1 };
+      (Property.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await propertyService.findAll({ status: 'paused' });
+
+      expect(Property.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: 'paused',
+          }),
+        })
+      );
+    });
+
+    it('should enforce maximum limit of 100', async () => {
+      const mockResult = { rows: [], count: 0 };
+      (Property.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await propertyService.findAll({ page: 1, limit: 500 });
+
+      expect(Property.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 100,
+        })
+      );
+    });
+
+    it('should order results by created_at descending', async () => {
+      const mockResult = { rows: [], count: 0 };
+      (Property.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await propertyService.findAll();
+
+      expect(Property.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: [['created_at', 'DESC']],
+        })
+      );
+    });
+
+    it('should calculate correct offset for page 2', async () => {
+      const mockResult = { rows: [], count: 0 };
+      (Property.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await propertyService.findAll({ page: 2, limit: 10 });
+
+      expect(Property.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 10,
+          offset: 10,
+        })
+      );
+    });
+  });
+
+  // ============================================================
+  // findById
+  // ============================================================
+  describe('findById', () => {
+    /**
+     * Test 6: findById success
+     * Verifies that a found property is returned
+     */
+    it('should return property when found', async () => {
+      const mockProperty = mockProperties[0];
+      (Property.findByPk as jest.Mock).mockResolvedValue(mockProperty);
+
+      const result = await propertyService.findById('property-1');
+
+      expect(result).toEqual(mockProperty);
+      expect(Property.findByPk).toHaveBeenCalledWith('property-1');
+    });
+
+    /**
+     * Test 7: findById not found → throws 404
+     * Verifies proper error object when property doesn't exist
+     */
+    it('should throw 404 error when property not found', async () => {
+      (Property.findByPk as jest.Mock).mockResolvedValue(null);
+
+      await expect(propertyService.findById('nonexistent-id')).rejects.toMatchObject({
+        statusCode: 404,
+        code: 'PROPERTY_NOT_FOUND',
+      });
+    });
+
+    it('should throw error with correct message when not found', async () => {
+      (Property.findByPk as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await propertyService.findById('nonexistent-id');
+        fail('Expected error to be thrown');
+      } catch (error: any) {
+        expect(error.statusCode).toBe(404);
+        expect(error.code).toBe('PROPERTY_NOT_FOUND');
+        expect(error.message).toBe('Property not found');
+      }
+    });
+  });
+
+  // ============================================================
+  // create
+  // ============================================================
+  describe('create', () => {
+    /**
+     * Test 8: create success
+     * Verifies that a property is created correctly
+     */
+    it('should create a property correctly', async () => {
+      const inputData = {
+        type: 'rental' as const,
+        title: 'Nuevo Apartamento',
+        price: 1200000,
+        address: 'Calle 50 # 10-30',
+        city: 'Medellín',
+      };
+
+      const createdProperty = { ...mockProperties[0], ...inputData, id: 'new-property-id' };
+      (Property.create as jest.Mock).mockResolvedValue(createdProperty);
+
+      const result = await propertyService.create(inputData);
+
+      expect(result).toEqual(createdProperty);
+      expect(Property.create).toHaveBeenCalledWith(expect.objectContaining(inputData));
+    });
+  });
+
+  // ============================================================
+  // update
+  // ============================================================
+  describe('update', () => {
+    /**
+     * Test 9: update success
+     * Verifies that a property is updated correctly
+     */
+    it('should update a property correctly', async () => {
+      const updateMock = jest.fn().mockResolvedValue(undefined);
+      const mockProperty = { ...mockProperties[0], update: updateMock };
+      (Property.findByPk as jest.Mock).mockResolvedValue(mockProperty);
+
+      const updateData = { title: 'Apartamento Renovado', price: 1800000 };
+      await propertyService.update('property-1', updateData);
+
+      expect(updateMock).toHaveBeenCalledWith(updateData);
+    });
+
+    /**
+     * Test 11: update not found → throws 404
+     * Verifies that 404 is thrown when updating a non-existent property
+     */
+    it('should throw 404 when updating non-existent property', async () => {
+      (Property.findByPk as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        propertyService.update('nonexistent-id', { title: 'Test' })
+      ).rejects.toMatchObject({
+        statusCode: 404,
+        code: 'PROPERTY_NOT_FOUND',
+      });
+    });
+  });
+
+  // ============================================================
+  // remove (soft-delete)
+  // ============================================================
+  describe('remove', () => {
+    /**
+     * Test 10: remove (soft-delete) success
+     * Verifies that destroy() is called on the found property
+     */
+    it('should soft-delete a property correctly', async () => {
+      const destroyMock = jest.fn().mockResolvedValue(undefined);
+      const mockProperty = { ...mockProperties[0], destroy: destroyMock };
+      (Property.findByPk as jest.Mock).mockResolvedValue(mockProperty);
+
+      await propertyService.remove('property-1');
+
+      expect(destroyMock).toHaveBeenCalled();
+    });
+
+    it('should throw 404 when removing non-existent property', async () => {
+      (Property.findByPk as jest.Mock).mockResolvedValue(null);
+
+      await expect(propertyService.remove('nonexistent-id')).rejects.toMatchObject({
+        statusCode: 404,
+        code: 'PROPERTY_NOT_FOUND',
+      });
+    });
+  });
+});

--- a/backend/src/controllers/PropertyController.ts
+++ b/backend/src/controllers/PropertyController.ts
@@ -1,0 +1,347 @@
+/**
+ * @fileoverview PropertyController - Property listing endpoints
+ * @description Controller for public property browsing and admin CRUD operations.
+ *              Public routes: list, detail.
+ *              Admin routes: create, update, soft-delete.
+ * @module controllers/PropertyController
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: List available properties
+ * GET /api/properties?city=Bogotá&status=available
+ *
+ * // Español: Listar propiedades disponibles
+ * GET /api/properties?city=Bogotá&status=available
+ */
+import { Request, Response } from 'express';
+import { body, param, query, validationResult } from 'express-validator';
+import { authenticate, requireAdmin } from '../middleware/auth.middleware';
+import { propertyService } from '../services/PropertyService';
+
+// ============================================
+// VALIDATION RULES
+// ============================================
+
+/**
+ * Validation rule sets for property endpoints
+ * Conjuntos de reglas de validación para endpoints de propiedades
+ */
+export const validationRules = {
+  /**
+   * Rules for listing properties (public + admin filter)
+   * Reglas para listar propiedades (filtro público + admin)
+   */
+  list: [
+    query('type').optional().isIn(['rental', 'sale', 'management']),
+    query('city').optional().isString().trim().isLength({ max: 100 }),
+    query('minPrice').optional().isFloat({ min: 0 }),
+    query('maxPrice').optional().isFloat({ min: 0 }),
+    query('bedrooms').optional().isInt({ min: 0 }),
+    query('status').optional().isIn(['available', 'rented', 'sold', 'paused']),
+    query('page').optional().isInt({ min: 1 }),
+    query('limit').optional().isInt({ min: 1, max: 100 }),
+  ],
+
+  /**
+   * Rules for creating a property
+   * Reglas para crear una propiedad
+   */
+  create: [
+    body('type').isIn(['rental', 'sale', 'management']),
+    body('title').notEmpty().trim().isLength({ min: 1, max: 255 }),
+    body('titleEn').optional({ nullable: true }).isString().trim().isLength({ max: 255 }),
+    body('description').optional({ nullable: true }).isString().trim(),
+    body('descriptionEn').optional({ nullable: true }).isString().trim(),
+    body('price').isFloat({ min: 0 }),
+    body('currency').optional().isString().trim().isLength({ min: 3, max: 3 }),
+    body('priceNegotiable').optional().isBoolean(),
+    body('bedrooms').optional({ nullable: true }).isInt({ min: 0 }),
+    body('bathrooms').optional({ nullable: true }).isInt({ min: 0 }),
+    body('areaM2').optional({ nullable: true }).isFloat({ min: 0 }),
+    body('address').notEmpty().trim().isLength({ min: 1, max: 500 }),
+    body('city').notEmpty().trim().isLength({ min: 1, max: 100 }),
+    body('country').optional().isString().trim().isLength({ max: 100 }),
+    body('lat').optional({ nullable: true }).isFloat({ min: -90, max: 90 }),
+    body('lng').optional({ nullable: true }).isFloat({ min: -180, max: 180 }),
+    body('amenities').optional().isArray(),
+    body('images').optional().isArray(),
+    body('status').optional().isIn(['available', 'rented', 'sold', 'paused']),
+    body('vendorId').optional({ nullable: true }).isUUID(),
+  ],
+
+  /**
+   * Rules for updating a property (all fields optional)
+   * Reglas para actualizar una propiedad (todos los campos opcionales)
+   */
+  update: [
+    param('id').isUUID(),
+    body('type').optional().isIn(['rental', 'sale', 'management']),
+    body('title').optional().trim().isLength({ min: 1, max: 255 }),
+    body('titleEn').optional({ nullable: true }).isString().trim().isLength({ max: 255 }),
+    body('description').optional({ nullable: true }).isString().trim(),
+    body('descriptionEn').optional({ nullable: true }).isString().trim(),
+    body('price').optional().isFloat({ min: 0 }),
+    body('currency').optional().isString().trim().isLength({ min: 3, max: 3 }),
+    body('priceNegotiable').optional().isBoolean(),
+    body('bedrooms').optional({ nullable: true }).isInt({ min: 0 }),
+    body('bathrooms').optional({ nullable: true }).isInt({ min: 0 }),
+    body('areaM2').optional({ nullable: true }).isFloat({ min: 0 }),
+    body('address').optional().trim().isLength({ min: 1, max: 500 }),
+    body('city').optional().trim().isLength({ min: 1, max: 100 }),
+    body('country').optional().isString().trim().isLength({ max: 100 }),
+    body('lat').optional({ nullable: true }).isFloat({ min: -90, max: 90 }),
+    body('lng').optional({ nullable: true }).isFloat({ min: -180, max: 180 }),
+    body('amenities').optional().isArray(),
+    body('images').optional().isArray(),
+    body('status').optional().isIn(['available', 'rented', 'sold', 'paused']),
+    body('vendorId').optional({ nullable: true }).isUUID(),
+  ],
+};
+
+// ============================================
+// HANDLERS
+// ============================================
+
+/**
+ * GET /api/properties — Public property listing with filters
+ * GET /api/properties — Listado público de propiedades con filtros
+ *
+ * @route GET /api/properties
+ * @access Public
+ */
+export const getProperties = [
+  validationRules.list,
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const { type, city, minPrice, maxPrice, bedrooms, status, page, limit } = req.query as Record<
+        string,
+        string | undefined
+      >;
+
+      const { rows, count } = await propertyService.findAll({
+        type: type as 'rental' | 'sale' | 'management' | undefined,
+        city,
+        minPrice: minPrice ? parseFloat(minPrice) : undefined,
+        maxPrice: maxPrice ? parseFloat(maxPrice) : undefined,
+        bedrooms: bedrooms ? parseInt(bedrooms, 10) : undefined,
+        status: status as 'available' | 'rented' | 'sold' | 'paused' | undefined,
+        page: page ? parseInt(page, 10) : undefined,
+        limit: limit ? parseInt(limit, 10) : undefined,
+      });
+
+      const parsedPage = page ? parseInt(page, 10) : 1;
+      const parsedLimit = limit ? Math.min(parseInt(limit, 10), 100) : 20;
+
+      res.json({
+        success: true,
+        data: rows,
+        pagination: {
+          total: count,
+          page: parsedPage,
+          limit: parsedLimit,
+          totalPages: Math.ceil(count / parsedLimit),
+        },
+      });
+    } catch (error: any) {
+      console.error('Get properties error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to get properties',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * GET /api/properties/:id — Public property detail
+ * GET /api/properties/:id — Detalle público de propiedad
+ *
+ * @route GET /api/properties/:id
+ * @access Public
+ */
+export const getProperty = [
+  param('id').isUUID(),
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const property = await propertyService.findById(req.params.id);
+
+      res.json({
+        success: true,
+        data: property,
+      });
+    } catch (error: any) {
+      console.error('Get property error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to get property',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * POST /api/admin/properties — Admin: create a property
+ * POST /api/admin/properties — Admin: crear una propiedad
+ *
+ * @route POST /api/admin/properties
+ * @access Admin
+ */
+export const createProperty = [
+  authenticate,
+  requireAdmin,
+  validationRules.create,
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const property = await propertyService.create(req.body);
+
+      res.status(201).json({
+        success: true,
+        data: property,
+      });
+    } catch (error: any) {
+      console.error('Create property error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to create property',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * PUT /api/admin/properties/:id — Admin: update a property
+ * PUT /api/admin/properties/:id — Admin: actualizar una propiedad
+ *
+ * @route PUT /api/admin/properties/:id
+ * @access Admin
+ */
+export const updateProperty = [
+  authenticate,
+  requireAdmin,
+  validationRules.update,
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const property = await propertyService.update(req.params.id, req.body);
+
+      res.json({
+        success: true,
+        data: property,
+      });
+    } catch (error: any) {
+      console.error('Update property error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to update property',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * DELETE /api/admin/properties/:id — Admin: soft-delete a property
+ * DELETE /api/admin/properties/:id — Admin: eliminar suavemente una propiedad
+ *
+ * @route DELETE /api/admin/properties/:id
+ * @access Admin
+ */
+export const deleteProperty = [
+  authenticate,
+  requireAdmin,
+  param('id').isUUID(),
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      await propertyService.remove(req.params.id);
+
+      res.json({
+        success: true,
+        message: 'Property deleted successfully',
+      });
+    } catch (error: any) {
+      console.error('Delete property error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to delete property',
+        },
+      });
+    }
+  },
+];

--- a/backend/src/database/migrations/20260406130000-create-properties.js
+++ b/backend/src/database/migrations/20260406130000-create-properties.js
@@ -1,0 +1,197 @@
+/**
+ * @fileoverview Create Properties Table Migration
+ * @description Creates the properties table for Nexo Real property listings module.
+ *   Supports rental, sale, and management listing types with geo data, JSONB fields,
+ *   soft-delete (paranoid), and vendor association.
+ *
+ * ES: Crea la tabla properties para el módulo de listados inmobiliarios de Nexo Real.
+ *   Soporta tipos alquiler, venta y gestión con datos geo, campos JSONB,
+ *   borrado suave (paranoid) y asociación a vendedor.
+ *
+ * EN: Creates the properties table for Nexo Real property listings module.
+ *   Supports rental, sale, and management types with geo data, JSONB fields,
+ *   soft-delete (paranoid), and vendor association.
+ *
+ * @example
+ * // English: Run migration
+ * npx sequelize-cli db:migrate
+ *
+ * // Español: Ejecutar migración
+ * npx sequelize-cli db:migrate
+ */
+'use strict';
+
+module.exports = {
+  /**
+   * Up: Create properties table
+   * @param {Object} queryInterface - Sequelize query interface
+   * @param {Object} Sequelize - Sequelize library
+   */
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('properties', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+        allowNull: false,
+      },
+      type: {
+        type: Sequelize.ENUM('rental', 'sale', 'management'),
+        allowNull: false,
+        comment: 'Property listing type: rental, sale, or management',
+      },
+      title: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+        comment: 'Property title in Spanish',
+      },
+      title_en: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+        comment: 'Property title in English',
+      },
+      description: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+        comment: 'Property description in Spanish',
+      },
+      description_en: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+        comment: 'Property description in English',
+      },
+      price: {
+        type: Sequelize.DECIMAL(12, 2),
+        allowNull: false,
+        comment: 'Listing price',
+      },
+      currency: {
+        type: Sequelize.STRING(3),
+        allowNull: false,
+        defaultValue: 'COP',
+        comment: 'ISO 4217 currency code',
+      },
+      price_negotiable: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false,
+        comment: 'Whether the price is negotiable',
+      },
+      bedrooms: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        comment: 'Number of bedrooms',
+      },
+      bathrooms: {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        comment: 'Number of bathrooms',
+      },
+      area_m2: {
+        type: Sequelize.DECIMAL(10, 2),
+        allowNull: true,
+        comment: 'Total area in square meters',
+      },
+      address: {
+        type: Sequelize.STRING(500),
+        allowNull: false,
+        comment: 'Street address',
+      },
+      city: {
+        type: Sequelize.STRING(100),
+        allowNull: false,
+        comment: 'City name',
+      },
+      country: {
+        type: Sequelize.STRING(100),
+        allowNull: false,
+        defaultValue: 'Colombia',
+        comment: 'Country name',
+      },
+      lat: {
+        type: Sequelize.DECIMAL(10, 7),
+        allowNull: true,
+        comment: 'Latitude coordinate',
+      },
+      lng: {
+        type: Sequelize.DECIMAL(10, 7),
+        allowNull: true,
+        comment: 'Longitude coordinate',
+      },
+      amenities: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+        defaultValue: [],
+        comment: 'List of amenity strings or objects',
+      },
+      images: {
+        type: Sequelize.JSONB,
+        allowNull: false,
+        defaultValue: [],
+        comment: 'List of image URL strings or objects',
+      },
+      status: {
+        type: Sequelize.ENUM('available', 'rented', 'sold', 'paused'),
+        allowNull: false,
+        defaultValue: 'available',
+        comment: 'Current listing status',
+      },
+      vendor_id: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        references: {
+          model: 'vendors',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+        comment: 'FK to vendors table — nullable',
+      },
+      deleted_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+        comment: 'Soft-delete timestamp (paranoid)',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+    });
+
+    // Index on status for filtering available/rented/sold listings
+    await queryInterface.addIndex('properties', ['status'], {
+      name: 'properties_status_idx',
+    });
+
+    // Index on city for geographic filtering
+    await queryInterface.addIndex('properties', ['city'], {
+      name: 'properties_city_idx',
+    });
+
+    // Index on type for listing type filtering
+    await queryInterface.addIndex('properties', ['type'], {
+      name: 'properties_type_idx',
+    });
+
+    // Index on vendor_id for vendor-specific queries
+    await queryInterface.addIndex('properties', ['vendor_id'], {
+      name: 'properties_vendor_id_idx',
+    });
+  },
+
+  /**
+   * Down: Drop properties table
+   * @param {Object} queryInterface - Sequelize query interface
+   * @param {Object} Sequelize - Sequelize library
+   */
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('properties');
+    // Note: ENUM types must be manually dropped in PostgreSQL if needed
+    // await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_properties_type";');
+    // await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_properties_status";');
+  },
+};

--- a/backend/src/models/Property.ts
+++ b/backend/src/models/Property.ts
@@ -1,0 +1,267 @@
+/**
+ * @fileoverview Property Model - Real estate property entity for Nexo Real
+ * @description Sequelize model representing properties (rental, sale, management) in the marketplace
+ * @module models/Property
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Get available properties in a city
+ * const properties = await Property.findAll({ where: { city: 'Bogotá', status: 'available' } });
+ *
+ * // Español: Obtener propiedades disponibles en una ciudad
+ * const properties = await Property.findAll({ where: { city: 'Bogotá', status: 'available' } });
+ */
+import { DataTypes, Model, Optional } from 'sequelize';
+import { sequelize } from '../config/database';
+
+// ============================================
+// INTERFACES — Property Attributes
+// ============================================
+
+/**
+ * Property attribute types — all columns on the table
+ * Tipos de atributos de propiedad — todas las columnas de la tabla
+ */
+export interface PropertyAttributes {
+  id: string;
+  type: 'rental' | 'sale' | 'management';
+  title: string;
+  titleEn: string | null;
+  description: string | null;
+  descriptionEn: string | null;
+  price: number;
+  currency: string;
+  priceNegotiable: boolean;
+  bedrooms: number | null;
+  bathrooms: number | null;
+  areaM2: number | null;
+  address: string;
+  city: string;
+  country: string;
+  lat: number | null;
+  lng: number | null;
+  amenities: unknown[];
+  images: unknown[];
+  status: 'available' | 'rented' | 'sold' | 'paused';
+  vendorId: string | null;
+  deletedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Creation attributes — fields that can be omitted on create
+ * Atributos de creación — campos que pueden omitirse al crear
+ */
+export interface PropertyCreationAttributes extends Optional<
+  PropertyAttributes,
+  | 'id'
+  | 'titleEn'
+  | 'description'
+  | 'descriptionEn'
+  | 'currency'
+  | 'priceNegotiable'
+  | 'bedrooms'
+  | 'bathrooms'
+  | 'areaM2'
+  | 'country'
+  | 'lat'
+  | 'lng'
+  | 'amenities'
+  | 'images'
+  | 'status'
+  | 'vendorId'
+  | 'deletedAt'
+  | 'createdAt'
+  | 'updatedAt'
+> {}
+
+type PropertyCreation = Optional<
+  PropertyAttributes,
+  | 'id'
+  | 'titleEn'
+  | 'description'
+  | 'descriptionEn'
+  | 'currency'
+  | 'priceNegotiable'
+  | 'bedrooms'
+  | 'bathrooms'
+  | 'areaM2'
+  | 'country'
+  | 'lat'
+  | 'lng'
+  | 'amenities'
+  | 'images'
+  | 'status'
+  | 'vendorId'
+  | 'deletedAt'
+  | 'createdAt'
+  | 'updatedAt'
+>;
+
+/**
+ * Property Model - Represents a real estate property in Nexo Real
+ * Modelo de Propiedad - Representa una propiedad inmobiliaria en Nexo Real
+ */
+export class Property
+  extends Model<PropertyAttributes, PropertyCreation>
+  implements PropertyAttributes
+{
+  declare id: string;
+  declare type: 'rental' | 'sale' | 'management';
+  declare title: string;
+  declare titleEn: string | null;
+  declare description: string | null;
+  declare descriptionEn: string | null;
+  declare price: number;
+  declare currency: string;
+  declare priceNegotiable: boolean;
+  declare bedrooms: number | null;
+  declare bathrooms: number | null;
+  declare areaM2: number | null;
+  declare address: string;
+  declare city: string;
+  declare country: string;
+  declare lat: number | null;
+  declare lng: number | null;
+  declare amenities: unknown[];
+  declare images: unknown[];
+  declare status: 'available' | 'rented' | 'sold' | 'paused';
+  declare vendorId: string | null;
+  declare deletedAt: Date | null;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
+}
+
+Property.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    type: {
+      type: DataTypes.ENUM('rental', 'sale', 'management'),
+      allowNull: false,
+    },
+    title: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      validate: {
+        len: [1, 255],
+      },
+    },
+    titleEn: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+      field: 'title_en',
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    descriptionEn: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: 'description_en',
+    },
+    price: {
+      type: DataTypes.DECIMAL(12, 2),
+      allowNull: false,
+      validate: {
+        min: 0,
+      },
+    },
+    currency: {
+      type: DataTypes.STRING(3),
+      defaultValue: 'COP',
+    },
+    priceNegotiable: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      field: 'price_negotiable',
+    },
+    bedrooms: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    bathrooms: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    areaM2: {
+      type: DataTypes.DECIMAL(10, 2),
+      allowNull: true,
+      field: 'area_m2',
+    },
+    address: {
+      type: DataTypes.STRING(500),
+      allowNull: false,
+    },
+    city: {
+      type: DataTypes.STRING(100),
+      allowNull: false,
+    },
+    country: {
+      type: DataTypes.STRING(100),
+      defaultValue: 'Colombia',
+    },
+    lat: {
+      type: DataTypes.DECIMAL(10, 7),
+      allowNull: true,
+    },
+    lng: {
+      type: DataTypes.DECIMAL(10, 7),
+      allowNull: true,
+    },
+    amenities: {
+      type: DataTypes.JSONB,
+      defaultValue: [],
+    },
+    images: {
+      type: DataTypes.JSONB,
+      defaultValue: [],
+    },
+    status: {
+      type: DataTypes.ENUM('available', 'rented', 'sold', 'paused'),
+      defaultValue: 'available',
+    },
+    vendorId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      field: 'vendor_id',
+      references: {
+        model: 'vendors',
+        key: 'id',
+      },
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'deleted_at',
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'created_at',
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'updated_at',
+    },
+  },
+  {
+    sequelize,
+    tableName: 'properties',
+    underscored: true,
+    timestamps: true,
+    paranoid: true,
+    indexes: [
+      { fields: ['status'] },
+      { fields: ['city'] },
+      { fields: ['type'] },
+      { fields: ['vendor_id'] },
+    ],
+  }
+);

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -39,6 +39,7 @@ import { Achievement } from './Achievement';
 import { Badge } from './Badge';
 import { UserAchievement } from './UserAchievement';
 import { WebhookEvent } from './WebhookEvent';
+import { Property } from './Property';
 
 // User relationships
 User.hasMany(User, { as: 'children', foreignKey: 'sponsorId', sourceKey: 'id' });
@@ -422,6 +423,14 @@ UserAchievement.belongsTo(Achievement, { foreignKey: 'achievementId', targetKey:
 User.hasMany(UserAchievement, { as: 'userAchievements', foreignKey: 'userId', sourceKey: 'id' });
 UserAchievement.belongsTo(User, { foreignKey: 'userId', targetKey: 'id' });
 
+// ============================================
+// NEXO REAL — Property Listings (#59)
+// ============================================
+
+// Vendor - Property (one vendor, many properties)
+Vendor.hasMany(Property, { foreignKey: 'vendorId', sourceKey: 'id' });
+Property.belongsTo(Vendor, { as: 'vendor', foreignKey: 'vendorId', targetKey: 'id' });
+
 export {
   sequelize,
   User,
@@ -465,6 +474,7 @@ export {
   Badge,
   UserAchievement,
   WebhookEvent,
+  Property,
 };
 
 export function initModels(): void {

--- a/backend/src/routes/admin-property.routes.ts
+++ b/backend/src/routes/admin-property.routes.ts
@@ -1,0 +1,235 @@
+/**
+ * @fileoverview Admin Property Routes - Admin property management endpoints
+ * @description Routes for admin property CRUD operations (create, update, delete, list)
+ * @module routes/admin-property.routes
+ * @author MLM Development Team
+ */
+import { Router } from 'express';
+import {
+  getProperties,
+  createProperty,
+  updateProperty,
+  deleteProperty,
+} from '../controllers/PropertyController';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: admin-properties
+ *     description: Admin property management / Gestión de propiedades (Admin)
+ */
+
+/**
+ * @swagger
+ * /admin/properties:
+ *   get:
+ *     summary: List all properties (admin) / Listar todas las propiedades (admin)
+ *     description: Admin endpoint to list all properties including paused, sold, and rented.
+ *                  Endpoint admin para listar todas las propiedades incluyendo pausadas, vendidas y alquiladas.
+ *     tags: [admin-properties]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: type
+ *         schema:
+ *           type: string
+ *           enum: [rental, sale, management]
+ *       - in: query
+ *         name: city
+ *         schema:
+ *           type: string
+ *           example: "Medellín"
+ *       - in: query
+ *         name: minPrice
+ *         schema:
+ *           type: number
+ *           minimum: 0
+ *       - in: query
+ *         name: maxPrice
+ *         schema:
+ *           type: number
+ *           minimum: 0
+ *       - in: query
+ *         name: bedrooms
+ *         schema:
+ *           type: integer
+ *           minimum: 0
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [available, rented, sold, paused]
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *     responses:
+ *       200:
+ *         description: Property list / Lista de propiedades
+ *       401:
+ *         description: Unauthorized / No autorizado
+ *       403:
+ *         description: Forbidden - not an admin / Prohibido - no es admin
+ */
+router.get('/', getProperties);
+
+/**
+ * @swagger
+ * /admin/properties:
+ *   post:
+ *     summary: Create property / Crear propiedad
+ *     tags: [admin-properties]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - type
+ *               - title
+ *               - price
+ *               - address
+ *               - city
+ *             properties:
+ *               type:
+ *                 type: string
+ *                 enum: [rental, sale, management]
+ *                 example: "rental"
+ *               title:
+ *                 type: string
+ *                 example: "Apartamento en el Poblado"
+ *               titleEn:
+ *                 type: string
+ *                 example: "Apartment in El Poblado"
+ *               description:
+ *                 type: string
+ *               descriptionEn:
+ *                 type: string
+ *               price:
+ *                 type: number
+ *                 minimum: 0
+ *                 example: 1500000
+ *               currency:
+ *                 type: string
+ *                 example: "COP"
+ *               priceNegotiable:
+ *                 type: boolean
+ *               bedrooms:
+ *                 type: integer
+ *                 example: 2
+ *               bathrooms:
+ *                 type: integer
+ *                 example: 1
+ *               areaM2:
+ *                 type: number
+ *                 example: 65.5
+ *               address:
+ *                 type: string
+ *                 example: "Cra 40 # 10-15"
+ *               city:
+ *                 type: string
+ *                 example: "Medellín"
+ *               country:
+ *                 type: string
+ *                 example: "Colombia"
+ *               lat:
+ *                 type: number
+ *               lng:
+ *                 type: number
+ *               amenities:
+ *                 type: array
+ *               images:
+ *                 type: array
+ *               status:
+ *                 type: string
+ *                 enum: [available, rented, sold, paused]
+ *               vendorId:
+ *                 type: string
+ *                 format: uuid
+ *     responses:
+ *       201:
+ *         description: Property created / Propiedad creada
+ *       400:
+ *         description: Validation error / Error de validación
+ *       401:
+ *         description: Unauthorized / No autorizado
+ *       403:
+ *         description: Forbidden / Prohibido
+ */
+router.post('/', createProperty);
+
+/**
+ * @swagger
+ * /admin/properties/{id}:
+ *   put:
+ *     summary: Update property / Actualizar propiedad
+ *     tags: [admin-properties]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *               price:
+ *                 type: number
+ *               status:
+ *                 type: string
+ *                 enum: [available, rented, sold, paused]
+ *     responses:
+ *       200:
+ *         description: Property updated / Propiedad actualizada
+ *       400:
+ *         description: Validation error / Error de validación
+ *       404:
+ *         description: Property not found / Propiedad no encontrada
+ */
+router.put('/:id', updateProperty);
+
+/**
+ * @swagger
+ * /admin/properties/{id}:
+ *   delete:
+ *     summary: Delete property (soft-delete) / Eliminar propiedad (borrado suave)
+ *     tags: [admin-properties]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Property deleted / Propiedad eliminada
+ *       404:
+ *         description: Property not found / Propiedad no encontrada
+ */
+router.delete('/:id', deleteProperty);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -22,6 +22,8 @@ import adminCategoryRoutes from './admin-category.routes';
 import categoryRoutes from './category.routes';
 import vendorRoutes from './vendor.routes';
 import adminVendorRoutes from './admin-vendor.routes';
+import propertyRoutes from './property.routes';
+import adminPropertyRoutes from './admin-property.routes';
 import contractRoutes from './contract.routes';
 import adminContractRoutes from './admin-contract.routes';
 import addressRoutes from './address.routes';
@@ -61,6 +63,12 @@ router.use('/vendors', vendorRoutes);
 
 // Admin vendor routes
 router.use('/admin/vendors', adminVendorRoutes);
+
+// Property routes (public)
+router.use('/properties', propertyRoutes);
+
+// Admin property routes
+router.use('/admin/properties', adminPropertyRoutes);
 
 // Contract routes (user)
 router.use('/contracts', contractRoutes);

--- a/backend/src/routes/property.routes.ts
+++ b/backend/src/routes/property.routes.ts
@@ -1,0 +1,115 @@
+/**
+ * @fileoverview Property Routes - Public property listing endpoints
+ * @description Routes for browsing property listings without authentication
+ * @module routes/property.routes
+ * @author MLM Development Team
+ */
+import { Router } from 'express';
+import { getProperties, getProperty } from '../controllers/PropertyController';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: properties
+ *     description: Property listings / Listados de propiedades
+ */
+
+/**
+ * @swagger
+ * /properties:
+ *   get:
+ *     summary: List properties / Listar propiedades
+ *     description: Public endpoint to browse available properties with optional filters.
+ *                  Endpoint público para navegar propiedades disponibles con filtros opcionales.
+ *     tags: [properties]
+ *     parameters:
+ *       - in: query
+ *         name: type
+ *         schema:
+ *           type: string
+ *           enum: [rental, sale, management]
+ *         description: Filter by listing type / Filtrar por tipo de listado
+ *       - in: query
+ *         name: city
+ *         schema:
+ *           type: string
+ *           example: "Bogotá"
+ *         description: Filter by city / Filtrar por ciudad
+ *       - in: query
+ *         name: minPrice
+ *         schema:
+ *           type: number
+ *           minimum: 0
+ *           example: 500000
+ *         description: Minimum price / Precio mínimo
+ *       - in: query
+ *         name: maxPrice
+ *         schema:
+ *           type: number
+ *           minimum: 0
+ *           example: 2000000
+ *         description: Maximum price / Precio máximo
+ *       - in: query
+ *         name: bedrooms
+ *         schema:
+ *           type: integer
+ *           minimum: 0
+ *           example: 3
+ *         description: Number of bedrooms / Número de habitaciones
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [available, rented, sold, paused]
+ *           default: available
+ *         description: Listing status / Estado del listado
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *           minimum: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *           minimum: 1
+ *           maximum: 100
+ *     responses:
+ *       200:
+ *         description: Property list with pagination / Lista de propiedades con paginación
+ *       400:
+ *         description: Validation error / Error de validación
+ */
+router.get('/', getProperties);
+
+/**
+ * @swagger
+ * /properties/{id}:
+ *   get:
+ *     summary: Get property by ID / Obtener propiedad por ID
+ *     description: Public endpoint to retrieve a single property's details.
+ *                  Endpoint público para obtener los detalles de una sola propiedad.
+ *     tags: [properties]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: Property UUID / UUID de la propiedad
+ *     responses:
+ *       200:
+ *         description: Property details / Detalles de la propiedad
+ *       400:
+ *         description: Invalid UUID / UUID inválido
+ *       404:
+ *         description: Property not found / Propiedad no encontrada
+ */
+router.get('/:id', getProperty);
+
+export default router;

--- a/backend/src/services/PropertyService.ts
+++ b/backend/src/services/PropertyService.ts
@@ -1,0 +1,190 @@
+/**
+ * @fileoverview PropertyService - Business logic for property listings
+ * @description Service layer for CRUD operations on properties.
+ *              Handles filtering, pagination, and soft-delete (paranoid).
+ * @module services/PropertyService
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: List available properties in Bogotá
+ * const result = await propertyService.findAll({ city: 'Bogotá', status: 'available' });
+ *
+ * // Español: Listar propiedades disponibles en Bogotá
+ * const result = await propertyService.findAll({ city: 'Bogotá', status: 'available' });
+ */
+import { Op, WhereOptions } from 'sequelize';
+import { Property } from '../models';
+import type { PropertyAttributes, PropertyCreationAttributes } from '../models/Property';
+
+// ============================================
+// TYPES
+// ============================================
+
+/**
+ * Input filters for listing properties
+ * Filtros de entrada para listar propiedades
+ */
+export interface PropertyFilters {
+  /** Listing type / Tipo de listado */
+  type?: 'rental' | 'sale' | 'management';
+  /** City filter / Filtro de ciudad */
+  city?: string;
+  /** Minimum price / Precio mínimo */
+  minPrice?: number;
+  /** Maximum price / Precio máximo */
+  maxPrice?: number;
+  /** Number of bedrooms / Número de habitaciones */
+  bedrooms?: number;
+  /** Listing status / Estado del listado */
+  status?: 'available' | 'rented' | 'sold' | 'paused';
+  /** Page number (1-based) / Número de página (base 1) */
+  page?: number;
+  /** Page size / Tamaño de página */
+  limit?: number;
+}
+
+/**
+ * Input data for creating or updating a property
+ * Datos de entrada para crear o actualizar una propiedad
+ */
+export type PropertyCreateInput = PropertyCreationAttributes;
+
+// ============================================
+// SERVICE CLASS
+// ============================================
+
+/**
+ * PropertyService - Handles all property listing business logic
+ * PropertyService - Gestiona toda la lógica de negocio de listados inmobiliarios
+ */
+export class PropertyService {
+  /**
+   * List properties with optional filters and pagination
+   * Listar propiedades con filtros opcionales y paginación
+   *
+   * @param filters - Optional filters and pagination params / Filtros opcionales y parámetros de paginación
+   * @returns Paginated list of properties / Lista paginada de propiedades
+   */
+  async findAll(filters: PropertyFilters = {}): Promise<{ rows: Property[]; count: number }> {
+    const {
+      type,
+      city,
+      minPrice,
+      maxPrice,
+      bedrooms,
+      status,
+      page = 1,
+      limit: rawLimit = 20,
+    } = filters;
+
+    // Enforce maximum limit
+    const limit = Math.min(rawLimit, 100);
+    const offset = (page - 1) * limit;
+
+    // Build where clause
+    const where: WhereOptions<PropertyAttributes> = {};
+
+    if (type) {
+      where.type = type;
+    }
+
+    if (city) {
+      where.city = city;
+    }
+
+    if (bedrooms !== undefined) {
+      where.bedrooms = bedrooms;
+    }
+
+    if (status) {
+      where.status = status;
+    }
+
+    // Price range filter
+    if (minPrice !== undefined || maxPrice !== undefined) {
+      where.price = {};
+      if (minPrice !== undefined) {
+        (where.price as Record<symbol, number>)[Op.gte] = minPrice;
+      }
+      if (maxPrice !== undefined) {
+        (where.price as Record<symbol, number>)[Op.lte] = maxPrice;
+      }
+    }
+
+    const result = await Property.findAndCountAll({
+      where,
+      limit,
+      offset,
+      order: [['created_at', 'DESC']],
+    });
+
+    return result;
+  }
+
+  /**
+   * Find a single property by primary key
+   * Buscar una propiedad por clave primaria
+   *
+   * @param id - Property UUID / UUID de la propiedad
+   * @returns Property instance / Instancia de propiedad
+   * @throws { statusCode: 404, code: 'PROPERTY_NOT_FOUND', message: string } when not found
+   */
+  async findById(id: string): Promise<Property> {
+    const property = await Property.findByPk(id);
+
+    if (!property) {
+      throw {
+        statusCode: 404,
+        code: 'PROPERTY_NOT_FOUND',
+        message: 'Property not found',
+      };
+    }
+
+    return property;
+  }
+
+  /**
+   * Create a new property listing
+   * Crear un nuevo listado de propiedad
+   *
+   * @param data - Property creation data / Datos de creación de propiedad
+   * @returns Created property / Propiedad creada
+   */
+  async create(data: PropertyCreateInput): Promise<Property> {
+    const property = await Property.create(data as PropertyAttributes);
+    return property;
+  }
+
+  /**
+   * Update an existing property by ID
+   * Actualizar una propiedad existente por ID
+   *
+   * @param id - Property UUID / UUID de la propiedad
+   * @param data - Partial update data / Datos parciales de actualización
+   * @returns Updated property / Propiedad actualizada
+   * @throws { statusCode: 404, code: 'PROPERTY_NOT_FOUND', message: string } when not found
+   */
+  async update(id: string, data: Partial<PropertyCreateInput>): Promise<Property> {
+    const property = await this.findById(id);
+    await property.update(data);
+    return property;
+  }
+
+  /**
+   * Soft-delete a property by ID (paranoid)
+   * Eliminar suavemente una propiedad por ID (paranoid)
+   *
+   * @param id - Property UUID / UUID de la propiedad
+   * @throws { statusCode: 404, code: 'PROPERTY_NOT_FOUND', message: string } when not found
+   */
+  async remove(id: string): Promise<void> {
+    const property = await this.findById(id);
+    await property.destroy();
+  }
+}
+
+/**
+ * Singleton instance of PropertyService
+ * Instancia singleton de PropertyService
+ */
+export const propertyService = new PropertyService();


### PR DESCRIPTION
## Summary

Implements the full **Property Listings** module for Sprint 5 (issue #59).

## Changes

### New Files
- `backend/src/models/Property.ts` — Sequelize model with ENUM, JSONB, paranoid soft-delete
- `backend/src/database/migrations/20260406130000-create-properties.js` — DB migration
- `backend/src/services/PropertyService.ts` — Business logic: findAll (filtros: type, city, price, status), findById, create, update, remove
- `backend/src/controllers/PropertyController.ts` — HTTP handlers con manejo de errores
- `backend/src/routes/property.routes.ts` — Rutas públicas (`/properties`)
- `backend/src/routes/admin-property.routes.ts` — Rutas admin (`/admin/properties`)
- `backend/src/__tests__/PropertyService.test.ts` — 16 tests unitarios ✅

### Modified Files
- `backend/src/models/index.ts` — Property registrado + asociaciones `Vendor.hasMany(Property)` / `Property.belongsTo(Vendor)`
- `backend/src/routes/index.ts` — Rutas `/properties` y `/admin/properties` registradas

## Test Results

```
Tests: 16 passed, 16 total
Test Suites: 1 passed, 1 total
```

## Closes

Closes #59