### PR TITLE
feat(tourism): Tourism Packages module — TourPackage, TourAvailability, CRUD, tests (#60)

### DIFF
--- a/backend/src/__tests__/TourPackageService.test.ts
+++ b/backend/src/__tests__/TourPackageService.test.ts
@@ -1,0 +1,493 @@
+/**
+ * @fileoverview Unit tests for TourPackageService
+ * @description Tests for TourPackageService CRUD operations including:
+ *              - Pagination, type filter, destination filter, country filter, status filter, price range, durationDays filter
+ *              - Find by ID success and not found scenarios
+ *              - Create, update, soft-delete operations
+ *              Tests para operaciones CRUD de TourPackageService incluyendo:
+ *              - Paginación, filtro por tipo, destino, país, estado, precio, duración
+ *              - findById con éxito y no encontrado (404)
+ *              - Crear, actualizar, borrado suave
+ * @module __tests__/TourPackageService
+ */
+
+// Mock sequelize before importing models
+jest.mock('../config/database', () => {
+  const mockTransaction = {
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    sequelize: {
+      transaction: jest.fn().mockResolvedValue(mockTransaction),
+      query: jest.fn(),
+      sync: jest.fn().mockResolvedValue({}),
+      authenticate: jest.fn().mockResolvedValue(undefined),
+    },
+    resetSequelize: jest.fn(),
+  };
+});
+
+// Mock all models
+jest.mock('../models', () => ({
+  TourPackage: {
+    findAndCountAll: jest.fn(),
+    findByPk: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  TourAvailability: {
+    findAndCountAll: jest.fn(),
+    findByPk: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  Vendor: {
+    findByPk: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+  User: {
+    findByPk: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    init: jest.fn(),
+    hasMany: jest.fn(),
+    belongsTo: jest.fn(),
+  },
+}));
+
+import { TourPackageService } from '../services/TourPackageService';
+import { TourPackage } from '../models';
+
+describe('TourPackageService', () => {
+  let tourPackageService: TourPackageService;
+
+  // Mock tour packages for testing
+  const mockTourPackages = [
+    {
+      id: 'tour-1',
+      type: 'adventure',
+      title: 'Trekking en el Cocuy',
+      titleEn: 'Trekking in Cocuy',
+      description: 'Expedición de 5 días por la Sierra Nevada del Cocuy',
+      descriptionEn: '5-day expedition through Sierra Nevada del Cocuy',
+      destination: 'Sierra Nevada del Cocuy, Colombia',
+      country: 'Colombia',
+      durationDays: 5,
+      price: 850,
+      currency: 'USD',
+      priceIncludes: ['accommodation', 'meals', 'guide'],
+      priceExcludes: ['flights', 'personal gear'],
+      images: ['https://example.com/cocuy.jpg'],
+      maxCapacity: 12,
+      minGroupSize: 2,
+      status: 'active',
+      vendorId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    },
+    {
+      id: 'tour-2',
+      type: 'cultural',
+      title: 'Tour Histórico Cartagena',
+      titleEn: 'Cartagena Historical Tour',
+      description: 'Descubre la historia colonial de Cartagena',
+      descriptionEn: 'Discover the colonial history of Cartagena',
+      destination: 'Cartagena, Colombia',
+      country: 'Colombia',
+      durationDays: 3,
+      price: 450,
+      currency: 'USD',
+      priceIncludes: ['hotel', 'guide'],
+      priceExcludes: ['flights'],
+      images: [],
+      maxCapacity: 20,
+      minGroupSize: 1,
+      status: 'active',
+      vendorId: 'vendor-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    },
+    {
+      id: 'tour-3',
+      type: 'luxury',
+      title: 'Retiro de Lujo Eje Cafetero',
+      titleEn: null,
+      description: 'Experiencia de lujo en el corazón del Eje Cafetero',
+      descriptionEn: null,
+      destination: 'Eje Cafetero, Colombia',
+      country: 'Colombia',
+      durationDays: 7,
+      price: 2500,
+      currency: 'USD',
+      priceIncludes: ['luxury hotel', 'all meals', 'transfers'],
+      priceExcludes: [],
+      images: [],
+      maxCapacity: 6,
+      minGroupSize: 2,
+      status: 'draft',
+      vendorId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      deletedAt: null,
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tourPackageService = new TourPackageService();
+  });
+
+  // ============================================================
+  // findAll
+  // ============================================================
+  describe('findAll', () => {
+    /**
+     * Test 1: Default pagination
+     * Verifies that default page=1 and limit=20 are applied
+     * Verifica que se aplican page=1 y limit=20 por defecto
+     */
+    it('should return paginated tour packages with default params', async () => {
+      const mockResult = {
+        rows: [mockTourPackages[0], mockTourPackages[1]],
+        count: 2,
+      };
+      (TourPackage.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await tourPackageService.findAll();
+
+      expect(result.count).toBe(2);
+      expect(result.rows).toHaveLength(2);
+      expect(TourPackage.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 20,
+          offset: 0,
+        })
+      );
+    });
+
+    /**
+     * Test 2: Filter by type
+     * Verifies that type filter is correctly passed to query
+     * Verifica que el filtro de tipo se pasa correctamente a la consulta
+     */
+    it('should filter tour packages by type', async () => {
+      const mockResult = { rows: [mockTourPackages[0]], count: 1 };
+      (TourPackage.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await tourPackageService.findAll({ type: 'adventure' });
+
+      expect(TourPackage.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            type: 'adventure',
+          }),
+        })
+      );
+    });
+
+    /**
+     * Test 3: Filter by destination
+     * Verifies that destination filter is correctly passed to query
+     * Verifica que el filtro de destino se pasa correctamente a la consulta
+     */
+    it('should filter tour packages by destination', async () => {
+      const mockResult = { rows: [mockTourPackages[1]], count: 1 };
+      (TourPackage.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await tourPackageService.findAll({ destination: 'Cartagena, Colombia' });
+
+      expect(TourPackage.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            destination: 'Cartagena, Colombia',
+          }),
+        })
+      );
+    });
+
+    /**
+     * Test 4: Filter by country
+     * Verifies that country filter is correctly passed to query
+     * Verifica que el filtro de país se pasa correctamente a la consulta
+     */
+    it('should filter tour packages by country', async () => {
+      const mockResult = { rows: mockTourPackages, count: 3 };
+      (TourPackage.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await tourPackageService.findAll({ country: 'Colombia' });
+
+      expect(TourPackage.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            country: 'Colombia',
+          }),
+        })
+      );
+    });
+
+    /**
+     * Test 5: Filter by status
+     * Verifies that status filter is correctly passed to query
+     * Verifica que el filtro de estado se pasa correctamente a la consulta
+     */
+    it('should filter tour packages by status', async () => {
+      const mockResult = { rows: [mockTourPackages[2]], count: 1 };
+      (TourPackage.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await tourPackageService.findAll({ status: 'draft' });
+
+      expect(TourPackage.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: 'draft',
+          }),
+        })
+      );
+    });
+
+    /**
+     * Test 6: Filter by price range
+     * Verifies that minPrice and maxPrice are applied as Op.gte / Op.lte
+     * Verifica que minPrice y maxPrice se aplican como Op.gte / Op.lte
+     */
+    it('should filter tour packages by price range', async () => {
+      const mockResult = { rows: [mockTourPackages[0], mockTourPackages[1]], count: 2 };
+      (TourPackage.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await tourPackageService.findAll({ minPrice: 400, maxPrice: 1000 });
+
+      expect(TourPackage.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            price: expect.any(Object),
+          }),
+        })
+      );
+    });
+
+    /**
+     * Test 7: Enforce maximum limit of 100
+     * Verifies that limit is capped at 100
+     * Verifica que el límite máximo es 100
+     */
+    it('should enforce maximum limit of 100', async () => {
+      const mockResult = { rows: [], count: 0 };
+      (TourPackage.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await tourPackageService.findAll({ page: 1, limit: 999 });
+
+      expect(TourPackage.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 100,
+        })
+      );
+    });
+
+    /**
+     * Test 8: Correct offset for page 2
+     * Verifies that offset is calculated correctly for page 2
+     * Verifica que el offset se calcula correctamente para la página 2
+     */
+    it('should calculate correct offset for page 2', async () => {
+      const mockResult = { rows: [], count: 0 };
+      (TourPackage.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await tourPackageService.findAll({ page: 2, limit: 10 });
+
+      expect(TourPackage.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 10,
+          offset: 10,
+        })
+      );
+    });
+
+    /**
+     * Test 9: Order by created_at DESC
+     * Verifies results are ordered by created_at descending
+     * Verifica que los resultados se ordenan por created_at descendente
+     */
+    it('should order results by created_at descending', async () => {
+      const mockResult = { rows: [], count: 0 };
+      (TourPackage.findAndCountAll as jest.Mock).mockResolvedValue(mockResult);
+
+      await tourPackageService.findAll();
+
+      expect(TourPackage.findAndCountAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          order: [['created_at', 'DESC']],
+        })
+      );
+    });
+  });
+
+  // ============================================================
+  // findById
+  // ============================================================
+  describe('findById', () => {
+    /**
+     * Test 10: findById success
+     * Verifies that a found tour package is returned
+     * Verifica que se retorna el paquete turístico encontrado
+     */
+    it('should return tour package when found', async () => {
+      const mockTour = mockTourPackages[0];
+      (TourPackage.findByPk as jest.Mock).mockResolvedValue(mockTour);
+
+      const result = await tourPackageService.findById('tour-1');
+
+      expect(result).toEqual(mockTour);
+      expect(TourPackage.findByPk).toHaveBeenCalledWith(
+        'tour-1',
+        expect.objectContaining({ include: expect.any(Array) })
+      );
+    });
+
+    /**
+     * Test 11: findById not found → throws 404
+     * Verifies proper error object when tour package doesn't exist
+     * Verifica el objeto de error correcto cuando el paquete no existe
+     */
+    it('should throw 404 error when tour package not found', async () => {
+      (TourPackage.findByPk as jest.Mock).mockResolvedValue(null);
+
+      await expect(tourPackageService.findById('nonexistent-id')).rejects.toMatchObject({
+        statusCode: 404,
+        code: 'TOUR_PACKAGE_NOT_FOUND',
+      });
+    });
+
+    /**
+     * Test 12: findById not found → correct message
+     * Verifies the exact error message when tour package is not found
+     * Verifica el mensaje de error exacto cuando el paquete no se encuentra
+     */
+    it('should throw error with correct message when not found', async () => {
+      (TourPackage.findByPk as jest.Mock).mockResolvedValue(null);
+
+      try {
+        await tourPackageService.findById('nonexistent-id');
+        fail('Expected error to be thrown');
+      } catch (error: any) {
+        expect(error.statusCode).toBe(404);
+        expect(error.code).toBe('TOUR_PACKAGE_NOT_FOUND');
+        expect(error.message).toBe('Tour package not found');
+      }
+    });
+  });
+
+  // ============================================================
+  // create
+  // ============================================================
+  describe('create', () => {
+    /**
+     * Test 13: create success
+     * Verifies that a tour package is created correctly
+     * Verifica que el paquete turístico se crea correctamente
+     */
+    it('should create a tour package correctly', async () => {
+      const inputData = {
+        type: 'adventure' as const,
+        title: 'Nuevo Tour de Aventura',
+        destination: 'Parque Tayrona, Colombia',
+        durationDays: 4,
+        price: 600,
+      };
+
+      const createdTour = { ...mockTourPackages[0], ...inputData, id: 'new-tour-id' };
+      (TourPackage.create as jest.Mock).mockResolvedValue(createdTour);
+
+      const result = await tourPackageService.create(inputData);
+
+      expect(result).toEqual(createdTour);
+      expect(TourPackage.create).toHaveBeenCalledWith(expect.objectContaining(inputData));
+    });
+  });
+
+  // ============================================================
+  // update
+  // ============================================================
+  describe('update', () => {
+    /**
+     * Test 14: update success
+     * Verifies that a tour package is updated correctly
+     * Verifica que el paquete turístico se actualiza correctamente
+     */
+    it('should update a tour package correctly', async () => {
+      const updateMock = jest.fn().mockResolvedValue(undefined);
+      const mockTour = { ...mockTourPackages[0], update: updateMock };
+      (TourPackage.findByPk as jest.Mock).mockResolvedValue(mockTour);
+
+      const updateData = { title: 'Trekking Renovado', price: 950 };
+      await tourPackageService.update('tour-1', updateData);
+
+      expect(updateMock).toHaveBeenCalledWith(updateData);
+    });
+
+    /**
+     * Test 15: update not found → throws 404
+     * Verifies that 404 is thrown when updating a non-existent tour package
+     * Verifica que se lanza 404 al actualizar un paquete inexistente
+     */
+    it('should throw 404 when updating non-existent tour package', async () => {
+      (TourPackage.findByPk as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        tourPackageService.update('nonexistent-id', { title: 'Test' })
+      ).rejects.toMatchObject({
+        statusCode: 404,
+        code: 'TOUR_PACKAGE_NOT_FOUND',
+      });
+    });
+  });
+
+  // ============================================================
+  // remove (soft-delete)
+  // ============================================================
+  describe('remove', () => {
+    /**
+     * Test 16: remove (soft-delete) success
+     * Verifies that destroy() is called on the found tour package
+     * Verifica que se llama destroy() en el paquete encontrado
+     */
+    it('should soft-delete a tour package correctly', async () => {
+      const destroyMock = jest.fn().mockResolvedValue(undefined);
+      const mockTour = { ...mockTourPackages[0], destroy: destroyMock };
+      (TourPackage.findByPk as jest.Mock).mockResolvedValue(mockTour);
+
+      await tourPackageService.remove('tour-1');
+
+      expect(destroyMock).toHaveBeenCalled();
+    });
+
+    /**
+     * Test 17: remove not found → throws 404
+     * Verifies that 404 is thrown when removing a non-existent tour package
+     * Verifica que se lanza 404 al eliminar un paquete inexistente
+     */
+    it('should throw 404 when removing non-existent tour package', async () => {
+      (TourPackage.findByPk as jest.Mock).mockResolvedValue(null);
+
+      await expect(tourPackageService.remove('nonexistent-id')).rejects.toMatchObject({
+        statusCode: 404,
+        code: 'TOUR_PACKAGE_NOT_FOUND',
+      });
+    });
+  });
+});

--- a/backend/src/controllers/TourPackageController.ts
+++ b/backend/src/controllers/TourPackageController.ts
@@ -1,0 +1,359 @@
+/**
+ * @fileoverview TourPackageController - Tourism package endpoints
+ * @description Controller for public tour browsing and admin CRUD operations.
+ *              Public routes: list, detail.
+ *              Admin routes: create, update, soft-delete.
+ *              Controlador para navegación pública de tours y operaciones CRUD de admin.
+ *              Rutas públicas: listado, detalle.
+ *              Rutas admin: crear, actualizar, borrado suave.
+ * @module controllers/TourPackageController
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: List active adventure tours
+ * GET /api/tours?type=adventure&status=active
+ *
+ * // Español: Listar tours de aventura activos
+ * GET /api/tours?type=adventure&status=active
+ */
+import { Request, Response } from 'express';
+import { body, param, query, validationResult } from 'express-validator';
+import { authenticate, requireAdmin } from '../middleware/auth.middleware';
+import { tourPackageService } from '../services/TourPackageService';
+
+// ============================================
+// VALIDATION RULES
+// ============================================
+
+/**
+ * Validation rule sets for tour package endpoints
+ * Conjuntos de reglas de validación para endpoints de paquetes turísticos
+ */
+export const validationRules = {
+  /**
+   * Rules for listing tour packages (public + admin filter)
+   * Reglas para listar paquetes turísticos (filtro público + admin)
+   */
+  list: [
+    query('type')
+      .optional()
+      .isIn(['adventure', 'cultural', 'relaxation', 'gastronomic', 'ecotourism', 'luxury']),
+    query('destination').optional().isString().trim().isLength({ max: 100 }),
+    query('country').optional().isString().trim().isLength({ max: 100 }),
+    query('status').optional().isIn(['active', 'inactive', 'draft']),
+    query('minPrice').optional().isFloat({ min: 0 }),
+    query('maxPrice').optional().isFloat({ min: 0 }),
+    query('durationDays').optional().isInt({ min: 1 }),
+    query('page').optional().isInt({ min: 1 }),
+    query('limit').optional().isInt({ min: 1, max: 100 }),
+  ],
+
+  /**
+   * Rules for creating a tour package
+   * Reglas para crear un paquete turístico
+   */
+  create: [
+    body('type').isIn([
+      'adventure',
+      'cultural',
+      'relaxation',
+      'gastronomic',
+      'ecotourism',
+      'luxury',
+    ]),
+    body('title').notEmpty().trim().isLength({ min: 1, max: 200 }),
+    body('titleEn').optional({ nullable: true }).isString().trim().isLength({ max: 200 }),
+    body('description').optional({ nullable: true }).isString().trim(),
+    body('descriptionEn').optional({ nullable: true }).isString().trim(),
+    body('destination').notEmpty().trim().isLength({ min: 1, max: 100 }),
+    body('country').optional().isString().trim().isLength({ max: 100 }),
+    body('durationDays').isInt({ min: 1 }),
+    body('price').isFloat({ min: 0 }),
+    body('currency').optional().isString().trim().isLength({ min: 3, max: 3 }),
+    body('priceIncludes').optional().isArray(),
+    body('priceExcludes').optional().isArray(),
+    body('images').optional().isArray(),
+    body('maxCapacity').optional().isInt({ min: 1 }),
+    body('minGroupSize').optional().isInt({ min: 1 }),
+    body('status').optional().isIn(['active', 'inactive', 'draft']),
+    body('vendorId').optional({ nullable: true }).isUUID(),
+  ],
+
+  /**
+   * Rules for updating a tour package (all fields optional)
+   * Reglas para actualizar un paquete turístico (todos los campos opcionales)
+   */
+  update: [
+    param('id').isUUID(),
+    body('type')
+      .optional()
+      .isIn(['adventure', 'cultural', 'relaxation', 'gastronomic', 'ecotourism', 'luxury']),
+    body('title').optional().trim().isLength({ min: 1, max: 200 }),
+    body('titleEn').optional({ nullable: true }).isString().trim().isLength({ max: 200 }),
+    body('description').optional({ nullable: true }).isString().trim(),
+    body('descriptionEn').optional({ nullable: true }).isString().trim(),
+    body('destination').optional().trim().isLength({ min: 1, max: 100 }),
+    body('country').optional().isString().trim().isLength({ max: 100 }),
+    body('durationDays').optional().isInt({ min: 1 }),
+    body('price').optional().isFloat({ min: 0 }),
+    body('currency').optional().isString().trim().isLength({ min: 3, max: 3 }),
+    body('priceIncludes').optional().isArray(),
+    body('priceExcludes').optional().isArray(),
+    body('images').optional().isArray(),
+    body('maxCapacity').optional().isInt({ min: 1 }),
+    body('minGroupSize').optional().isInt({ min: 1 }),
+    body('status').optional().isIn(['active', 'inactive', 'draft']),
+    body('vendorId').optional({ nullable: true }).isUUID(),
+  ],
+};
+
+// ============================================
+// HANDLERS
+// ============================================
+
+/**
+ * GET /api/tours — Public tour listing with filters
+ * GET /api/tours — Listado público de tours con filtros
+ *
+ * @route GET /api/tours
+ * @access Public
+ */
+export const getTourPackages = [
+  validationRules.list,
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const { type, destination, country, status, minPrice, maxPrice, durationDays, page, limit } =
+        req.query as Record<string, string | undefined>;
+
+      const { rows, count } = await tourPackageService.findAll({
+        type: type as
+          | 'adventure'
+          | 'cultural'
+          | 'relaxation'
+          | 'gastronomic'
+          | 'ecotourism'
+          | 'luxury'
+          | undefined,
+        destination,
+        country,
+        status: status as 'active' | 'inactive' | 'draft' | undefined,
+        minPrice: minPrice ? parseFloat(minPrice) : undefined,
+        maxPrice: maxPrice ? parseFloat(maxPrice) : undefined,
+        durationDays: durationDays ? parseInt(durationDays, 10) : undefined,
+        page: page ? parseInt(page, 10) : undefined,
+        limit: limit ? parseInt(limit, 10) : undefined,
+      });
+
+      const parsedPage = page ? parseInt(page, 10) : 1;
+      const parsedLimit = limit ? Math.min(parseInt(limit, 10), 100) : 20;
+
+      res.json({
+        success: true,
+        data: rows,
+        pagination: {
+          total: count,
+          page: parsedPage,
+          limit: parsedLimit,
+          totalPages: Math.ceil(count / parsedLimit),
+        },
+      });
+    } catch (error: any) {
+      console.error('Get tour packages error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to get tour packages',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * GET /api/tours/:id — Public tour package detail
+ * GET /api/tours/:id — Detalle público de paquete turístico
+ *
+ * @route GET /api/tours/:id
+ * @access Public
+ */
+export const getTourPackage = [
+  param('id').isUUID(),
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const tourPackage = await tourPackageService.findById(req.params.id);
+
+      res.json({
+        success: true,
+        data: tourPackage,
+      });
+    } catch (error: any) {
+      console.error('Get tour package error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to get tour package',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * POST /api/admin/tours — Admin: create a tour package
+ * POST /api/admin/tours — Admin: crear un paquete turístico
+ *
+ * @route POST /api/admin/tours
+ * @access Admin
+ */
+export const createTourPackage = [
+  authenticate,
+  requireAdmin,
+  validationRules.create,
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const tourPackage = await tourPackageService.create(req.body);
+
+      res.status(201).json({
+        success: true,
+        data: tourPackage,
+      });
+    } catch (error: any) {
+      console.error('Create tour package error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to create tour package',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * PUT /api/admin/tours/:id — Admin: update a tour package
+ * PUT /api/admin/tours/:id — Admin: actualizar un paquete turístico
+ *
+ * @route PUT /api/admin/tours/:id
+ * @access Admin
+ */
+export const updateTourPackage = [
+  authenticate,
+  requireAdmin,
+  validationRules.update,
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      const tourPackage = await tourPackageService.update(req.params.id, req.body);
+
+      res.json({
+        success: true,
+        data: tourPackage,
+      });
+    } catch (error: any) {
+      console.error('Update tour package error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to update tour package',
+        },
+      });
+    }
+  },
+];
+
+/**
+ * DELETE /api/admin/tours/:id — Admin: soft-delete a tour package
+ * DELETE /api/admin/tours/:id — Admin: eliminar suavemente un paquete turístico
+ *
+ * @route DELETE /api/admin/tours/:id
+ * @access Admin
+ */
+export const deleteTourPackage = [
+  authenticate,
+  requireAdmin,
+  param('id').isUUID(),
+  async (req: Request, res: Response): Promise<void> => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      res.status(400).json({
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: errors.array(),
+        },
+      });
+      return;
+    }
+
+    try {
+      await tourPackageService.remove(req.params.id);
+
+      res.status(204).send();
+    } catch (error: any) {
+      console.error('Delete tour package error:', error);
+      res.status(error.statusCode || 500).json({
+        success: false,
+        error: {
+          code: error.code || 'SERVER_ERROR',
+          message: error.message || 'Failed to delete tour package',
+        },
+      });
+    }
+  },
+];

--- a/backend/src/database/migrations/20260406140000-create-tour-packages.js
+++ b/backend/src/database/migrations/20260406140000-create-tour-packages.js
@@ -1,0 +1,143 @@
+'use strict';
+
+/**
+ * Migration: create-tour-packages
+ * Creates the tour_packages table for Nexo Real Tourism module (Issue #60)
+ * Crea la tabla tour_packages para el módulo de Turismo de Nexo Real (Issue #60)
+ */
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('tour_packages', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+        allowNull: false,
+      },
+      type: {
+        type: Sequelize.ENUM(
+          'adventure',
+          'cultural',
+          'relaxation',
+          'gastronomic',
+          'ecotourism',
+          'luxury'
+        ),
+        allowNull: false,
+      },
+      title: {
+        type: Sequelize.STRING(200),
+        allowNull: false,
+      },
+      title_en: {
+        type: Sequelize.STRING(200),
+        allowNull: true,
+      },
+      description: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      description_en: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      destination: {
+        type: Sequelize.STRING(100),
+        allowNull: false,
+      },
+      country: {
+        type: Sequelize.STRING(100),
+        defaultValue: 'Colombia',
+        allowNull: false,
+      },
+      duration_days: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      price: {
+        type: Sequelize.DECIMAL(12, 2),
+        allowNull: false,
+      },
+      currency: {
+        type: Sequelize.STRING(3),
+        defaultValue: 'USD',
+        allowNull: false,
+      },
+      price_includes: {
+        type: Sequelize.JSONB,
+        defaultValue: [],
+        allowNull: false,
+      },
+      price_excludes: {
+        type: Sequelize.JSONB,
+        defaultValue: [],
+        allowNull: false,
+      },
+      images: {
+        type: Sequelize.JSONB,
+        defaultValue: [],
+        allowNull: false,
+      },
+      max_capacity: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 10,
+      },
+      min_group_size: {
+        type: Sequelize.INTEGER,
+        defaultValue: 1,
+        allowNull: false,
+      },
+      status: {
+        type: Sequelize.ENUM('active', 'inactive', 'draft'),
+        defaultValue: 'active',
+        allowNull: false,
+      },
+      vendor_id: {
+        type: Sequelize.UUID,
+        allowNull: true,
+        references: {
+          model: 'vendors',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      deleted_at: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+    });
+
+    // Indexes / Índices
+    await queryInterface.addIndex('tour_packages', ['type'], { name: 'tour_packages_type_idx' });
+    await queryInterface.addIndex('tour_packages', ['destination'], {
+      name: 'tour_packages_destination_idx',
+    });
+    await queryInterface.addIndex('tour_packages', ['country'], {
+      name: 'tour_packages_country_idx',
+    });
+    await queryInterface.addIndex('tour_packages', ['status'], {
+      name: 'tour_packages_status_idx',
+    });
+    await queryInterface.addIndex('tour_packages', ['vendor_id'], {
+      name: 'tour_packages_vendor_id_idx',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('tour_packages');
+  },
+};

--- a/backend/src/database/migrations/20260406150000-create-tour-availabilities.js
+++ b/backend/src/database/migrations/20260406150000-create-tour-availabilities.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * Migration: create-tour-availabilities
+ * Creates the tour_availabilities table for Nexo Real Tourism module (Issue #60)
+ * Crea la tabla tour_availabilities para el módulo de Turismo de Nexo Real (Issue #60)
+ */
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('tour_availabilities', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUIDV4,
+        primaryKey: true,
+        allowNull: false,
+      },
+      tour_package_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'tour_packages',
+          key: 'id',
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      date: {
+        type: Sequelize.DATEONLY,
+        allowNull: false,
+      },
+      available_spots: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      booked_spots: {
+        type: Sequelize.INTEGER,
+        defaultValue: 0,
+        allowNull: false,
+      },
+      is_blocked: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      },
+      notes: {
+        type: Sequelize.STRING(500),
+        allowNull: true,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+    });
+
+    // Index on tour_package_id / Índice en tour_package_id
+    await queryInterface.addIndex('tour_availabilities', ['tour_package_id'], {
+      name: 'tour_availabilities_package_id_idx',
+    });
+
+    // Composite unique index on (tour_package_id, date) / Índice único compuesto en (tour_package_id, date)
+    await queryInterface.addIndex('tour_availabilities', ['tour_package_id', 'date'], {
+      unique: true,
+      name: 'tour_availabilities_package_date_unique',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('tour_availabilities');
+  },
+};

--- a/backend/src/models/TourAvailability.ts
+++ b/backend/src/models/TourAvailability.ts
@@ -1,0 +1,141 @@
+/**
+ * @fileoverview TourAvailability Model - Availability calendar for tourism packages
+ * @description Sequelize model representing available dates and spots for a tour package.
+ *              Modelo Sequelize que representa fechas y cupos disponibles para un paquete turístico.
+ * @module models/TourAvailability
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Get available spots for a tour on a specific date
+ * const availability = await TourAvailability.findOne({ where: { tourPackageId: 'uuid', date: '2026-07-15' } });
+ *
+ * // Español: Obtener cupos disponibles para un tour en una fecha específica
+ * const availability = await TourAvailability.findOne({ where: { tourPackageId: 'uuid', date: '2026-07-15' } });
+ */
+import { DataTypes, Model, Optional } from 'sequelize';
+import { sequelize } from '../config/database';
+
+// ============================================
+// INTERFACES — TourAvailability Attributes
+// ============================================
+
+/**
+ * TourAvailability attribute types — all columns on the table
+ * Tipos de atributos de disponibilidad turística — todas las columnas de la tabla
+ */
+export interface TourAvailabilityAttributes {
+  id: string;
+  tourPackageId: string;
+  date: string;
+  availableSpots: number;
+  bookedSpots: number;
+  isBlocked: boolean;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Creation attributes — fields that can be omitted on create
+ * Atributos de creación — campos que pueden omitirse al crear
+ */
+export interface TourAvailabilityCreationAttributes extends Optional<
+  TourAvailabilityAttributes,
+  'id' | 'bookedSpots' | 'isBlocked' | 'notes' | 'createdAt' | 'updatedAt'
+> {}
+
+type TourAvailabilityCreation = Optional<
+  TourAvailabilityAttributes,
+  'id' | 'bookedSpots' | 'isBlocked' | 'notes' | 'createdAt' | 'updatedAt'
+>;
+
+/**
+ * TourAvailability Model - Represents availability calendar for a tour package
+ * Modelo TourAvailability - Representa el calendario de disponibilidad de un paquete turístico
+ */
+export class TourAvailability
+  extends Model<TourAvailabilityAttributes, TourAvailabilityCreation>
+  implements TourAvailabilityAttributes
+{
+  declare id: string;
+  declare tourPackageId: string;
+  declare date: string;
+  declare availableSpots: number;
+  declare bookedSpots: number;
+  declare isBlocked: boolean;
+  declare notes: string | null;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
+}
+
+TourAvailability.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    tourPackageId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      field: 'tour_package_id',
+      references: {
+        model: 'tour_packages',
+        key: 'id',
+      },
+    },
+    date: {
+      type: DataTypes.DATEONLY,
+      allowNull: false,
+    },
+    availableSpots: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: 'available_spots',
+      validate: {
+        min: 0,
+      },
+    },
+    bookedSpots: {
+      type: DataTypes.INTEGER,
+      defaultValue: 0,
+      field: 'booked_spots',
+      validate: {
+        min: 0,
+      },
+    },
+    isBlocked: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      field: 'is_blocked',
+    },
+    notes: {
+      type: DataTypes.STRING(500),
+      allowNull: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'created_at',
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'updated_at',
+    },
+  },
+  {
+    sequelize,
+    tableName: 'tour_availabilities',
+    underscored: true,
+    timestamps: true,
+    indexes: [
+      { fields: ['tour_package_id'] },
+      {
+        unique: true,
+        fields: ['tour_package_id', 'date'],
+        name: 'tour_availabilities_package_date_unique',
+      },
+    ],
+  }
+);

--- a/backend/src/models/TourPackage.ts
+++ b/backend/src/models/TourPackage.ts
@@ -1,0 +1,259 @@
+/**
+ * @fileoverview TourPackage Model - Tourism package entity for Nexo Real
+ * @description Sequelize model representing tourism packages (adventure, cultural, etc.) in the marketplace.
+ *              Modelo Sequelize que representa paquetes turísticos en el marketplace de Nexo Real.
+ * @module models/TourPackage
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Get active adventure tours in Colombia
+ * const tours = await TourPackage.findAll({ where: { type: 'adventure', status: 'active', country: 'Colombia' } });
+ *
+ * // Español: Obtener tours de aventura activos en Colombia
+ * const tours = await TourPackage.findAll({ where: { type: 'adventure', status: 'active', country: 'Colombia' } });
+ */
+import { DataTypes, Model, Optional } from 'sequelize';
+import { sequelize } from '../config/database';
+
+// ============================================
+// INTERFACES — TourPackage Attributes
+// ============================================
+
+/**
+ * TourPackage attribute types — all columns on the table
+ * Tipos de atributos de paquete turístico — todas las columnas de la tabla
+ */
+export interface TourPackageAttributes {
+  id: string;
+  type: 'adventure' | 'cultural' | 'relaxation' | 'gastronomic' | 'ecotourism' | 'luxury';
+  title: string;
+  titleEn: string | null;
+  description: string | null;
+  descriptionEn: string | null;
+  destination: string;
+  country: string;
+  durationDays: number;
+  price: number;
+  currency: string;
+  priceIncludes: unknown[];
+  priceExcludes: unknown[];
+  images: unknown[];
+  maxCapacity: number;
+  minGroupSize: number;
+  status: 'active' | 'inactive' | 'draft';
+  vendorId: string | null;
+  deletedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Creation attributes — fields that can be omitted on create
+ * Atributos de creación — campos que pueden omitirse al crear
+ */
+export interface TourPackageCreationAttributes extends Optional<
+  TourPackageAttributes,
+  | 'id'
+  | 'titleEn'
+  | 'description'
+  | 'descriptionEn'
+  | 'country'
+  | 'currency'
+  | 'priceIncludes'
+  | 'priceExcludes'
+  | 'images'
+  | 'maxCapacity'
+  | 'minGroupSize'
+  | 'status'
+  | 'vendorId'
+  | 'deletedAt'
+  | 'createdAt'
+  | 'updatedAt'
+> {}
+
+type TourPackageCreation = Optional<
+  TourPackageAttributes,
+  | 'id'
+  | 'titleEn'
+  | 'description'
+  | 'descriptionEn'
+  | 'country'
+  | 'currency'
+  | 'priceIncludes'
+  | 'priceExcludes'
+  | 'images'
+  | 'maxCapacity'
+  | 'minGroupSize'
+  | 'status'
+  | 'vendorId'
+  | 'deletedAt'
+  | 'createdAt'
+  | 'updatedAt'
+>;
+
+/**
+ * TourPackage Model - Represents a tourism package in Nexo Real
+ * Modelo TourPackage - Representa un paquete turístico en Nexo Real
+ */
+export class TourPackage
+  extends Model<TourPackageAttributes, TourPackageCreation>
+  implements TourPackageAttributes
+{
+  declare id: string;
+  declare type: 'adventure' | 'cultural' | 'relaxation' | 'gastronomic' | 'ecotourism' | 'luxury';
+  declare title: string;
+  declare titleEn: string | null;
+  declare description: string | null;
+  declare descriptionEn: string | null;
+  declare destination: string;
+  declare country: string;
+  declare durationDays: number;
+  declare price: number;
+  declare currency: string;
+  declare priceIncludes: unknown[];
+  declare priceExcludes: unknown[];
+  declare images: unknown[];
+  declare maxCapacity: number;
+  declare minGroupSize: number;
+  declare status: 'active' | 'inactive' | 'draft';
+  declare vendorId: string | null;
+  declare deletedAt: Date | null;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
+}
+
+TourPackage.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    type: {
+      type: DataTypes.ENUM(
+        'adventure',
+        'cultural',
+        'relaxation',
+        'gastronomic',
+        'ecotourism',
+        'luxury'
+      ),
+      allowNull: false,
+    },
+    title: {
+      type: DataTypes.STRING(200),
+      allowNull: false,
+      validate: {
+        len: [1, 200],
+      },
+    },
+    titleEn: {
+      type: DataTypes.STRING(200),
+      allowNull: true,
+      field: 'title_en',
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    descriptionEn: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      field: 'description_en',
+    },
+    destination: {
+      type: DataTypes.STRING(100),
+      allowNull: false,
+    },
+    country: {
+      type: DataTypes.STRING(100),
+      defaultValue: 'Colombia',
+    },
+    durationDays: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      field: 'duration_days',
+      validate: {
+        min: 1,
+      },
+    },
+    price: {
+      type: DataTypes.DECIMAL(12, 2),
+      allowNull: false,
+      validate: {
+        min: 0,
+      },
+    },
+    currency: {
+      type: DataTypes.STRING(3),
+      defaultValue: 'USD',
+    },
+    priceIncludes: {
+      type: DataTypes.JSONB,
+      defaultValue: [],
+      field: 'price_includes',
+    },
+    priceExcludes: {
+      type: DataTypes.JSONB,
+      defaultValue: [],
+      field: 'price_excludes',
+    },
+    images: {
+      type: DataTypes.JSONB,
+      defaultValue: [],
+    },
+    maxCapacity: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 10,
+      field: 'max_capacity',
+    },
+    minGroupSize: {
+      type: DataTypes.INTEGER,
+      defaultValue: 1,
+      field: 'min_group_size',
+    },
+    status: {
+      type: DataTypes.ENUM('active', 'inactive', 'draft'),
+      defaultValue: 'active',
+    },
+    vendorId: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      field: 'vendor_id',
+      references: {
+        model: 'vendors',
+        key: 'id',
+      },
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'deleted_at',
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'created_at',
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      field: 'updated_at',
+    },
+  },
+  {
+    sequelize,
+    tableName: 'tour_packages',
+    underscored: true,
+    timestamps: true,
+    paranoid: true,
+    indexes: [
+      { fields: ['type'] },
+      { fields: ['destination'] },
+      { fields: ['country'] },
+      { fields: ['status'] },
+      { fields: ['vendor_id'] },
+    ],
+  }
+);

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -40,6 +40,8 @@ import { Badge } from './Badge';
 import { UserAchievement } from './UserAchievement';
 import { WebhookEvent } from './WebhookEvent';
 import { Property } from './Property';
+import { TourPackage } from './TourPackage';
+import { TourAvailability } from './TourAvailability';
 
 // User relationships
 User.hasMany(User, { as: 'children', foreignKey: 'sponsorId', sourceKey: 'id' });
@@ -431,6 +433,23 @@ UserAchievement.belongsTo(User, { foreignKey: 'userId', targetKey: 'id' });
 Vendor.hasMany(Property, { foreignKey: 'vendorId', sourceKey: 'id' });
 Property.belongsTo(Vendor, { as: 'vendor', foreignKey: 'vendorId', targetKey: 'id' });
 
+// ============================================
+// NEXO REAL — Tourism Packages (#60)
+// ============================================
+
+Vendor.hasMany(TourPackage, { foreignKey: 'vendorId', sourceKey: 'id' });
+TourPackage.belongsTo(Vendor, { as: 'vendor', foreignKey: 'vendorId', targetKey: 'id' });
+TourPackage.hasMany(TourAvailability, {
+  as: 'availabilities',
+  foreignKey: 'tourPackageId',
+  sourceKey: 'id',
+});
+TourAvailability.belongsTo(TourPackage, {
+  as: 'tourPackage',
+  foreignKey: 'tourPackageId',
+  targetKey: 'id',
+});
+
 export {
   sequelize,
   User,
@@ -475,6 +494,8 @@ export {
   UserAchievement,
   WebhookEvent,
   Property,
+  TourPackage,
+  TourAvailability,
 };
 
 export function initModels(): void {

--- a/backend/src/routes/admin-tour.routes.ts
+++ b/backend/src/routes/admin-tour.routes.ts
@@ -1,0 +1,259 @@
+/**
+ * @fileoverview Admin Tour Routes - Admin tourism package management endpoints
+ * @description Routes for admin tour package CRUD operations (create, update, delete, list).
+ *              Rutas para operaciones CRUD de paquetes turísticos del admin (crear, actualizar, eliminar, listar).
+ * @module routes/admin-tour.routes
+ * @author MLM Development Team
+ */
+import { Router } from 'express';
+import {
+  getTourPackages,
+  getTourPackage,
+  createTourPackage,
+  updateTourPackage,
+  deleteTourPackage,
+} from '../controllers/TourPackageController';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: admin-tours
+ *     description: Admin tourism package management / Gestión de paquetes turísticos (Admin)
+ */
+
+/**
+ * @swagger
+ * /admin/tours:
+ *   get:
+ *     summary: List all tour packages (admin) / Listar todos los paquetes turísticos (admin)
+ *     description: Admin endpoint to list all tour packages including inactive and draft.
+ *                  Endpoint admin para listar todos los paquetes turísticos incluyendo inactivos y borradores.
+ *     tags: [admin-tours]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: type
+ *         schema:
+ *           type: string
+ *           enum: [adventure, cultural, relaxation, gastronomic, ecotourism, luxury]
+ *       - in: query
+ *         name: destination
+ *         schema:
+ *           type: string
+ *           example: "Cartagena, Colombia"
+ *       - in: query
+ *         name: country
+ *         schema:
+ *           type: string
+ *           example: "Colombia"
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [active, inactive, draft]
+ *       - in: query
+ *         name: minPrice
+ *         schema:
+ *           type: number
+ *           minimum: 0
+ *       - in: query
+ *         name: maxPrice
+ *         schema:
+ *           type: number
+ *           minimum: 0
+ *       - in: query
+ *         name: durationDays
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *     responses:
+ *       200:
+ *         description: Tour package list / Lista de paquetes turísticos
+ *       401:
+ *         description: Unauthorized / No autorizado
+ *       403:
+ *         description: Forbidden - not an admin / Prohibido - no es admin
+ */
+router.get('/', getTourPackages);
+
+/**
+ * @swagger
+ * /admin/tours/{id}:
+ *   get:
+ *     summary: Get tour package by ID (admin) / Obtener paquete turístico por ID (admin)
+ *     tags: [admin-tours]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Tour package details / Detalles del paquete turístico
+ *       404:
+ *         description: Not found / No encontrado
+ */
+router.get('/:id', getTourPackage);
+
+/**
+ * @swagger
+ * /admin/tours:
+ *   post:
+ *     summary: Create tour package / Crear paquete turístico
+ *     tags: [admin-tours]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - type
+ *               - title
+ *               - destination
+ *               - durationDays
+ *               - price
+ *             properties:
+ *               type:
+ *                 type: string
+ *                 enum: [adventure, cultural, relaxation, gastronomic, ecotourism, luxury]
+ *                 example: "adventure"
+ *               title:
+ *                 type: string
+ *                 example: "Trekking en el Cocuy"
+ *               titleEn:
+ *                 type: string
+ *                 example: "Trekking in Cocuy"
+ *               description:
+ *                 type: string
+ *               descriptionEn:
+ *                 type: string
+ *               destination:
+ *                 type: string
+ *                 example: "Sierra Nevada del Cocuy, Colombia"
+ *               country:
+ *                 type: string
+ *                 example: "Colombia"
+ *               durationDays:
+ *                 type: integer
+ *                 minimum: 1
+ *                 example: 5
+ *               price:
+ *                 type: number
+ *                 minimum: 0
+ *                 example: 850
+ *               currency:
+ *                 type: string
+ *                 example: "USD"
+ *               priceIncludes:
+ *                 type: array
+ *               priceExcludes:
+ *                 type: array
+ *               images:
+ *                 type: array
+ *               maxCapacity:
+ *                 type: integer
+ *                 example: 12
+ *               minGroupSize:
+ *                 type: integer
+ *                 example: 2
+ *               status:
+ *                 type: string
+ *                 enum: [active, inactive, draft]
+ *               vendorId:
+ *                 type: string
+ *                 format: uuid
+ *     responses:
+ *       201:
+ *         description: Tour package created / Paquete turístico creado
+ *       400:
+ *         description: Validation error / Error de validación
+ *       401:
+ *         description: Unauthorized / No autorizado
+ *       403:
+ *         description: Forbidden / Prohibido
+ */
+router.post('/', createTourPackage);
+
+/**
+ * @swagger
+ * /admin/tours/{id}:
+ *   put:
+ *     summary: Update tour package / Actualizar paquete turístico
+ *     tags: [admin-tours]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *               price:
+ *                 type: number
+ *               status:
+ *                 type: string
+ *                 enum: [active, inactive, draft]
+ *     responses:
+ *       200:
+ *         description: Tour package updated / Paquete turístico actualizado
+ *       400:
+ *         description: Validation error / Error de validación
+ *       404:
+ *         description: Tour package not found / Paquete turístico no encontrado
+ */
+router.put('/:id', updateTourPackage);
+
+/**
+ * @swagger
+ * /admin/tours/{id}:
+ *   delete:
+ *     summary: Delete tour package (soft-delete) / Eliminar paquete turístico (borrado suave)
+ *     tags: [admin-tours]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       204:
+ *         description: Tour package deleted / Paquete turístico eliminado
+ *       404:
+ *         description: Tour package not found / Paquete turístico no encontrado
+ */
+router.delete('/:id', deleteTourPackage);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -24,6 +24,8 @@ import vendorRoutes from './vendor.routes';
 import adminVendorRoutes from './admin-vendor.routes';
 import propertyRoutes from './property.routes';
 import adminPropertyRoutes from './admin-property.routes';
+import tourRoutes from './tour.routes';
+import adminTourRoutes from './admin-tour.routes';
 import contractRoutes from './contract.routes';
 import adminContractRoutes from './admin-contract.routes';
 import addressRoutes from './address.routes';
@@ -69,6 +71,12 @@ router.use('/properties', propertyRoutes);
 
 // Admin property routes
 router.use('/admin/properties', adminPropertyRoutes);
+
+// Tour routes (public)
+router.use('/tours', tourRoutes);
+
+// Admin tour routes
+router.use('/admin/tours', adminTourRoutes);
 
 // Contract routes (user)
 router.use('/contracts', contractRoutes);

--- a/backend/src/routes/tour.routes.ts
+++ b/backend/src/routes/tour.routes.ts
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview Tour Routes - Public tourism package listing endpoints
+ * @description Routes for browsing tourism packages without authentication.
+ *              Rutas para navegar paquetes turísticos sin autenticación.
+ * @module routes/tour.routes
+ * @author MLM Development Team
+ */
+import { Router } from 'express';
+import { getTourPackages, getTourPackage } from '../controllers/TourPackageController';
+
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   - name: tours
+ *     description: Tourism package listings / Listados de paquetes turísticos
+ */
+
+/**
+ * @swagger
+ * /tours:
+ *   get:
+ *     summary: List tour packages / Listar paquetes turísticos
+ *     description: Public endpoint to browse available tour packages with optional filters.
+ *                  Endpoint público para navegar paquetes turísticos disponibles con filtros opcionales.
+ *     tags: [tours]
+ *     parameters:
+ *       - in: query
+ *         name: type
+ *         schema:
+ *           type: string
+ *           enum: [adventure, cultural, relaxation, gastronomic, ecotourism, luxury]
+ *         description: Filter by tour type / Filtrar por tipo de tour
+ *       - in: query
+ *         name: destination
+ *         schema:
+ *           type: string
+ *           example: "Cartagena, Colombia"
+ *         description: Filter by destination / Filtrar por destino
+ *       - in: query
+ *         name: country
+ *         schema:
+ *           type: string
+ *           example: "Colombia"
+ *         description: Filter by country / Filtrar por país
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [active, inactive, draft]
+ *           default: active
+ *         description: Listing status / Estado del listado
+ *       - in: query
+ *         name: minPrice
+ *         schema:
+ *           type: number
+ *           minimum: 0
+ *           example: 500
+ *         description: Minimum price / Precio mínimo
+ *       - in: query
+ *         name: maxPrice
+ *         schema:
+ *           type: number
+ *           minimum: 0
+ *           example: 3000
+ *         description: Maximum price / Precio máximo
+ *       - in: query
+ *         name: durationDays
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           example: 7
+ *         description: Duration in days / Duración en días
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *           minimum: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *           minimum: 1
+ *           maximum: 100
+ *     responses:
+ *       200:
+ *         description: Tour package list with pagination / Lista de paquetes turísticos con paginación
+ *       400:
+ *         description: Validation error / Error de validación
+ */
+router.get('/', getTourPackages);
+
+/**
+ * @swagger
+ * /tours/{id}:
+ *   get:
+ *     summary: Get tour package by ID / Obtener paquete turístico por ID
+ *     description: Public endpoint to retrieve a single tour package's details.
+ *                  Endpoint público para obtener los detalles de un paquete turístico.
+ *     tags: [tours]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: Tour package UUID / UUID del paquete turístico
+ *     responses:
+ *       200:
+ *         description: Tour package details / Detalles del paquete turístico
+ *       400:
+ *         description: Invalid UUID / UUID inválido
+ *       404:
+ *         description: Tour package not found / Paquete turístico no encontrado
+ */
+router.get('/:id', getTourPackage);
+
+export default router;

--- a/backend/src/services/TourPackageService.ts
+++ b/backend/src/services/TourPackageService.ts
@@ -1,0 +1,226 @@
+/**
+ * @fileoverview TourPackageService - Business logic for tourism packages
+ * @description Service layer for CRUD operations on tourism packages.
+ *              Handles filtering, pagination, and soft-delete (paranoid).
+ *              Capa de servicio para operaciones CRUD en paquetes turísticos.
+ *              Maneja filtrado, paginación y borrado suave (paranoid).
+ * @module services/TourPackageService
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: List active adventure tours in Colombia
+ * const result = await tourPackageService.findAll({ type: 'adventure', country: 'Colombia', status: 'active' });
+ *
+ * // Español: Listar tours de aventura activos en Colombia
+ * const result = await tourPackageService.findAll({ type: 'adventure', country: 'Colombia', status: 'active' });
+ */
+import { Op, WhereOptions } from 'sequelize';
+import { TourPackage, TourAvailability } from '../models';
+import type { TourPackageAttributes, TourPackageCreationAttributes } from '../models/TourPackage';
+
+// ============================================
+// TYPES
+// ============================================
+
+/**
+ * Input filters for listing tour packages
+ * Filtros de entrada para listar paquetes turísticos
+ */
+export interface TourPackageFilters {
+  /** Tour type / Tipo de tour */
+  type?: 'adventure' | 'cultural' | 'relaxation' | 'gastronomic' | 'ecotourism' | 'luxury';
+  /** Destination filter / Filtro de destino */
+  destination?: string;
+  /** Country filter / Filtro de país */
+  country?: string;
+  /** Listing status / Estado del listado */
+  status?: 'active' | 'inactive' | 'draft';
+  /** Minimum price / Precio mínimo */
+  minPrice?: number;
+  /** Maximum price / Precio máximo */
+  maxPrice?: number;
+  /** Duration in days / Duración en días */
+  durationDays?: number;
+  /** Page number (1-based) / Número de página (base 1) */
+  page?: number;
+  /** Page size / Tamaño de página */
+  limit?: number;
+}
+
+/**
+ * Input data for creating or updating a tour package
+ * Datos de entrada para crear o actualizar un paquete turístico
+ */
+export type TourPackageCreateInput = TourPackageCreationAttributes;
+
+// ============================================
+// SERVICE CLASS
+// ============================================
+
+/**
+ * TourPackageService - Handles all tourism package business logic
+ * TourPackageService - Gestiona toda la lógica de negocio de paquetes turísticos
+ */
+export class TourPackageService {
+  /**
+   * List tour packages with optional filters and pagination
+   * Listar paquetes turísticos con filtros opcionales y paginación
+   *
+   * @param filters - Optional filters and pagination params / Filtros opcionales y parámetros de paginación
+   * @returns Paginated list of tour packages / Lista paginada de paquetes turísticos
+   */
+  async findAll(filters: TourPackageFilters = {}): Promise<{ rows: TourPackage[]; count: number }> {
+    const {
+      type,
+      destination,
+      country,
+      status,
+      minPrice,
+      maxPrice,
+      durationDays,
+      page = 1,
+      limit: rawLimit = 20,
+    } = filters;
+
+    // Enforce maximum limit / Aplicar límite máximo
+    const limit = Math.min(rawLimit, 100);
+    const offset = (page - 1) * limit;
+
+    // Build where clause / Construir cláusula where
+    const where: WhereOptions<TourPackageAttributes> = {};
+
+    if (type) {
+      where.type = type;
+    }
+
+    if (destination) {
+      where.destination = destination;
+    }
+
+    if (country) {
+      where.country = country;
+    }
+
+    if (status) {
+      where.status = status;
+    }
+
+    if (durationDays !== undefined) {
+      where.durationDays = durationDays;
+    }
+
+    // Price range filter / Filtro de rango de precio
+    if (minPrice !== undefined || maxPrice !== undefined) {
+      where.price = {};
+      if (minPrice !== undefined) {
+        (where.price as Record<symbol, number>)[Op.gte] = minPrice;
+      }
+      if (maxPrice !== undefined) {
+        (where.price as Record<symbol, number>)[Op.lte] = maxPrice;
+      }
+    }
+
+    const today = new Date().toISOString().split('T')[0];
+
+    const result = await TourPackage.findAndCountAll({
+      where,
+      limit,
+      offset,
+      order: [['created_at', 'DESC']],
+      include: [
+        {
+          model: TourAvailability,
+          as: 'availabilities',
+          required: false,
+          where: {
+            date: { [Op.gte]: today },
+            isBlocked: false,
+          },
+        },
+      ],
+    });
+
+    return result;
+  }
+
+  /**
+   * Find a single tour package by primary key
+   * Buscar un paquete turístico por clave primaria
+   *
+   * @param id - TourPackage UUID / UUID del paquete turístico
+   * @returns TourPackage instance / Instancia de paquete turístico
+   * @throws { statusCode: 404, code: 'TOUR_PACKAGE_NOT_FOUND', message: string } when not found
+   */
+  async findById(id: string): Promise<TourPackage> {
+    const today = new Date().toISOString().split('T')[0];
+
+    const tourPackage = await TourPackage.findByPk(id, {
+      include: [
+        {
+          model: TourAvailability,
+          as: 'availabilities',
+          required: false,
+          where: {
+            date: { [Op.gte]: today },
+            isBlocked: false,
+          },
+        },
+      ],
+    });
+
+    if (!tourPackage) {
+      throw {
+        statusCode: 404,
+        code: 'TOUR_PACKAGE_NOT_FOUND',
+        message: 'Tour package not found',
+      };
+    }
+
+    return tourPackage;
+  }
+
+  /**
+   * Create a new tour package
+   * Crear un nuevo paquete turístico
+   *
+   * @param data - Tour package creation data / Datos de creación del paquete turístico
+   * @returns Created tour package / Paquete turístico creado
+   */
+  async create(data: TourPackageCreateInput): Promise<TourPackage> {
+    const tourPackage = await TourPackage.create(data as TourPackageAttributes);
+    return tourPackage;
+  }
+
+  /**
+   * Update an existing tour package by ID
+   * Actualizar un paquete turístico existente por ID
+   *
+   * @param id - TourPackage UUID / UUID del paquete turístico
+   * @param data - Partial update data / Datos parciales de actualización
+   * @returns Updated tour package / Paquete turístico actualizado
+   * @throws { statusCode: 404, code: 'TOUR_PACKAGE_NOT_FOUND', message: string } when not found
+   */
+  async update(id: string, data: Partial<TourPackageCreateInput>): Promise<TourPackage> {
+    const tourPackage = await this.findById(id);
+    await tourPackage.update(data);
+    return tourPackage;
+  }
+
+  /**
+   * Soft-delete a tour package by ID (paranoid)
+   * Eliminar suavemente un paquete turístico por ID (paranoid)
+   *
+   * @param id - TourPackage UUID / UUID del paquete turístico
+   * @throws { statusCode: 404, code: 'TOUR_PACKAGE_NOT_FOUND', message: string } when not found
+   */
+  async remove(id: string): Promise<void> {
+    const tourPackage = await this.findById(id);
+    await tourPackage.destroy();
+  }
+}
+
+/**
+ * Singleton instance of TourPackageService
+ * Instancia singleton de TourPackageService
+ */
+export const tourPackageService = new TourPackageService();


### PR DESCRIPTION
## Summary

Implements the full **Tourism Packages** module for Sprint 5 (issue #60).

## Changes

### New Files
- `backend/src/models/TourPackage.ts` — Sequelize model con 6 tipos ENUM (adventure, cultural, relaxation, gastronomic, ecotourism, luxury), paranoid soft-delete, JSONB
- `backend/src/models/TourAvailability.ts` — Calendario de disponibilidad por fecha con unique compuesto `(tour_package_id, date)`
- `backend/src/database/migrations/20260406140000-create-tour-packages.js` — migración con 5 índices
- `backend/src/database/migrations/20260406150000-create-tour-availabilities.js` — migración con índice único compuesto
- `backend/src/services/TourPackageService.ts` — findAll (filtros: type, destination, country, status, price range, durationDays + include de disponibilidades futuras), findById, create, update, remove
- `backend/src/controllers/TourPackageController.ts` — 5 handlers HTTP
- `backend/src/routes/tour.routes.ts` — Rutas públicas (`/tours`)
- `backend/src/routes/admin-tour.routes.ts` — Rutas admin (`/admin/tours`)
- `backend/src/__tests__/TourPackageService.test.ts` — 17 tests unitarios ✅

### Modified Files
- `backend/src/models/index.ts` — TourPackage + TourAvailability registrados + asociaciones Vendor↔TourPackage + TourPackage↔TourAvailability
- `backend/src/routes/index.ts` — Rutas `/tours` y `/admin/tours` registradas

## Test Results

```
Tests: 17 passed, 17 total
Test Suites: 1 passed, 1 total
```

## Closes

Closes #60