### PR TITLE
feat(calendar): Google Calendar sync via n8n webhook on reservation confirm (#63)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -92,3 +92,11 @@ R2_ACCESS_KEY_ID=your_r2_access_key_id
 R2_SECRET_ACCESS_KEY=your_r2_secret_access_key
 R2_BUCKET=nexoreal-media
 R2_PUBLIC_URL=https://media.nexoreal.xyz
+
+# Internal Webhook Secret (for n8n → backend communication)
+# Secreto de webhook interno (para comunicación n8n → backend)
+INTERNAL_WEBHOOK_SECRET=change-this-to-a-random-32-char-secret
+
+# n8n Webhook URL for Google Calendar sync
+# URL del webhook de n8n para sincronización con Google Calendar
+N8N_CALENDAR_WEBHOOK_URL=https://n8n.nexoreal.xyz/webhook/calendar-sync

--- a/backend/src/__tests__/CalendarService.test.ts
+++ b/backend/src/__tests__/CalendarService.test.ts
@@ -1,0 +1,185 @@
+/**
+ * @fileoverview Unit tests for CalendarService
+ * @description Tests for CalendarService.notifyReservationConfirmed including:
+ *              - Calls fetch with correct URL and payload
+ *              - Includes X-Internal-Secret header
+ *              - Graceful skip when webhookUrl is not set
+ *              - Non-blocking behavior when fetch fails
+ *              - Logs error when n8n returns non-ok status
+ *              Tests para CalendarService.notifyReservationConfirmed incluyendo:
+ *              - Llama a fetch con la URL y payload correctos
+ *              - Incluye el encabezado X-Internal-Secret
+ *              - Omisión sin error cuando webhookUrl no está configurada
+ *              - Comportamiento no bloqueante cuando fetch falla
+ *              - Registra error cuando n8n retorna estado no-ok
+ * @module __tests__/CalendarService
+ */
+
+import { CalendarService, CalendarEventPayload } from '../services/CalendarService';
+
+// ============================================
+// HELPERS / AYUDANTES
+// ============================================
+
+/**
+ * Build a minimal valid CalendarEventPayload for testing
+ * Construir un CalendarEventPayload válido mínimo para pruebas
+ */
+const buildPayload = (overrides: Partial<CalendarEventPayload> = {}): CalendarEventPayload => ({
+  reservationId: 'res-uuid-001',
+  type: 'property',
+  guestName: 'Juan Pérez',
+  guestEmail: 'juan@example.com',
+  guestPhone: '+549111234567',
+  title: 'Casa en la playa',
+  startDate: '2026-05-01T00:00:00.000Z',
+  endDate: '2026-05-07T00:00:00.000Z',
+  notes: 'Llegan tarde',
+  vendorId: 'vendor-uuid-001',
+  ...overrides,
+});
+
+// ============================================
+// MOCK global.fetch
+// ============================================
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  global.fetch = mockFetch;
+});
+
+afterEach(() => {
+  // Restore original env vars / Restaurar variables de entorno originales
+  delete process.env.N8N_CALENDAR_WEBHOOK_URL;
+  delete process.env.INTERNAL_WEBHOOK_SECRET;
+});
+
+// ============================================
+// TESTS
+// ============================================
+
+describe('CalendarService', () => {
+  describe('notifyReservationConfirmed', () => {
+    it('should call fetch with correct URL and payload', async () => {
+      // Arrange / Preparar
+      process.env.N8N_CALENDAR_WEBHOOK_URL = 'https://n8n.example.com/webhook/calendar-sync';
+      process.env.INTERNAL_WEBHOOK_SECRET = 'test-secret-32-chars-xxxxxxxxxx';
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+
+      const service = new CalendarService();
+      const payload = buildPayload();
+
+      // Act / Actuar
+      await service.notifyReservationConfirmed(payload);
+
+      // Assert / Afirmar
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://n8n.example.com/webhook/calendar-sync',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify(payload),
+        })
+      );
+    });
+
+    it('should include X-Internal-Secret header', async () => {
+      // Arrange / Preparar
+      process.env.N8N_CALENDAR_WEBHOOK_URL = 'https://n8n.example.com/webhook/calendar-sync';
+      process.env.INTERNAL_WEBHOOK_SECRET = 'super-secret-value';
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+      });
+
+      const service = new CalendarService();
+
+      // Act / Actuar
+      await service.notifyReservationConfirmed(buildPayload());
+
+      // Assert / Afirmar
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Internal-Secret': 'super-secret-value',
+            'Content-Type': 'application/json',
+          }),
+        })
+      );
+    });
+
+    it('should not throw when webhookUrl is not set (graceful skip)', async () => {
+      // Arrange — N8N_CALENDAR_WEBHOOK_URL is not set
+      // Preparar — N8N_CALENDAR_WEBHOOK_URL no está configurada
+      delete process.env.N8N_CALENDAR_WEBHOOK_URL;
+
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const service = new CalendarService();
+
+      // Act & Assert — should resolve without calling fetch
+      // Actuar y Afirmar — debe resolver sin llamar a fetch
+      await expect(service.notifyReservationConfirmed(buildPayload())).resolves.toBeUndefined();
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[CalendarService] N8N_CALENDAR_WEBHOOK_URL not set, skipping calendar sync'
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('should not throw when fetch fails (non-blocking)', async () => {
+      // Arrange / Preparar
+      process.env.N8N_CALENDAR_WEBHOOK_URL = 'https://n8n.example.com/webhook/calendar-sync';
+      process.env.INTERNAL_WEBHOOK_SECRET = 'test-secret';
+
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const service = new CalendarService();
+
+      // Act & Assert — should resolve even when fetch throws
+      // Actuar y Afirmar — debe resolver incluso cuando fetch lanza error
+      await expect(service.notifyReservationConfirmed(buildPayload())).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[CalendarService] Failed to notify n8n webhook:',
+        expect.any(Error)
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should log error when n8n returns non-ok status', async () => {
+      // Arrange / Preparar
+      process.env.N8N_CALENDAR_WEBHOOK_URL = 'https://n8n.example.com/webhook/calendar-sync';
+      process.env.INTERNAL_WEBHOOK_SECRET = 'test-secret';
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const service = new CalendarService();
+
+      // Act / Actuar
+      await service.notifyReservationConfirmed(buildPayload());
+
+      // Assert — should log error but NOT throw
+      // Afirmar — debe registrar error pero NO lanzar
+      expect(errorSpy).toHaveBeenCalledWith('[CalendarService] n8n webhook returned 500');
+
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -34,6 +34,7 @@ import addressRoutes from './address.routes';
 import shippingRoutes from './shipping.routes';
 import achievementRoutes from './achievement.routes';
 import leaderboardRoutes from './leaderboard.routes';
+import webhookInternalRoutes from './webhook-internal.routes';
 
 const router: ExpressRouter = Router();
 
@@ -103,6 +104,10 @@ router.use('/achievements', achievementRoutes);
 
 // Leaderboard routes
 router.use('/leaderboard', leaderboardRoutes);
+
+// Internal webhook routes (for n8n and internal services)
+// Rutas de webhook interno (para n8n y servicios internos)
+router.use('/webhooks/internal', webhookInternalRoutes);
 
 // Profile public routes (MUST be before publicRoutes to avoid /profile/:code conflict)
 import profilePublicRoutes from './profile-public.routes';

--- a/backend/src/routes/webhook-internal.routes.ts
+++ b/backend/src/routes/webhook-internal.routes.ts
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Internal webhook routes — for n8n and internal services
+ * @description Protected routes for internal service-to-service communication.
+ *              All routes require the X-Internal-Secret header.
+ *              Rutas protegidas para comunicación interna entre servicios.
+ *              Todas las rutas requieren el encabezado X-Internal-Secret.
+ * @module routes/webhook-internal.routes
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Call from n8n to confirm a reservation after payment
+ * POST /webhooks/internal/reservation-confirm
+ * Headers: { 'X-Internal-Secret': '<secret>' }
+ * Body: { "reservationId": "uuid" }
+ *
+ * // Español: Llamada desde n8n para confirmar reserva luego del pago
+ * POST /webhooks/internal/reservation-confirm
+ * Headers: { 'X-Internal-Secret': '<secreto>' }
+ * Body: { "reservationId": "uuid" }
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { ReservationService } from '../services/ReservationService';
+
+const router = Router();
+
+// ============================================
+// MIDDLEWARE
+// ============================================
+
+/**
+ * Middleware to verify internal webhook secret
+ * Middleware para verificar el secreto de webhook interno
+ *
+ * @param req - Express request / Solicitud Express
+ * @param res - Express response / Respuesta Express
+ * @param next - Next middleware / Siguiente middleware
+ */
+const verifyInternalSecret = (req: Request, res: Response, next: NextFunction): void => {
+  const secret = req.headers['x-internal-secret'];
+  if (!secret || secret !== process.env.INTERNAL_WEBHOOK_SECRET) {
+    res.status(401).json({ message: 'Unauthorized / No autorizado' });
+    return;
+  }
+  next();
+};
+
+// ============================================
+// ROUTES / RUTAS
+// ============================================
+
+/**
+ * POST /webhooks/internal/reservation-confirm
+ * @description Confirm a reservation (called by n8n after payment verification)
+ *              Confirmar una reserva (llamado por n8n después de verificar el pago)
+ * @security X-Internal-Secret header required / Requiere encabezado X-Internal-Secret
+ * @body {{ reservationId: string }} Reservation UUID / UUID de la reserva
+ * @returns {{ success: boolean, reservationId: string, status: string }}
+ */
+router.post(
+  '/reservation-confirm',
+  verifyInternalSecret,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { reservationId } = req.body;
+
+      if (!reservationId) {
+        res.status(400).json({ message: 'reservationId is required' });
+        return;
+      }
+
+      const reservationService = new ReservationService();
+      const reservation = await reservationService.confirm(reservationId);
+
+      res.json({
+        success: true,
+        reservationId: reservation.id,
+        status: reservation.status,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+export default router;

--- a/backend/src/services/CalendarService.ts
+++ b/backend/src/services/CalendarService.ts
@@ -1,0 +1,114 @@
+/**
+ * @fileoverview CalendarService — Google Calendar sync via n8n webhook
+ * @description Notifies n8n when a reservation is confirmed so n8n can
+ *              create the Google Calendar event and notify the agent via WhatsApp.
+ *              Notifica a n8n cuando una reserva es confirmada para que n8n pueda
+ *              crear el evento en Google Calendar y notificar al agente por WhatsApp.
+ * @module services/CalendarService
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Notify n8n on reservation confirmation
+ * const calendarService = new CalendarService();
+ * await calendarService.notifyReservationConfirmed({ reservationId: '123', ... });
+ *
+ * // Español: Notificar a n8n al confirmar una reserva
+ * const calendarService = new CalendarService();
+ * await calendarService.notifyReservationConfirmed({ reservationId: '123', ... });
+ */
+
+// ============================================
+// TYPES / TIPOS
+// ============================================
+
+/**
+ * Payload sent to the n8n webhook for calendar event creation
+ * Payload enviado al webhook de n8n para la creación del evento de calendario
+ */
+export interface CalendarEventPayload {
+  /** Reservation UUID / UUID de la reserva */
+  reservationId: string;
+  /** Reservation type / Tipo de reserva */
+  type: 'property' | 'tour';
+  /** Guest full name / Nombre completo del huésped */
+  guestName: string;
+  /** Guest email address / Correo electrónico del huésped */
+  guestEmail: string;
+  /** Guest phone number or null / Teléfono del huésped o null */
+  guestPhone: string | null;
+  /** Property title or tour title / Título de la propiedad o del tour */
+  title: string;
+  /** ISO date string — checkIn for property, tourDate for tour / Fecha ISO — checkIn para propiedad, tourDate para tour */
+  startDate: string;
+  /** ISO date string — checkOut for property, null for tours / Fecha ISO — checkOut para propiedad, null para tours */
+  endDate: string | null;
+  /** Optional notes / Notas opcionales */
+  notes: string | null;
+  /** Vendor ID or null / ID del vendedor o null */
+  vendorId: string | null;
+}
+
+// ============================================
+// SERVICE CLASS
+// ============================================
+
+/**
+ * CalendarService — Handles Google Calendar sync via n8n webhook
+ * CalendarService — Gestiona la sincronización con Google Calendar via webhook de n8n
+ *
+ * @description All errors are non-blocking: catch and log, never throw.
+ *              Todos los errores son no bloqueantes: captura y registra, nunca lanza.
+ */
+export class CalendarService {
+  /** n8n webhook URL for calendar sync / URL del webhook de n8n para sincronización de calendario */
+  private readonly webhookUrl: string;
+
+  /** Internal shared secret for webhook authentication / Secreto compartido interno para autenticación de webhook */
+  private readonly secret: string;
+
+  /**
+   * Constructor — reads config from environment variables
+   * Constructor — lee la configuración de las variables de entorno
+   */
+  constructor() {
+    this.webhookUrl = process.env.N8N_CALENDAR_WEBHOOK_URL ?? '';
+    this.secret = process.env.INTERNAL_WEBHOOK_SECRET ?? '';
+  }
+
+  /**
+   * Notify n8n webhook to create a Google Calendar event
+   * Notifica al webhook de n8n para crear un evento en Google Calendar
+   *
+   * @description Non-blocking — catches all errors and logs them.
+   *              No bloqueante — captura todos los errores y los registra.
+   * @param payload - Event payload to send to n8n / Payload del evento a enviar a n8n
+   * @returns Promise<void> — always resolves, never rejects
+   */
+  async notifyReservationConfirmed(payload: CalendarEventPayload): Promise<void> {
+    if (!this.webhookUrl) {
+      console.warn('[CalendarService] N8N_CALENDAR_WEBHOOK_URL not set, skipping calendar sync');
+      return;
+    }
+
+    try {
+      const response = await fetch(this.webhookUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Internal-Secret': this.secret,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        console.error(`[CalendarService] n8n webhook returned ${response.status}`);
+      }
+    } catch (error) {
+      // Non-blocking — log error but don't throw
+      // (calendar sync failure should not break booking flow)
+      // No bloqueante — registrar error pero no lanzar
+      // (el fallo de sincronización no debe romper el flujo de reserva)
+      console.error('[CalendarService] Failed to notify n8n webhook:', error);
+    }
+  }
+}

--- a/backend/src/services/ReservationService.ts
+++ b/backend/src/services/ReservationService.ts
@@ -17,6 +17,7 @@
 import { WhereOptions } from 'sequelize';
 import { Reservation, Property, TourPackage, TourAvailability, User } from '../models';
 import type { ReservationAttributes, ReservationCreationAttributes } from '../models/Reservation';
+import { CalendarService } from './CalendarService';
 
 // ============================================
 // TYPES
@@ -282,6 +283,32 @@ export class ReservationService {
     const reservation = await this.findById(id);
     reservation.status = 'confirmed';
     await reservation.save();
+
+    // Non-blocking calendar sync — don't await
+    // Sincronización de calendario no bloqueante — no usar await
+    const calendarService = new CalendarService();
+    const payload = {
+      reservationId: reservation.id,
+      type: reservation.type,
+      guestName: reservation.guestName,
+      guestEmail: reservation.guestEmail,
+      guestPhone: reservation.guestPhone ?? null,
+      title:
+        reservation.type === 'property'
+          ? ((reservation as any).property?.title ?? 'Propiedad')
+          : ((reservation as any).tourPackage?.title ?? 'Tour'),
+      startDate:
+        reservation.type === 'property'
+          ? (reservation.checkIn ?? '')
+          : (reservation.tourDate ?? ''),
+      endDate: reservation.type === 'property' ? (reservation.checkOut ?? null) : null,
+      notes: reservation.notes ?? null,
+      vendorId: reservation.vendorId ?? null,
+    };
+    calendarService.notifyReservationConfirmed(payload).catch((err: unknown) => {
+      console.error('[ReservationService] Calendar sync error:', err);
+    });
+
     return reservation;
   }
 }


### PR DESCRIPTION
## Summary

Implementa sincronización con **Google Calendar** via n8n webhook cuando se confirma una reserva (issue #63).

## Arquitectura

```
Reserva confirmada → backend.confirm()
  → CalendarService.notifyReservationConfirmed() [fire-and-forget, non-blocking]
    → POST n8n webhook
      → n8n crea Google Calendar event
      → n8n notifica agente por WhatsApp
```

El backend **no llama a Google Calendar directamente** — delega a n8n.

## New Files
- `backend/src/services/CalendarService.ts` — POSTea al webhook de n8n con payload de la reserva; errores son non-blocking (catch+log)
- `backend/src/routes/webhook-internal.routes.ts` — Endpoint inbound `POST /webhooks/internal/reservation-confirm` protegido con `X-Internal-Secret`
- `backend/src/__tests__/CalendarService.test.ts` — 5 tests ✅

## Modified Files
- `backend/src/services/ReservationService.ts` — fire-and-forget en `confirm()` post-save
- `backend/src/routes/index.ts` — montaje en `/webhooks/internal`
- `backend/.env` + `.env.example` — `INTERNAL_WEBHOOK_SECRET` + `N8N_CALENDAR_WEBHOOK_URL`

## Test Results
```
Tests: 5 passed, 5 total
```

## Closes
Closes #63