### PR TITLE
fix(security): validate images array type to prevent type confusion (CodeQL #39, #40)

### DIFF
--- a/backend/src/controllers/PropertyController.ts
+++ b/backend/src/controllers/PropertyController.ts
@@ -373,7 +373,10 @@ export const uploadPropertyImages = async (
       return;
     }
 
-    const currentImages = (property.images as string[]) ?? [];
+    const rawImages = property.images;
+    const currentImages: string[] = Array.isArray(rawImages)
+      ? rawImages.filter((img): img is string => typeof img === 'string')
+      : [];
 
     if (currentImages.length + files.length > 10) {
       res

--- a/backend/src/controllers/TourPackageController.ts
+++ b/backend/src/controllers/TourPackageController.ts
@@ -385,7 +385,10 @@ export const uploadTourImages = async (
       return;
     }
 
-    const currentImages = (tourPackage.images as string[]) ?? [];
+    const rawImages = tourPackage.images;
+    const currentImages: string[] = Array.isArray(rawImages)
+      ? rawImages.filter((img): img is string => typeof img === 'string')
+      : [];
 
     if (currentImages.length + files.length > 10) {
       res.status(400).json({ message: `Max 10 images per tour. Current: ${currentImages.length}` });


### PR DESCRIPTION
## Summary

Fixes CodeQL Critical alerts #39 and #40: **Type confusion through parameter tampering (CWE-843)**.

## Problem

Both `PropertyController` and `TourPackageController` were using an unsafe `as string[]` cast on the `images` field coming from the database, without runtime validation:

```ts
// ❌ Before — unsafe cast, no runtime check
const currentImages = (property.images as string[]) ?? [];
```

CodeQL detects this as a type confusion vulnerability: if an attacker can manipulate the `images` field in the DB to a non-array value, it could cause unexpected runtime behavior downstream.

## Fix

Replaced the unsafe cast with a proper runtime guard using `Array.isArray` + explicit string filter:

```ts
// ✅ After — runtime-validated
const rawImages = property.images;
const currentImages: string[] = Array.isArray(rawImages)
  ? rawImages.filter((img): img is string => typeof img === 'string')
  : [];
```

This eliminates the CWE-843 finding by ensuring `currentImages` is always a verified `string[]`, regardless of what comes from the database.

## Files changed

- `backend/src/controllers/PropertyController.ts` — line ~376 (alert #40)
- `backend/src/controllers/TourPackageController.ts` — line ~388 (alert #39)

## Closes

- Closes CodeQL alert #39
- Closes CodeQL alert #40