### PR TITLE
fix(security): normalize req.files cast — CodeQL type confusion #39 #40

### DIFF
--- a/backend/src/controllers/PropertyController.ts
+++ b/backend/src/controllers/PropertyController.ts
@@ -352,9 +352,14 @@ export const deleteProperty = [
  * POST /api/admin/properties/:id/images — Sube imágenes a una propiedad
  *
  * @description Uploads files to Cloudflare R2 and appends the resulting public URLs
- *              to the property's images array.
+ *              to the property's images array. Safely normalizes req.files regardless
+ *              of whether Multer returns a flat array (array()) or a fieldname dict (fields()).
  *              Sube archivos a Cloudflare R2 y agrega las URLs públicas resultantes
- *              al array de imágenes de la propiedad.
+ *              al array de imágenes de la propiedad. Normaliza req.files de forma segura
+ *              independientemente de si Multer retorna array plano o diccionario por campo.
+ *
+ * @security Fixed CodeQL js/type-confusion-through-parameter-tampering (#40)
+ *           req.files puede ser File[] o { [fieldname]: File[] } — se normaliza explícitamente.
  *
  * @route POST /api/admin/properties/:id/images
  * @access Admin
@@ -366,7 +371,11 @@ export const uploadPropertyImages = async (
 ): Promise<void> => {
   try {
     const property = await propertyService.findById(req.params.id);
-    const files = req.files as Express.Multer.File[];
+    // Normalize req.files: Multer can return File[] (array()) or { [field]: File[] } (fields())
+    // Normalizar req.files: Multer puede retornar File[] (array()) o { [campo]: File[] } (fields())
+    const files: Express.Multer.File[] = Array.isArray(req.files)
+      ? req.files
+      : Object.values(req.files ?? {}).flat();
 
     if (!files || files.length === 0) {
       res.status(400).json({ message: 'No images provided / No se proporcionaron imágenes' });

--- a/backend/src/controllers/TourPackageController.ts
+++ b/backend/src/controllers/TourPackageController.ts
@@ -364,9 +364,14 @@ export const deleteTourPackage = [
  * POST /api/admin/tours/:id/images — Sube imágenes a un paquete turístico
  *
  * @description Uploads files to Cloudflare R2 and appends the resulting public URLs
- *              to the tour package's images array.
+ *              to the tour package's images array. Safely normalizes req.files regardless
+ *              of whether Multer returns a flat array (array()) or a fieldname dict (fields()).
  *              Sube archivos a Cloudflare R2 y agrega las URLs públicas resultantes
- *              al array de imágenes del paquete turístico.
+ *              al array de imágenes del paquete turístico. Normaliza req.files de forma segura
+ *              independientemente de si Multer retorna array plano o diccionario por campo.
+ *
+ * @security Fixed CodeQL js/type-confusion-through-parameter-tampering (#39)
+ *           req.files puede ser File[] o { [fieldname]: File[] } — se normaliza explícitamente.
  *
  * @route POST /api/admin/tours/:id/images
  * @access Admin
@@ -378,7 +383,11 @@ export const uploadTourImages = async (
 ): Promise<void> => {
   try {
     const tourPackage = await tourPackageService.findById(req.params.id);
-    const files = req.files as Express.Multer.File[];
+    // Normalize req.files: Multer can return File[] (array()) or { [field]: File[] } (fields())
+    // Normalizar req.files: Multer puede retornar File[] (array()) o { [campo]: File[] } (fields())
+    const files: Express.Multer.File[] = Array.isArray(req.files)
+      ? req.files
+      : Object.values(req.files ?? {}).flat();
 
     if (!files || files.length === 0) {
       res.status(400).json({ message: 'No images provided / No se proporcionaron imágenes' });


### PR DESCRIPTION
## Resumen

Corrige 2 alertas CodeQL de severidad **error** (`js/type-confusion-through-parameter-tampering`) en los controllers de upload de imágenes.

## Problema

```typescript
// ❌ ANTES — cast directo sin validar tipo
const files = req.files as Express.Multer.File[];
```

`req.files` en Express/Multer puede ser:
- `Express.Multer.File[]` cuando se configura con `upload.array()`
- `{ [fieldname: string]: Express.Multer.File[] }` cuando se configura con `upload.fields()`

El cast directo asume siempre el primer caso, causando type confusion potencial.

## Fix

```typescript
// ✅ AHORA — normalización explícita y segura
const files: Express.Multer.File[] = Array.isArray(req.files)
  ? req.files
  : Object.values(req.files ?? {}).flat();
```

## Archivos modificados

- `backend/src/controllers/PropertyController.ts` — línea 369 (CodeQL #40)
- `backend/src/controllers/TourPackageController.ts` — línea 381 (CodeQL #39)

## Testing

- [ ] Upload de imágenes funciona correctamente con el fix
- [ ] TypeScript compila sin errores nuevos introducidos por este cambio
- [ ] CodeQL alerts #39 y #40 cierran automáticamente al mergear

Closes #87