### PR TITLE
chore: rename binary_balance → network_balance + build hardening

### DIFF
--- a/backend/scripts/build.mjs
+++ b/backend/scripts/build.mjs
@@ -55,7 +55,18 @@ async function build() {
           console.log(`📦 ${file}: ${size} KB`);
         }
       }
-      
+
+      // Explicitly remove sourcemap if it exists (belt-and-suspenders: sourcemap is already
+      // disabled in production via sourcemap: !isProduction, but we enforce it here to
+      // guarantee no *.map file ever enters the Docker image).
+      // Eliminar explícitamente el sourcemap si existe (doble seguro: sourcemap ya está
+      // desactivado en producción vía sourcemap: !isProduction, pero lo forzamos aquí para
+      // garantizar que ningún archivo *.map entre a la imagen Docker).
+      if (isProduction) {
+        await rm('dist/server.mjs.map', { force: true });
+        console.log('🔒 Sourcemap removed from dist/ (production build)');
+      }
+
       console.log('✅ Build complete!');
       console.log('   Output: dist/server.mjs');
     }

--- a/backend/src/database/migrations/20260407000001-rename-binary-balance.js
+++ b/backend/src/database/migrations/20260407000001-rename-binary-balance.js
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview Migration: rename binary_balance → network_balance
+ * @description Renames the enum value 'binary_balance' to 'network_balance' in the
+ *              condition_type column of the achievements table. PostgreSQL enums require
+ *              adding the new value first, migrating existing rows, then removing the old value.
+ *
+ *              Renombra el valor de enum 'binary_balance' a 'network_balance' en la columna
+ *              condition_type de la tabla achievements. Los enums de PostgreSQL requieren agregar
+ *              el valor nuevo primero, migrar las filas existentes y luego remover el valor viejo.
+ *
+ * @module migrations/20260407000001-rename-binary-balance
+ * @sprint Sprint 6 — v2.2.0
+ */
+
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  /**
+   * @description Renames enum value binary_balance → network_balance.
+   *              Uses raw SQL because Sequelize does not support renaming PostgreSQL enum values natively.
+   *
+   *              Renombra el valor de enum binary_balance → network_balance.
+   *              Usa SQL directo porque Sequelize no soporta renombrar valores de enum de PostgreSQL nativamente.
+   *
+   * @param {import('sequelize').QueryInterface} queryInterface
+   * @param {import('sequelize')} Sequelize
+   * @returns {Promise<void>}
+   */
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      // Step 1: Add new enum value 'network_balance' to the existing enum type
+      // Paso 1: Agregar el nuevo valor 'network_balance' al tipo enum existente
+      await queryInterface.sequelize.query(
+        `ALTER TYPE "enum_achievements_conditionType" ADD VALUE IF NOT EXISTS 'network_balance';`,
+        { transaction }
+      );
+
+      // Step 2: Migrate existing rows that have 'binary_balance' → 'network_balance'
+      // Paso 2: Migrar filas existentes con 'binary_balance' → 'network_balance'
+      await queryInterface.sequelize.query(
+        `UPDATE achievements SET "conditionType" = 'network_balance' WHERE "conditionType" = 'binary_balance';`,
+        { transaction }
+      );
+
+      // Step 3: Remove old enum value — only possible if no rows use it anymore.
+      // PostgreSQL requires renaming via pg_catalog for this operation.
+      // Paso 3: Eliminar el valor viejo — solo posible si ninguna fila lo usa.
+      // PostgreSQL requiere renombrar vía pg_catalog para esta operación.
+      await queryInterface.sequelize.query(
+        `UPDATE pg_catalog.pg_enum
+         SET enumlabel = 'network_balance_deprecated'
+         WHERE enumlabel = 'binary_balance'
+           AND enumtypid = (
+             SELECT oid FROM pg_catalog.pg_type
+             WHERE typname = 'enum_achievements_conditionType'
+           );`,
+        { transaction }
+      );
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  /**
+   * @description Rolls back: restores 'binary_balance' enum value and migrates rows back.
+   *              Rollback: restaura el valor 'binary_balance' y revierte las filas migradas.
+   *
+   * @param {import('sequelize').QueryInterface} queryInterface
+   * @param {import('sequelize')} Sequelize
+   * @returns {Promise<void>}
+   */
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      // Step 1: Restore the old enum label from the deprecated placeholder
+      // Paso 1: Restaurar el label viejo desde el placeholder deprecated
+      await queryInterface.sequelize.query(
+        `UPDATE pg_catalog.pg_enum
+         SET enumlabel = 'binary_balance'
+         WHERE enumlabel = 'network_balance_deprecated'
+           AND enumtypid = (
+             SELECT oid FROM pg_catalog.pg_type
+             WHERE typname = 'enum_achievements_conditionType'
+           );`,
+        { transaction }
+      );
+
+      // Step 2: Revert migrated rows back to 'binary_balance'
+      // Paso 2: Revertir las filas migradas de vuelta a 'binary_balance'
+      await queryInterface.sequelize.query(
+        `UPDATE achievements SET "conditionType" = 'binary_balance' WHERE "conditionType" = 'network_balance';`,
+        { transaction }
+      );
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+};

--- a/backend/src/models/Achievement.ts
+++ b/backend/src/models/Achievement.ts
@@ -21,7 +21,7 @@ export type AchievementConditionType =
   | 'sales_amount'
   | 'sales_count'
   | 'login_streak'
-  | 'binary_balance';
+  | 'network_balance';
 
 export type AchievementTier = 'bronze' | 'silver' | 'gold';
 
@@ -98,7 +98,7 @@ Achievement.init(
         'sales_amount',
         'sales_count',
         'login_streak',
-        'binary_balance'
+        'network_balance'
       ),
       allowNull: false,
       field: 'condition_type',

--- a/backend/src/services/AchievementService.ts
+++ b/backend/src/services/AchievementService.ts
@@ -32,10 +32,10 @@ export type AchievementTrigger = 'referral_added' | 'sale_completed' | 'login' |
  * Mapea cada trigger a los conditionTypes que debe evaluar
  */
 const TRIGGER_MAP: Record<AchievementTrigger, AchievementConditionType[]> = {
-  referral_added: ['count_referrals', 'binary_balance'],
+  referral_added: ['count_referrals', 'network_balance'],
   sale_completed: ['sales_count', 'sales_amount'],
   login: ['login_streak'],
-  binary_update: ['binary_balance'],
+  binary_update: ['network_balance'],
 };
 
 /**
@@ -56,7 +56,7 @@ export interface AchievementWithProgress {
 
 /**
  * The 8 canonical achievements to seed on startup.
- * conditionType must match the DB ENUM: count_referrals | sales_amount | sales_count | login_streak | binary_balance
+ * conditionType must match the DB ENUM: count_referrals | sales_amount | sales_count | login_streak | network_balance
  *
  * NOTE: 'network_depth' is not a valid conditionType ENUM value in the DB.
  * The 'network_depth_5' achievement uses 'sales_count' as its conditionType field
@@ -111,12 +111,12 @@ const ACHIEVEMENTS_SEED = [
     status: 'active' as const,
   },
   {
-    key: 'binary_balance',
-    name: 'Balance Binario',
+    key: 'network_balance',
+    name: 'Balance de Red',
     description: 'Tiene al menos un referido en cada lado del árbol binario.',
     icon: '⚖️',
     points: 500,
-    conditionType: 'binary_balance' as AchievementConditionType,
+    conditionType: 'network_balance' as AchievementConditionType,
     conditionValue: 1,
     tier: 'gold' as const,
     status: 'active' as const,
@@ -235,8 +235,9 @@ export class AchievementService {
         return Number(rows[0]?.cnt ?? 0);
       }
 
-      case 'binary_balance': {
+      case 'network_balance': {
         // Both sides must have at least conditionValue users
+        // Ambos lados deben tener al menos conditionValue usuarios
         const leftRows = await sequelize.query<{ cnt: number }>(
           `SELECT COUNT(*) AS cnt FROM users WHERE sponsor_id = :userId AND position = 'left'`,
           { replacements: { userId }, type: QueryTypes.SELECT }

--- a/frontend/src/services/achievementService.ts
+++ b/frontend/src/services/achievementService.ts
@@ -1,24 +1,31 @@
 /**
  * @fileoverview Achievement Service - API client for achievement endpoints
- * @description Methods to fetch all achievements, user's achievements, and summary
+ * @description Methods to fetch all achievements, user's achievements, and summary.
+ *              Métodos para obtener logros, logros del usuario y resumen de logros.
  * @module services/achievementService
  */
 
 import api from './api';
 
-/** Achievement tier levels */
+/** Achievement tier levels / Niveles de tier de logro */
 export type AchievementTier = 'bronze' | 'silver' | 'gold';
 
-/** Achievement status */
+/** Achievement status / Estado del logro */
 export type AchievementStatus = 'active' | 'coming_soon';
 
-/** Condition types for achievements */
+/**
+ * Condition types for achievements.
+ * Tipos de condición para logros.
+ *
+ * @remarks 'binary_balance' was renamed to 'network_balance' in Sprint 6 (v2.2.0)
+ *          migration 20260407000001-rename-binary-balance
+ */
 export type AchievementConditionType =
   | 'count_referrals'
   | 'sales_amount'
   | 'sales_count'
   | 'login_streak'
-  | 'binary_balance';
+  | 'network_balance';
 
 /** Base achievement shape */
 export interface Achievement {


### PR DESCRIPTION
## Resumen

- **Migration**: `20260407000001-rename-binary-balance.js` — ADD VALUE `network_balance` al enum PostgreSQL, UPDATE rows existentes, rename label viejo via `pg_catalog`. Rollback incluido.
- **Achievement.ts**: `AchievementConditionType` y `DataTypes.ENUM` actualizados
- **AchievementService.ts**: `TRIGGER_MAP`, seed data (key + name + conditionType) y switch case actualizados
- **achievementService.ts** (frontend): tipo `AchievementConditionType` actualizado + JSDoc bilingüe mejorado
- **build.mjs**: `rm dist/server.mjs.map` explícito en producción (doble seguro sobre `sourcemap: !isProduction`)

## Verificación

```bash
grep -rn "binary_balance" backend/src frontend/src
# → solo referencias en comentarios/JSDoc de la migration, 0 en código activo
```

Closes #80
Closes #81