### PR TITLE
feat(bot): Nexo Bot — Properties & Tours Flows (Sprint 6 Fase 5)

### DIFF
--- a/bot/src/app.ts
+++ b/bot/src/app.ts
@@ -17,6 +17,8 @@ import { networkFlow } from './flows/network.flow.js';
 import { supportFlow } from './flows/support.flow.js';
 import { scheduleFlow } from './flows/schedule.flow.js';
 import { handoffFlow } from './flows/handoff.flow.js';
+import { propertiesFlow } from './flows/properties.flow.js';
+import { toursFlow } from './flows/tours.flow.js';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -65,6 +67,8 @@ const flow = createFlow([
   scheduleFlow,
   handoffFlow,
   commissionsKeywordFlow,
+  propertiesFlow,
+  toursFlow,
 ]);
 
 // ── Bootstrap ─────────────────────────────────────────────────────────────────

--- a/bot/src/flows/properties.flow.ts
+++ b/bot/src/flows/properties.flow.ts
@@ -1,0 +1,115 @@
+import { addKeyword } from '@builderbot/bot';
+import { mlmApi, type BotProperty } from '../services/mlm-api.service.js';
+
+/**
+ * Keywords that trigger the properties flow in Spanish and English.
+ * Palabras clave que activan el flujo de propiedades en español e inglés.
+ */
+const PROPERTIES_KEYWORDS: [string, ...string[]] = [
+  'propiedades',
+  'ver propiedades',
+  'buscar propiedades',
+  'inmuebles',
+  'alquileres',
+  'casas',
+  'departamentos',
+  'properties',
+  'real estate',
+  'houses',
+  'apartments',
+];
+
+/**
+ * Formats a list of properties into a human-readable WhatsApp message.
+ * Formatea una lista de propiedades en un mensaje legible para WhatsApp.
+ *
+ * @param lang - Language code ('es' | 'en') / Código de idioma ('es' | 'en')
+ * @param properties - Array of simplified property objects / Array de propiedades simplificadas
+ * @returns Formatted message string / Cadena de mensaje formateada
+ */
+function formatPropertiesMessage(lang: string, properties: BotProperty[]): string {
+  const isEs = lang !== 'en';
+
+  if (properties.length === 0) {
+    return isEs
+      ? '🏠 No hay propiedades disponibles en este momento.\n\nVisitá la plataforma para más información:\n🌐 https://nexoreal.com/properties'
+      : '🏠 No properties available at the moment.\n\nVisit the platform for more info:\n🌐 https://nexoreal.com/properties';
+  }
+
+  const header = isEs
+    ? `🏠 *Propiedades Disponibles — Nexo Real*\n\nAquí tenés las últimas ${properties.length} opciones:\n`
+    : `🏠 *Available Properties — Nexo Real*\n\nHere are the latest ${properties.length} options:\n`;
+
+  const lines = properties.map((p, i) => {
+    const typeLabel = isEs
+      ? p.type === 'rental'
+        ? 'Alquiler'
+        : p.type === 'sale'
+          ? 'Venta'
+          : 'Gestión'
+      : p.type === 'rental'
+        ? 'Rental'
+        : p.type === 'sale'
+          ? 'Sale'
+          : 'Management';
+
+    const price = p.price.toLocaleString('es-AR', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
+
+    const details: string[] = [];
+    if (p.bedrooms != null) details.push(isEs ? `${p.bedrooms} hab.` : `${p.bedrooms} bed.`);
+    if (p.bathrooms != null) details.push(isEs ? `${p.bathrooms} baños` : `${p.bathrooms} bath.`);
+    if (p.areaM2 != null) details.push(`${p.areaM2} m²`);
+
+    const detailStr = details.length > 0 ? ` | ${details.join(' · ')}` : '';
+
+    return (
+      `*${i + 1}. ${p.title}*\n` +
+      `📍 ${p.city} — ${typeLabel}\n` +
+      `💰 ${p.currency} ${price}${detailStr}`
+    );
+  });
+
+  const footer = isEs
+    ? `\n\n🔍 Ver todas las propiedades:\n🌐 https://nexoreal.com/properties`
+    : `\n\n🔍 View all properties:\n🌐 https://nexoreal.com/properties`;
+
+  return header + lines.join('\n\n') + footer;
+}
+
+/**
+ * Properties flow — responds with a list of up to 5 active properties.
+ * Flujo de propiedades — responde con una lista de hasta 5 propiedades activas.
+ *
+ * Triggered by keywords like "propiedades", "alquileres", "real estate".
+ * Activado por palabras clave como "propiedades", "alquileres", "real estate".
+ *
+ * Flow steps / Pasos del flujo:
+ * 1. Read user language from state (set by welcomeFlow) / Lee el idioma del state (definido por welcomeFlow)
+ * 2. Call mlmApi.searchProperties({ limit: 5 }) / Llama a mlmApi.searchProperties({ limit: 5 })
+ * 3. Format and send the response / Formatea y envía la respuesta
+ */
+export const propertiesFlow = addKeyword(PROPERTIES_KEYWORDS).addAction(
+  async (_ctx: any, { state, flowDynamic }: any) => {
+    const lang: string = state.get('lang') ?? 'es';
+
+    let properties: BotProperty[] = [];
+
+    try {
+      properties = await mlmApi.searchProperties({ limit: 5 });
+    } catch {
+      const errorMsg =
+        lang !== 'en'
+          ? '⚠️ No pude obtener las propiedades en este momento. Intentá de nuevo en unos minutos.'
+          : '⚠️ Could not fetch properties right now. Please try again in a few minutes.';
+
+      await flowDynamic([{ body: errorMsg }]);
+      return;
+    }
+
+    const message = formatPropertiesMessage(lang, properties);
+    await flowDynamic([{ body: message }]);
+  }
+);

--- a/bot/src/flows/tours.flow.ts
+++ b/bot/src/flows/tours.flow.ts
@@ -1,0 +1,104 @@
+import { addKeyword } from '@builderbot/bot';
+import { mlmApi, type BotTour } from '../services/mlm-api.service.js';
+
+/**
+ * Keywords that trigger the tours flow in Spanish and English.
+ * Palabras clave que activan el flujo de tours en español e inglés.
+ */
+const TOURS_KEYWORDS: [string, ...string[]] = [
+  'tours',
+  'tours disponibles',
+  'ver tours',
+  'buscar tours',
+  'paquetes',
+  'paquetes turísticos',
+  'viajes',
+  'excursiones',
+  'travel packages',
+  'available tours',
+  'tour packages',
+];
+
+/**
+ * Formats a list of tour packages into a human-readable WhatsApp message.
+ * Formatea una lista de paquetes turísticos en un mensaje legible para WhatsApp.
+ *
+ * @param lang - Language code ('es' | 'en') / Código de idioma ('es' | 'en')
+ * @param tours - Array of simplified tour objects / Array de tours simplificados
+ * @returns Formatted message string / Cadena de mensaje formateada
+ */
+function formatToursMessage(lang: string, tours: BotTour[]): string {
+  const isEs = lang !== 'en';
+
+  if (tours.length === 0) {
+    return isEs
+      ? '✈️ No hay tours disponibles en este momento.\n\nVisitá la plataforma para más información:\n🌐 https://nexoreal.com/tours'
+      : '✈️ No tours available at the moment.\n\nVisit the platform for more info:\n🌐 https://nexoreal.com/tours';
+  }
+
+  const header = isEs
+    ? `✈️ *Tours Disponibles — Nexo Real*\n\nAquí tenés los últimos ${tours.length} paquetes:\n`
+    : `✈️ *Available Tours — Nexo Real*\n\nHere are the latest ${tours.length} packages:\n`;
+
+  const lines = tours.map((t, i) => {
+    const price = t.price.toLocaleString('es-AR', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    });
+
+    const durationLabel = isEs
+      ? `${t.durationDays} día${t.durationDays !== 1 ? 's' : ''}`
+      : `${t.durationDays} day${t.durationDays !== 1 ? 's' : ''}`;
+
+    const capacityLabel = isEs
+      ? `hasta ${t.maxCapacity} personas`
+      : `up to ${t.maxCapacity} people`;
+
+    return (
+      `*${i + 1}. ${t.title}*\n` +
+      `📍 ${t.destination} — ${t.type}\n` +
+      `💰 ${t.currency} ${price} | 📅 ${durationLabel} | 👥 ${capacityLabel}`
+    );
+  });
+
+  const footer = isEs
+    ? `\n\n🔍 Ver todos los tours:\n🌐 https://nexoreal.com/tours`
+    : `\n\n🔍 View all tours:\n🌐 https://nexoreal.com/tours`;
+
+  return header + lines.join('\n\n') + footer;
+}
+
+/**
+ * Tours flow — responds with a list of up to 5 active tour packages.
+ * Flujo de tours — responde con una lista de hasta 5 paquetes turísticos activos.
+ *
+ * Triggered by keywords like "tours", "paquetes", "viajes", "travel packages".
+ * Activado por palabras clave como "tours", "paquetes", "viajes", "travel packages".
+ *
+ * Flow steps / Pasos del flujo:
+ * 1. Read user language from state (set by welcomeFlow) / Lee el idioma del state (definido por welcomeFlow)
+ * 2. Call mlmApi.searchTours({ limit: 5 }) / Llama a mlmApi.searchTours({ limit: 5 })
+ * 3. Format and send the response / Formatea y envía la respuesta
+ */
+export const toursFlow = addKeyword(TOURS_KEYWORDS).addAction(
+  async (_ctx: any, { state, flowDynamic }: any) => {
+    const lang: string = state.get('lang') ?? 'es';
+
+    let tours: BotTour[] = [];
+
+    try {
+      tours = await mlmApi.searchTours({ limit: 5 });
+    } catch {
+      const errorMsg =
+        lang !== 'en'
+          ? '⚠️ No pude obtener los tours en este momento. Intentá de nuevo en unos minutos.'
+          : '⚠️ Could not fetch tours right now. Please try again in a few minutes.';
+
+      await flowDynamic([{ body: errorMsg }]);
+      return;
+    }
+
+    const message = formatToursMessage(lang, tours);
+    await flowDynamic([{ body: message }]);
+  }
+);


### PR DESCRIPTION
## Summary

Sprint 6 — Fase 5: Dos nuevos flows para el Nexo Bot que permiten consultar propiedades y tours por WhatsApp.

## Changes

### `bot/src/flows/properties.flow.ts` *(nuevo)*
- `PROPERTIES_KEYWORDS`: 11 keywords en ES/EN ("propiedades", "alquileres", "real estate", etc.)
- `propertiesFlow`: llama `mlmApi.searchProperties({ limit: 5 })`, lee idioma del state
- `formatPropertiesMessage(lang, properties)`: formato WhatsApp con precio, ciudad, tipo, habitaciones, m²
- Manejo de array vacío y guard de error con mensaje amigable en ES/EN

### `bot/src/flows/tours.flow.ts` *(nuevo)*
- `TOURS_KEYWORDS`: 11 keywords en ES/EN ("tours", "paquetes", "viajes", "travel packages", etc.)
- `toursFlow`: llama `mlmApi.searchTours({ limit: 5 })`, lee idioma del state
- `formatToursMessage(lang, tours)`: formato WhatsApp con precio, destino, duración, capacidad
- Manejo de array vacío y guard de error con mensaje amigable en ES/EN

### `bot/src/app.ts`
- Importa `propertiesFlow` y `toursFlow`
- Los registra en `createFlow([...])`

## Related Issues

Closes #85

## Checklist

- [x] JSDoc bilingüe en todos los archivos
- [x] `tsc --noEmit` sin errores
- [x] Patrón consistente con `balance.flow.ts`
- [x] Idioma leído del state (set por welcomeFlow)
- [x] Sin breaking changes