### PR TITLE
docs: fase 6 - swagger v2.2.0, BotProperty/BotTour schemas, ROADMAP y CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ Todos los cambios notables de este proyecto serán documentados en este archivo.
 
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/).
 
+## [2.2.0] - 2026-04-07
+
+### Added
+
+- **Sprint 6: Admin Dashboard CRUD — Real Estate & Tourism**
+  - `AdminPropertiesPage` — tabla paginada con filtros por tipo, estado y ciudad; modal CRUD; toggle activo/inactivo
+  - `AdminToursPage` — tabla paginada con filtros por tipo, estado y destino; modal CRUD; toggle activo/inactivo
+  - `AdminReservationsPage` — tabla con filtros por estado/tipo; confirm/cancel rápido; modal de notas y estado detallado
+  - 12 métodos en `adminService` (`api.ts`): `getAdminProperties`, `createProperty`, `updateProperty`, `deleteProperty`, `getAdminTours`, `createTour`, `updateTour`, `deleteTour`, `getAdminReservations`, `updateReservationStatus`, `confirmReservation`, `cancelReservation`
+  - 3 rutas lazy `<AdminRoute>` en `App.tsx`: `/admin/properties`, `/admin/tours`, `/admin/reservations`
+
+- **Sprint 6: Nexo Bot — Properties & Tours Flows**
+  - `properties.flow.ts` — 11 keywords ES/EN, llama `mlmApi.searchProperties({ limit: 5 })`, formatea con precio/ciudad/tipo/habitaciones/m², manejo de array vacío y errores
+  - `tours.flow.ts` — 11 keywords ES/EN, llama `mlmApi.searchTours({ limit: 5 })`, formatea con precio/destino/duración/capacidad, manejo de array vacío y errores
+  - `bot/src/app.ts` — `propertiesFlow` y `toursFlow` registrados en `createFlow([...])`
+  - Idioma leído del state (definido por `welcomeFlow`) para respuestas bilingües
+
+- **Sprint 6: Swagger / OpenAPI v2.2.0**
+  - Versión actualizada a `2.2.0` en `swagger.ts`
+  - Schemas globales `BotProperty` y `BotTour` agregados en `components/schemas`
+  - Security scheme `botSecret` (apiKey, header `X-Bot-Secret`)
+  - Endpoints documentados con `@swagger`: `GET /api/bot/properties` y `GET /api/bot/tours` (tag: bot)
+  - Tag `bot` agregado en lista de tags de Swagger UI
+
+### Changed
+
+- **`binary_balance` → `network_balance`** (Sprint 6 Fase 1, PR #89): campo renombrado en modelo `User`, migración Sequelize `20260407000000-rename-binary-balance.js`, eliminadas todas las referencias en frontend y backend
+- **Build hardening** (Sprint 6 Fase 1, PR #89): `build.mjs` actualizado para producción — elimina archivos `.map` con `--sourcemap false`, log de tamaños post-build
+- **i18n cleanup** (Sprint 6 Fase 2, PR #90): eliminadas 8 claves huérfanas en `es.json` y `en.json`, eliminado componente `DashboardStreaming` que no existía
+
+### Security
+
+- **CodeQL #39 & #40** (Sprint 6 Fase 9, PR #88): `req.files` cast normalizado a `Array.isArray(req.files) ? req.files : Object.values(req.files ?? {}).flat()` en `PropertyController.ts` y `TourPackageController.ts` — previene CWE-843 type confusion
+
+---
+
 ## [2.1.0] - 2026-04-07
 
 ### Added

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -4,6 +4,7 @@ import swaggerJsdoc from 'swagger-jsdoc';
  * Swagger/OpenAPI Configuration for Nexo Real API
  * Configuración Swagger/OpenAPI para la API de Nexo Real
  *
+ * v2.2.0: Sprint 6 - Admin Dashboard CRUD, Nexo Bot flows, i18n cleanup, binary_balance migration, build hardening
  * v2.1.0: Sprint 5 - Real Estate Frontend, Tourism Frontend, Reservation Wizard, Security fixes
  * v2.0.0: Sprint 4 - Nexo Bot (WhatsApp AI), n8n Automation, Frontend tests 210+, Gamification
  * v1.10.0: Sprint 2 - Gift Cards, Abandoned Cart Recovery, Email Automation
@@ -20,7 +21,7 @@ const options: swaggerJsdoc.Options = {
     openapi: '3.0.0',
     info: {
       title: 'Nexo Real API',
-      version: '2.1.0',
+      version: '2.2.0',
       description: `
 ## API REST para plataforma MLM de Afiliaciones Binarias
 
@@ -40,6 +41,7 @@ Esta API usa JWT Bearer tokens. Incluye el token en el header:
 | 429 | Rate limit excedido / Rate Limit Exceeded |
 
 ### Versiones / Versions
+- **v2.2.0** (2026-04-07): Sprint 6 - Admin Dashboard CRUD, Nexo Bot flows, i18n cleanup, network_balance migration, build hardening
 - **v2.1.0** (2026-04-07): Sprint 5 - Real Estate Frontend, Tourism Frontend, Reservation Wizard, Security fixes (CodeQL CWE-843, Dependabot file-type)
 - **v2.0.0** (2026-04-06): Sprint 4 - Nexo Bot (WhatsApp AI), n8n Automation, Frontend tests 210+, Gamification
 - **v1.10.0** (2026-04-04): Sprint 2 - Gift Cards, Abandoned Cart Recovery, Email Automation
@@ -69,6 +71,13 @@ Esta API usa JWT Bearer tokens. Incluye el token en el header:
           scheme: 'bearer',
           bearerFormat: 'JWT',
           description: 'JWT token obtained from /auth/login or /auth/register',
+        },
+        botSecret: {
+          type: 'apiKey',
+          in: 'header',
+          name: 'X-Bot-Secret',
+          description:
+            'Bot secret key from BOT_SECRET env variable — used by Nexo Bot to authenticate / Clave secreta del bot desde la variable BOT_SECRET — usada por el Nexo Bot para autenticarse',
         },
       },
       schemas: {
@@ -2276,6 +2285,85 @@ Esta API usa JWT Bearer tokens. Incluye el token en el header:
             createdAt: { type: 'string', format: 'date-time' },
           },
         },
+
+        // ============================================================
+        // BOT SCHEMAS (Sprint 6)
+        // ============================================================
+        BotProperty: {
+          type: 'object',
+          description:
+            'Simplified property for Nexo Bot responses / Propiedad simplificada para respuestas del Nexo Bot',
+          properties: {
+            id: { type: 'string', format: 'uuid', description: 'Property ID / ID de la propiedad' },
+            type: {
+              type: 'string',
+              enum: ['rental', 'sale', 'management'],
+              description: 'Property type / Tipo de propiedad',
+            },
+            title: { type: 'string', description: 'Listing title / Título del listado' },
+            price: { type: 'number', description: 'Listing price / Precio del listado' },
+            currency: {
+              type: 'string',
+              example: 'USD',
+              description: 'Price currency / Moneda del precio',
+            },
+            city: {
+              type: 'string',
+              description: 'City where the property is located / Ciudad donde está la propiedad',
+            },
+            bedrooms: {
+              type: 'integer',
+              nullable: true,
+              description: 'Number of bedrooms / Número de habitaciones',
+            },
+            bathrooms: {
+              type: 'integer',
+              nullable: true,
+              description: 'Number of bathrooms / Número de baños',
+            },
+            areaM2: {
+              type: 'number',
+              nullable: true,
+              description: 'Area in square meters / Área en metros cuadrados',
+            },
+          },
+        },
+
+        BotTour: {
+          type: 'object',
+          description:
+            'Simplified tour package for Nexo Bot responses / Paquete turístico simplificado para respuestas del Nexo Bot',
+          properties: {
+            id: {
+              type: 'string',
+              format: 'uuid',
+              description: 'Tour package ID / ID del paquete turístico',
+            },
+            type: {
+              type: 'string',
+              description: 'Tour type (adventure, cultural, etc.) / Tipo de tour',
+            },
+            title: { type: 'string', description: 'Package title / Título del paquete' },
+            destination: {
+              type: 'string',
+              description: 'Main destination / Destino principal',
+            },
+            price: { type: 'number', description: 'Package price / Precio del paquete' },
+            currency: {
+              type: 'string',
+              example: 'USD',
+              description: 'Price currency / Moneda del precio',
+            },
+            durationDays: {
+              type: 'integer',
+              description: 'Duration in days / Duración en días',
+            },
+            maxCapacity: {
+              type: 'integer',
+              description: 'Maximum passenger capacity / Capacidad máxima de pasajeros',
+            },
+          },
+        },
       },
     },
 
@@ -2338,6 +2426,11 @@ Esta API usa JWT Bearer tokens. Incluye el token en el header:
         name: 'email-campaigns',
         description:
           'Campañas de Email / Email Campaigns - Envío, programación, estadísticas, logs (Sprint 2)',
+      },
+      {
+        name: 'bot',
+        description:
+          'Nexo Bot API / API del Nexo Bot - Endpoints para el bot de WhatsApp: propiedades y tours (Sprint 6)',
       },
     ],
   },

--- a/backend/src/controllers/BotController.ts
+++ b/backend/src/controllers/BotController.ts
@@ -183,6 +183,60 @@ export async function getRecentCommissions(req: Request, res: Response): Promise
 // ── GET /api/bot/properties ───────────────────────────────────────────────────
 
 /**
+ * @swagger
+ * /bot/properties:
+ *   get:
+ *     summary: Search available properties (Bot API)
+ *     description: |
+ *       Returns a simplified list of available properties optimized for WhatsApp bot prompts.
+ *       Requires `X-Bot-Secret` header with the value of `BOT_SECRET` env variable.
+ *
+ *       Retorna una lista simplificada de propiedades disponibles optimizada para prompts del bot de WhatsApp.
+ *       Requiere el header `X-Bot-Secret` con el valor de la variable de entorno `BOT_SECRET`.
+ *     tags: [bot]
+ *     security:
+ *       - botSecret: []
+ *     parameters:
+ *       - in: query
+ *         name: city
+ *         schema: { type: string }
+ *         description: Filter by city / Filtrar por ciudad
+ *       - in: query
+ *         name: type
+ *         schema:
+ *           type: string
+ *           enum: [rental, sale, management]
+ *         description: Filter by property type / Filtrar por tipo de propiedad
+ *       - in: query
+ *         name: maxPrice
+ *         schema: { type: number }
+ *         description: Maximum price filter / Filtro de precio máximo
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, default: 5, maximum: 10 }
+ *         description: Max results (default 5, cap 10) / Máximo resultados (default 5, cap 10)
+ *     responses:
+ *       200:
+ *         description: List of available properties / Lista de propiedades disponibles
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 properties:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/BotProperty'
+ *                 total:
+ *                   type: integer
+ *                   description: Number of results returned / Número de resultados retornados
+ *       401:
+ *         description: Missing or invalid BOT_SECRET / BOT_SECRET ausente o inválido
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
+
+/**
  * Search available properties and return a simplified format optimized for bot prompts.
  * Busca propiedades disponibles y retorna un formato simplificado para prompts del bot.
  *
@@ -237,6 +291,58 @@ export const getBotProperties = async (
 };
 
 // ── GET /api/bot/tours ────────────────────────────────────────────────────────
+
+/**
+ * @swagger
+ * /bot/tours:
+ *   get:
+ *     summary: Search active tour packages (Bot API)
+ *     description: |
+ *       Returns a simplified list of active tour packages optimized for WhatsApp bot prompts.
+ *       Requires `X-Bot-Secret` header with the value of `BOT_SECRET` env variable.
+ *
+ *       Retorna una lista simplificada de paquetes turísticos activos optimizada para prompts del bot de WhatsApp.
+ *       Requiere el header `X-Bot-Secret` con el valor de la variable de entorno `BOT_SECRET`.
+ *     tags: [bot]
+ *     security:
+ *       - botSecret: []
+ *     parameters:
+ *       - in: query
+ *         name: destination
+ *         schema: { type: string }
+ *         description: Filter by destination / Filtrar por destino
+ *       - in: query
+ *         name: type
+ *         schema: { type: string }
+ *         description: Filter by tour type / Filtrar por tipo de tour
+ *       - in: query
+ *         name: maxPrice
+ *         schema: { type: number }
+ *         description: Maximum price filter / Filtro de precio máximo
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, default: 5, maximum: 10 }
+ *         description: Max results (default 5, cap 10) / Máximo resultados (default 5, cap 10)
+ *     responses:
+ *       200:
+ *         description: List of active tour packages / Lista de paquetes turísticos activos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 tours:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/BotTour'
+ *                 total:
+ *                   type: integer
+ *                   description: Number of results returned / Número de resultados retornados
+ *       401:
+ *         description: Missing or invalid BOT_SECRET / BOT_SECRET ausente o inválido
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
 
 /**
  * Search active tour packages and return a simplified format optimized for bot prompts.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 > Hoja de ruta completa para la plataforma **Nexo Real** — Servicios Inmobiliarios, Turismo/Hospitalidad y Afiliaciones.  
 > _"Conectamos tu negocio con el mundo."_
 
-**Versión actual**: v2.1.0 — Sprint 5 Completado ✅  
+**Versión actual**: v2.2.0 — Sprint 6 Completado ✅  
 **Última actualización**: 2026-04-07  
 **Estado**: Activo - Desarrollo intensivo  
 **Meta**: v3.0.0 — expansión México + Argentina
@@ -12,36 +12,56 @@
 
 ## 📊 Estado Actual del Proyecto
 
-### ✅ Lo que YA está implementado (v2.1.0)
+### ✅ Lo que YA está implementado (v2.2.0)
 
-| Área                     | Funcionalidad                                         | Estado |
-| ------------------------ | ----------------------------------------------------- | ------ |
-| **Auth**                 | JWT, 2FA, Roles                                       | ✅     |
-| **MLM**                  | Binario con Closure Table                             | ✅     |
-| **Comisiones**           | 5 niveles configurables                               | ✅     |
-| **E-commerce**           | Productos streaming (MVP ejemplo)                     | ✅     |
-| **Wallet**               | Balance, transacciones, retiros                       | ✅     |
-| **CRM**                  | Leads, Tasks, Communications                          | ✅     |
-| **Notificaciones**       | Email (Brevo), Push (Web)                             | ✅     |
-| **PWA**                  | Offline, instalable, shortcuts                        | ✅     |
-| **Landing Pages**        | Productos con SEO                                     | ✅     |
-| **Dashboard**            | Stats, tree view, perfil                              | ✅     |
-| **i18n**                 | Español + Inglés                                      | ✅     |
-| **Pagos**                | PayPal + MercadoPago                                  | ✅     |
-| **Gamificación**         | Leaderboards + Achievements                           | ✅     |
-| **Gift Cards**           | CRUD, redeem, balance, admin                          | ✅     |
-| **Cart Recovery**        | Persistence, tokens, emails                           | ✅     |
-| **Email Auto**           | Templates, campaigns, scheduling                      | ✅     |
-| **Security**             | SSRF, XSS, pino-http, Docker hardening                | ✅     |
-| **Products**             | Generic products + inventory + categories             | ✅     |
-| **Marketplace**          | Multi-vendor, commission split 3-way                  | ✅     |
-| **Delivery**             | Shipping addresses, providers, tracking               | ✅     |
-| **Contracts**            | Affiliate contracts MVP con hash/IP                   | ✅     |
-| **Tests**                | 307 tests (integration + E2E)                         | ✅     |
-| **Real Estate Frontend** | PropertiesPage, PropertyDetailPage, filtros, galería  | ✅     |
-| **Tourism Frontend**     | ToursPage, TourDetailPage, itinerario, disponibilidad | ✅     |
-| **Reservation Wizard**   | Wizard 3 pasos + MisReservasPage + reservationStore   | ✅     |
-| **Tests**                | 307+ tests (integration + E2E + Vitest frontend)      | ✅     |
+| Área                     | Funcionalidad                                                | Estado |
+| ------------------------ | ------------------------------------------------------------ | ------ |
+| **Auth**                 | JWT, 2FA, Roles                                              | ✅     |
+| **MLM**                  | Binario con Closure Table                                    | ✅     |
+| **Comisiones**           | 5 niveles configurables                                      | ✅     |
+| **E-commerce**           | Productos streaming (MVP ejemplo)                            | ✅     |
+| **Wallet**               | Balance, transacciones, retiros                              | ✅     |
+| **CRM**                  | Leads, Tasks, Communications                                 | ✅     |
+| **Notificaciones**       | Email (Brevo), Push (Web)                                    | ✅     |
+| **PWA**                  | Offline, instalable, shortcuts                               | ✅     |
+| **Landing Pages**        | Productos con SEO                                            | ✅     |
+| **Dashboard**            | Stats, tree view, perfil                                     | ✅     |
+| **i18n**                 | Español + Inglés (sin claves huérfanas)                      | ✅     |
+| **Pagos**                | PayPal + MercadoPago                                         | ✅     |
+| **Gamificación**         | Leaderboards + Achievements                                  | ✅     |
+| **Gift Cards**           | CRUD, redeem, balance, admin                                 | ✅     |
+| **Cart Recovery**        | Persistence, tokens, emails                                  | ✅     |
+| **Email Auto**           | Templates, campaigns, scheduling                             | ✅     |
+| **Security**             | SSRF, XSS, pino-http, Docker hardening, CodeQL fixes         | ✅     |
+| **Products**             | Generic products + inventory + categories                    | ✅     |
+| **Marketplace**          | Multi-vendor, commission split 3-way                         | ✅     |
+| **Delivery**             | Shipping addresses, providers, tracking                      | ✅     |
+| **Contracts**            | Affiliate contracts MVP con hash/IP                          | ✅     |
+| **Real Estate Frontend** | PropertiesPage, PropertyDetailPage, filtros, galería         | ✅     |
+| **Tourism Frontend**     | ToursPage, TourDetailPage, itinerario, disponibilidad        | ✅     |
+| **Reservation Wizard**   | Wizard 3 pasos + MisReservasPage + reservationStore          | ✅     |
+| **Admin Dashboard CRUD** | AdminPropertiesPage + AdminToursPage + AdminReservationsPage | ✅     |
+| **Nexo Bot Flows**       | propertiesFlow + toursFlow (ES/EN, limit 5)                  | ✅     |
+| **network_balance**      | Migración `binary_balance` → `network_balance`               | ✅     |
+| **Build Hardening**      | Sin `.map` en producción, logs de tamaño                     | ✅     |
+| **Tests**                | 307+ tests (integration + E2E + Vitest frontend)             | ✅     |
+
+---
+
+## 🚀 Sprint 6 — v2.2.0 (Completado 2026-04-07)
+
+### Objetivos cumplidos
+
+| Fase   | Área                                       | Estado    |
+| ------ | ------------------------------------------ | --------- |
+| Fase 0 | Setup: Issues + ramas                      | ✅        |
+| Fase 9 | Security: CodeQL #39 #40 fix               | ✅ PR #88 |
+| Fase 1 | Migration + Build hardening                | ✅ PR #89 |
+| Fase 2 | i18n cleanup + DashboardStreaming removal  | ✅ PR #90 |
+| Fase 3 | Backend bot endpoints (incluido en PR #89) | ✅        |
+| Fase 4 | Admin Dashboard CRUD frontend              | ✅ PR #91 |
+| Fase 5 | Nexo Bot flows (properties + tours)        | ✅ PR #92 |
+| Fase 6 | Documentación (Swagger v2.2.0 + CHANGELOG) | ✅        |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Swagger**: versión bumpeada a `2.2.0`, schemas `BotProperty` y `BotTour` agregados, security scheme `botSecret` (`apiKey` en header `X-Bot-Secret`), tag `bot` registrado
- **BotController**: `@swagger` JSDoc completo en `getBotProperties` y `getBotTours` (parámetros, security, responses 200/401/500)
- **ROADMAP**: versión actualizada a `v2.2.0`, tabla de features implementadas actualizada, sección Sprint 6 con tabla de fases
- **CHANGELOG**: sección `[2.2.0] - 2026-04-07` con Added/Changed/Security

## Related Issue

Closes #85

## Type of Change

- [x] Documentation