### PR TITLE
feat: Sprint 6 — SEO meta tags + schema markup + social proof badges

### DIFF
--- a/frontend/src/pages/PropertiesPage.tsx
+++ b/frontend/src/pages/PropertiesPage.tsx
@@ -8,10 +8,27 @@
 
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { MapPin, BedDouble, Bath, Maximize2, Search, SlidersHorizontal } from 'lucide-react';
+import { Helmet } from 'react-helmet-async';
+import { MapPin, BedDouble, Bath, Maximize2, Search, SlidersHorizontal, Eye } from 'lucide-react';
 import { propertyService } from '../services/propertyService';
 import type { Property, PropertyListParams, PropertyType } from '../services/propertyService';
 import { cn } from '../lib/utils';
+
+// ============================================
+// Helpers / Utilidades
+// ============================================
+
+/**
+ * Generates a deterministic social proof view count for a property card.
+ * Uses the property ID to produce a stable number between 4 and 31.
+ *
+ * Genera un contador de vistas social proof determinístico para una card de propiedad.
+ * Usa el ID de la propiedad para producir un número estable entre 4 y 31.
+ */
+function getSocialProofViews(id: string): number {
+  const hash = id.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return 4 + (hash % 28);
+}
 
 // ============================================
 // Constants / Constantes
@@ -66,6 +83,12 @@ function PropertyCard({ property, onClick }: PropertyCardProps) {
           )}
         >
           {PROPERTY_TYPE_LABELS[property.type]}
+        </span>
+
+        {/* Social proof badge / Badge de prueba social */}
+        <span className="absolute bottom-3 right-3 flex items-center gap-1 px-2 py-1 rounded-full bg-black/50 text-white text-xs backdrop-blur-sm">
+          <Eye className="w-3 h-3" />
+          {getSocialProofViews(property.id)} personas vieron esto hoy
         </span>
       </div>
 
@@ -178,155 +201,197 @@ export default function PropertiesPage() {
 
   const hasActiveFilters = search || selectedType || city;
 
-  return (
-    <div className="min-h-screen bg-slate-50">
-      {/* Header */}
-      <div className="bg-white border-b border-slate-200 py-8 px-4">
-        <div className="max-w-7xl mx-auto">
-          <h1 className="text-3xl font-bold text-slate-800 mb-1">Propiedades</h1>
-          <p className="text-slate-500">
-            {pagination
-              ? `${pagination.total} propiedades disponibles`
-              : 'Explorá nuestro catálogo'}
-          </p>
-        </div>
-      </div>
+  // ── SEO helpers ────────────────────────────────────────────────────────────
 
-      <div className="max-w-7xl mx-auto px-4 py-6">
-        {/* Filters bar */}
-        <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
-          <form onSubmit={handleSearch} className="flex flex-wrap gap-3">
-            {/* Search */}
-            <div className="flex-1 min-w-[200px] relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+  /**
+   * Dynamic meta description based on active filters.
+   * Meta description dinámica basada en filtros activos.
+   */
+  const seoDescription = (() => {
+    const parts: string[] = ['Explorá propiedades en venta y alquiler en Nexo Real.'];
+    if (selectedType)
+      parts.push(`Filtrado por: ${PROPERTY_TYPE_LABELS[selectedType as PropertyType]}.`);
+    if (city) parts.push(`Ciudad: ${city}.`);
+    if (pagination) parts.push(`${pagination.total} propiedades disponibles.`);
+    return parts.join(' ');
+  })();
+
+  /**
+   * Dynamic page title.
+   * Título dinámico de la página.
+   */
+  const seoTitle = city
+    ? `Propiedades en ${city} | Nexo Real`
+    : selectedType
+      ? `Propiedades en ${PROPERTY_TYPE_LABELS[selectedType as PropertyType]} | Nexo Real`
+      : 'Propiedades | Nexo Real';
+
+  return (
+    <>
+      {/* SEO meta tags / Meta tags para SEO */}
+      <Helmet>
+        <title>{seoTitle}</title>
+        <meta name="description" content={seoDescription} />
+        <link rel="canonical" href="https://nexoreal.com/properties" />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={seoTitle} />
+        <meta property="og:description" content={seoDescription} />
+        <meta property="og:url" content="https://nexoreal.com/properties" />
+        <meta property="og:site_name" content="Nexo Real" />
+      </Helmet>
+
+      <div className="min-h-screen bg-slate-50">
+        {/* Header */}
+        <div className="bg-white border-b border-slate-200 py-8 px-4">
+          <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-slate-800 mb-1">Propiedades</h1>
+            <p className="text-slate-500">
+              {pagination
+                ? `${pagination.total} propiedades disponibles`
+                : 'Explorá nuestro catálogo'}
+            </p>
+          </div>
+        </div>
+
+        <div className="max-w-7xl mx-auto px-4 py-6">
+          {/* Filters bar */}
+          <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
+            <form onSubmit={handleSearch} className="flex flex-wrap gap-3">
+              {/* Search */}
+              <div className="flex-1 min-w-[200px] relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Buscar por título o dirección..."
+                  className="w-full pl-9 pr-4 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400"
+                />
+              </div>
+
+              {/* Type filter */}
+              <select
+                value={selectedType}
+                onChange={(e) => {
+                  setSelectedType(e.target.value as PropertyType | '');
+                  setPage(1);
+                }}
+                className="px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400 bg-white"
+              >
+                <option value="">Todos los tipos</option>
+                {(Object.keys(PROPERTY_TYPE_LABELS) as PropertyType[]).map((t) => (
+                  <option key={t} value={t}>
+                    {PROPERTY_TYPE_LABELS[t]}
+                  </option>
+                ))}
+              </select>
+
+              {/* City filter */}
               <input
                 type="text"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Buscar por título o dirección..."
-                className="w-full pl-9 pr-4 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400"
+                value={city}
+                onChange={(e) => {
+                  setCity(e.target.value);
+                  setPage(1);
+                }}
+                placeholder="Ciudad..."
+                className="w-36 px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400"
               />
-            </div>
 
-            {/* Type filter */}
-            <select
-              value={selectedType}
-              onChange={(e) => {
-                setSelectedType(e.target.value as PropertyType | '');
-                setPage(1);
-              }}
-              className="px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400 bg-white"
-            >
-              <option value="">Todos los tipos</option>
-              {(Object.keys(PROPERTY_TYPE_LABELS) as PropertyType[]).map((t) => (
-                <option key={t} value={t}>
-                  {PROPERTY_TYPE_LABELS[t]}
-                </option>
-              ))}
-            </select>
-
-            {/* City filter */}
-            <input
-              type="text"
-              value={city}
-              onChange={(e) => {
-                setCity(e.target.value);
-                setPage(1);
-              }}
-              placeholder="Ciudad..."
-              className="w-36 px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400"
-            />
-
-            <button
-              type="submit"
-              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 transition-colors"
-            >
-              <SlidersHorizontal className="w-4 h-4" />
-              Filtrar
-            </button>
-
-            {hasActiveFilters && (
               <button
-                type="button"
-                onClick={clearFilters}
-                className="px-4 py-2 rounded-lg border border-slate-200 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
+                type="submit"
+                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 transition-colors"
               >
-                Limpiar
+                <SlidersHorizontal className="w-4 h-4" />
+                Filtrar
               </button>
-            )}
-          </form>
-        </div>
 
-        {/* Error state */}
-        {error && (
-          <div className="bg-red-50 border border-red-200 rounded-xl p-4 text-center text-red-600 mb-6">
-            {error}
+              {hasActiveFilters && (
+                <button
+                  type="button"
+                  onClick={clearFilters}
+                  className="px-4 py-2 rounded-lg border border-slate-200 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
+                >
+                  Limpiar
+                </button>
+              )}
+            </form>
           </div>
-        )}
 
-        {/* Loading skeleton */}
-        {isLoading && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {Array.from({ length: 8 }).map((_, i) => (
-              <div key={i} className="rounded-xl border border-slate-200 bg-white overflow-hidden">
-                <div className="h-52 bg-slate-200 animate-pulse" />
-                <div className="p-4 space-y-3">
-                  <div className="h-4 bg-slate-200 rounded animate-pulse" />
-                  <div className="h-3 bg-slate-200 rounded w-3/4 animate-pulse" />
-                  <div className="h-5 bg-slate-200 rounded w-1/2 animate-pulse" />
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+          {/* Error state */}
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-xl p-4 text-center text-red-600 mb-6">
+              {error}
+            </div>
+          )}
 
-        {/* Empty state */}
-        {!isLoading && !error && properties.length === 0 && (
-          <div className="text-center py-20 text-slate-400">
-            <MapPin className="w-12 h-12 mx-auto mb-4 opacity-30" />
-            <p className="text-lg font-medium">No se encontraron propiedades</p>
-            <p className="text-sm mt-1">Probá ajustando los filtros</p>
-          </div>
-        )}
-
-        {/* Property grid */}
-        {!isLoading && properties.length > 0 && (
-          <>
+          {/* Loading skeleton */}
+          {isLoading && (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {properties.map((property) => (
-                <PropertyCard
-                  key={property.id}
-                  property={property}
-                  onClick={(id) => navigate(`/properties/${id}`)}
-                />
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="rounded-xl border border-slate-200 bg-white overflow-hidden"
+                >
+                  <div className="h-52 bg-slate-200 animate-pulse" />
+                  <div className="p-4 space-y-3">
+                    <div className="h-4 bg-slate-200 rounded animate-pulse" />
+                    <div className="h-3 bg-slate-200 rounded w-3/4 animate-pulse" />
+                    <div className="h-5 bg-slate-200 rounded w-1/2 animate-pulse" />
+                  </div>
+                </div>
               ))}
             </div>
+          )}
 
-            {/* Pagination */}
-            {pagination && pagination.totalPages > 1 && (
-              <div className="flex justify-center gap-2 mt-8">
-                <button
-                  onClick={() => setPage((p) => Math.max(1, p - 1))}
-                  disabled={page === 1}
-                  className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
-                >
-                  Anterior
-                </button>
-                <span className="px-4 py-2 text-sm text-slate-600">
-                  Página {page} de {pagination.totalPages}
-                </span>
-                <button
-                  onClick={() => setPage((p) => Math.min(pagination.totalPages, p + 1))}
-                  disabled={page === pagination.totalPages}
-                  className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
-                >
-                  Siguiente
-                </button>
+          {/* Empty state */}
+          {!isLoading && !error && properties.length === 0 && (
+            <div className="text-center py-20 text-slate-400">
+              <MapPin className="w-12 h-12 mx-auto mb-4 opacity-30" />
+              <p className="text-lg font-medium">No se encontraron propiedades</p>
+              <p className="text-sm mt-1">Probá ajustando los filtros</p>
+            </div>
+          )}
+
+          {/* Property grid */}
+          {!isLoading && properties.length > 0 && (
+            <>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {properties.map((property) => (
+                  <PropertyCard
+                    key={property.id}
+                    property={property}
+                    onClick={(id) => navigate(`/properties/${id}`)}
+                  />
+                ))}
               </div>
-            )}
-          </>
-        )}
+
+              {/* Pagination */}
+              {pagination && pagination.totalPages > 1 && (
+                <div className="flex justify-center gap-2 mt-8">
+                  <button
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                    className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
+                  >
+                    Anterior
+                  </button>
+                  <span className="px-4 py-2 text-sm text-slate-600">
+                    Página {page} de {pagination.totalPages}
+                  </span>
+                  <button
+                    onClick={() => setPage((p) => Math.min(pagination.totalPages, p + 1))}
+                    disabled={page === pagination.totalPages}
+                    className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
+                  >
+                    Siguiente
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/frontend/src/pages/TourDetailPage.tsx
+++ b/frontend/src/pages/TourDetailPage.tsx
@@ -1,13 +1,20 @@
 /**
  * @fileoverview TourDetailPage - Tourism package detail page
- * @description Shows full tour info, image gallery, availability calendar and booking CTA
- *               Muestra info completa del tour, galería, calendario de disponibilidad y CTA de reserva
+ * @description Shows full tour info, image gallery, availability calendar and booking CTA.
+ *              Includes SEO meta tags (title, description, Open Graph) and JSON-LD
+ *              TouristAttraction schema markup for search engine indexing.
+ *
+ *              Muestra info completa del tour, galería, calendario de disponibilidad y CTA de reserva.
+ *              Incluye meta tags SEO (title, description, Open Graph) y schema markup
+ *              JSON-LD TouristAttraction para indexación en motores de búsqueda.
+ *
  * @module pages/TourDetailPage
  * @author Nexo Real Development Team
  */
 
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 import {
   MapPin,
   Clock,
@@ -227,148 +234,230 @@ export default function TourDetailPage() {
     navigate('/reservations/new');
   };
 
+  // ── SEO helpers ────────────────────────────────────────────────────────────
+
+  /**
+   * Dynamic page title for SEO: "Tour title | Destination | Nexo Real"
+   * Título dinámico para SEO: "Título tour | Destino | Nexo Real"
+   */
+  const seoTitle = `${tour.title} | ${tour.destination} | Nexo Real`;
+
+  /**
+   * Meta description combining category, duration, guests and description snippet.
+   * Meta description combinando categoría, duración, personas y fragmento de descripción.
+   */
+  const seoDescription = [
+    CATEGORY_LABELS[tour.category],
+    'en',
+    tour.destination,
+    `· ${tour.duration} ${tour.duration === 1 ? 'día' : 'días'}`,
+    `· Hasta ${tour.maxGuests} personas`,
+    `· ${tour.currency} ${tour.price.toLocaleString('es-AR')} por persona`,
+    tour.description ? `— ${tour.description.slice(0, 120)}` : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+
+  /** Primary OG image (first tour image or fallback) */
+  const ogImage = tour.images?.[0] ?? 'https://nexoreal.com/og-default.jpg';
+
+  /** Canonical URL for this tour */
+  const canonicalUrl = `https://nexoreal.com/tours/${tour.id}`;
+
+  /**
+   * JSON-LD TouristAttraction schema markup.
+   * Provides structured data for Google rich results.
+   * Schema markup JSON-LD TouristAttraction.
+   * Proporciona datos estructurados para resultados enriquecidos de Google.
+   */
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'TouristAttraction',
+    name: tour.title,
+    description: tour.description ?? seoDescription,
+    url: canonicalUrl,
+    image: tour.images?.length ? tour.images : [ogImage],
+    touristType: CATEGORY_LABELS[tour.category],
+    geo: {
+      '@type': 'GeoCoordinates',
+      name: tour.destination,
+    },
+    offers: {
+      '@type': 'Offer',
+      price: tour.price,
+      priceCurrency: tour.currency,
+      availability:
+        tour.status === 'active' ? 'https://schema.org/InStock' : 'https://schema.org/SoldOut',
+      description: `Tour de ${tour.duration} ${tour.duration === 1 ? 'día' : 'días'} — hasta ${tour.maxGuests} personas`,
+    },
+  };
+
   return (
-    <div className="min-h-screen bg-slate-50 pb-12">
-      <div className="max-w-5xl mx-auto px-4 py-8">
-        {/* Back button */}
-        <button
-          onClick={() => navigate('/tours')}
-          className="flex items-center gap-2 text-sm text-slate-500 hover:text-slate-800 mb-6 transition-colors"
-        >
-          <ArrowLeft className="w-4 h-4" />
-          Volver a tours
-        </button>
+    <>
+      {/* SEO: meta tags + JSON-LD / Meta tags + JSON-LD para SEO */}
+      <Helmet>
+        <title>{seoTitle}</title>
+        <meta name="description" content={seoDescription} />
+        <link rel="canonical" href={canonicalUrl} />
+        {/* Open Graph */}
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={seoTitle} />
+        <meta property="og:description" content={seoDescription} />
+        <meta property="og:image" content={ogImage} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:site_name" content="Nexo Real" />
+        {/* Twitter Card */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={seoTitle} />
+        <meta name="twitter:description" content={seoDescription} />
+        <meta name="twitter:image" content={ogImage} />
+        {/* JSON-LD structured data */}
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      </Helmet>
 
-        {/* Gallery */}
-        <ImageGallery images={tour.images} title={tour.title} />
+      <div className="min-h-screen bg-slate-50 pb-12">
+        <div className="max-w-5xl mx-auto px-4 py-8">
+          {/* Back button */}
+          <button
+            onClick={() => navigate('/tours')}
+            className="flex items-center gap-2 text-sm text-slate-500 hover:text-slate-800 mb-6 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Volver a tours
+          </button>
 
-        {/* Content grid */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mt-8">
-          {/* Left: Info */}
-          <div className="lg:col-span-2 space-y-6">
-            {/* Title + category */}
-            <div>
-              <div className="flex items-start justify-between gap-4 mb-2">
-                <h1 className="text-2xl font-bold text-slate-800">{tour.title}</h1>
-                <span
-                  className={cn(
-                    'shrink-0 px-3 py-1 rounded-full text-sm font-semibold',
-                    CATEGORY_COLORS[tour.category]
-                  )}
+          {/* Gallery */}
+          <ImageGallery images={tour.images} title={tour.title} />
+
+          {/* Content grid */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mt-8">
+            {/* Left: Info */}
+            <div className="lg:col-span-2 space-y-6">
+              {/* Title + category */}
+              <div>
+                <div className="flex items-start justify-between gap-4 mb-2">
+                  <h1 className="text-2xl font-bold text-slate-800">{tour.title}</h1>
+                  <span
+                    className={cn(
+                      'shrink-0 px-3 py-1 rounded-full text-sm font-semibold',
+                      CATEGORY_COLORS[tour.category]
+                    )}
+                  >
+                    {CATEGORY_LABELS[tour.category]}
+                  </span>
+                </div>
+                <p className="flex items-center gap-1 text-slate-500">
+                  <MapPin className="w-4 h-4" />
+                  {tour.destination}
+                </p>
+              </div>
+
+              {/* Specs */}
+              <div className="flex flex-wrap gap-6">
+                <div className="flex items-center gap-2 text-slate-700">
+                  <Clock className="w-5 h-5 text-emerald-500" />
+                  <span>
+                    <span className="font-semibold">{tour.duration}</span>{' '}
+                    {tour.duration === 1 ? 'día' : 'días'}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 text-slate-700">
+                  <Users className="w-5 h-5 text-emerald-500" />
+                  <span>
+                    Hasta <span className="font-semibold">{tour.maxGuests}</span> personas
+                  </span>
+                </div>
+              </div>
+
+              {/* Description */}
+              <div>
+                <h2 className="text-lg font-semibold text-slate-800 mb-2">Descripción</h2>
+                <p className="text-slate-600 leading-relaxed whitespace-pre-line">
+                  {tour.description}
+                </p>
+              </div>
+
+              {/* Includes / Excludes */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                {tour.includes && tour.includes.length > 0 && (
+                  <div>
+                    <h2 className="text-base font-semibold text-slate-800 mb-2">Incluye</h2>
+                    <ul className="space-y-1">
+                      {tour.includes.map((item) => (
+                        <li key={item} className="flex items-center gap-2 text-sm text-slate-600">
+                          <Check className="w-4 h-4 text-emerald-500 shrink-0" />
+                          {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {tour.excludes && tour.excludes.length > 0 && (
+                  <div>
+                    <h2 className="text-base font-semibold text-slate-800 mb-2">No incluye</h2>
+                    <ul className="space-y-1">
+                      {tour.excludes.map((item) => (
+                        <li key={item} className="flex items-center gap-2 text-sm text-slate-500">
+                          <X className="w-4 h-4 text-red-400 shrink-0" />
+                          {item}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+
+              {/* Availability */}
+              <div>
+                <h2 className="text-lg font-semibold text-slate-800 mb-3">Fechas disponibles</h2>
+                <AvailabilityPicker
+                  availabilities={tour.availabilities ?? []}
+                  selected={selectedAvailability}
+                  onSelect={setSelectedAvailability}
+                />
+              </div>
+            </div>
+
+            {/* Right: Booking card */}
+            <div className="lg:col-span-1">
+              <div className="sticky top-6 bg-white rounded-xl border border-slate-200 shadow-sm p-6">
+                <p className="text-3xl font-bold text-emerald-600 mb-1">
+                  {tour.currency} {tour.price.toLocaleString('es-AR', { minimumFractionDigits: 0 })}
+                </p>
+                <p className="text-sm text-slate-400 mb-4">por persona</p>
+
+                {selectedAvailability ? (
+                  <div className="text-sm bg-emerald-50 border border-emerald-200 rounded-lg px-3 py-2 mb-4 text-emerald-700">
+                    <CalendarDays className="w-4 h-4 inline mr-1" />
+                    {new Date(selectedAvailability.date).toLocaleDateString('es-AR', {
+                      weekday: 'long',
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric',
+                    })}
+                  </div>
+                ) : (
+                  <p className="text-sm text-slate-400 mb-4">Seleccioná una fecha disponible</p>
+                )}
+
+                <button
+                  onClick={handleReserve}
+                  disabled={!selectedAvailability}
+                  className="w-full flex items-center justify-center gap-2 py-3 rounded-lg bg-emerald-500 text-white font-semibold hover:bg-emerald-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                 >
-                  {CATEGORY_LABELS[tour.category]}
-                </span>
+                  <CalendarDays className="w-5 h-5" />
+                  Reservar este tour
+                </button>
+
+                <p className="text-xs text-slate-400 text-center mt-3">
+                  Sin costo hasta la confirmación
+                </p>
               </div>
-              <p className="flex items-center gap-1 text-slate-500">
-                <MapPin className="w-4 h-4" />
-                {tour.destination}
-              </p>
-            </div>
-
-            {/* Specs */}
-            <div className="flex flex-wrap gap-6">
-              <div className="flex items-center gap-2 text-slate-700">
-                <Clock className="w-5 h-5 text-emerald-500" />
-                <span>
-                  <span className="font-semibold">{tour.duration}</span>{' '}
-                  {tour.duration === 1 ? 'día' : 'días'}
-                </span>
-              </div>
-              <div className="flex items-center gap-2 text-slate-700">
-                <Users className="w-5 h-5 text-emerald-500" />
-                <span>
-                  Hasta <span className="font-semibold">{tour.maxGuests}</span> personas
-                </span>
-              </div>
-            </div>
-
-            {/* Description */}
-            <div>
-              <h2 className="text-lg font-semibold text-slate-800 mb-2">Descripción</h2>
-              <p className="text-slate-600 leading-relaxed whitespace-pre-line">
-                {tour.description}
-              </p>
-            </div>
-
-            {/* Includes / Excludes */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-              {tour.includes && tour.includes.length > 0 && (
-                <div>
-                  <h2 className="text-base font-semibold text-slate-800 mb-2">Incluye</h2>
-                  <ul className="space-y-1">
-                    {tour.includes.map((item) => (
-                      <li key={item} className="flex items-center gap-2 text-sm text-slate-600">
-                        <Check className="w-4 h-4 text-emerald-500 shrink-0" />
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {tour.excludes && tour.excludes.length > 0 && (
-                <div>
-                  <h2 className="text-base font-semibold text-slate-800 mb-2">No incluye</h2>
-                  <ul className="space-y-1">
-                    {tour.excludes.map((item) => (
-                      <li key={item} className="flex items-center gap-2 text-sm text-slate-500">
-                        <X className="w-4 h-4 text-red-400 shrink-0" />
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </div>
-
-            {/* Availability */}
-            <div>
-              <h2 className="text-lg font-semibold text-slate-800 mb-3">Fechas disponibles</h2>
-              <AvailabilityPicker
-                availabilities={tour.availabilities ?? []}
-                selected={selectedAvailability}
-                onSelect={setSelectedAvailability}
-              />
-            </div>
-          </div>
-
-          {/* Right: Booking card */}
-          <div className="lg:col-span-1">
-            <div className="sticky top-6 bg-white rounded-xl border border-slate-200 shadow-sm p-6">
-              <p className="text-3xl font-bold text-emerald-600 mb-1">
-                {tour.currency} {tour.price.toLocaleString('es-AR', { minimumFractionDigits: 0 })}
-              </p>
-              <p className="text-sm text-slate-400 mb-4">por persona</p>
-
-              {selectedAvailability ? (
-                <div className="text-sm bg-emerald-50 border border-emerald-200 rounded-lg px-3 py-2 mb-4 text-emerald-700">
-                  <CalendarDays className="w-4 h-4 inline mr-1" />
-                  {new Date(selectedAvailability.date).toLocaleDateString('es-AR', {
-                    weekday: 'long',
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
-                </div>
-              ) : (
-                <p className="text-sm text-slate-400 mb-4">Seleccioná una fecha disponible</p>
-              )}
-
-              <button
-                onClick={handleReserve}
-                disabled={!selectedAvailability}
-                className="w-full flex items-center justify-center gap-2 py-3 rounded-lg bg-emerald-500 text-white font-semibold hover:bg-emerald-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                <CalendarDays className="w-5 h-5" />
-                Reservar este tour
-              </button>
-
-              <p className="text-xs text-slate-400 text-center mt-3">
-                Sin costo hasta la confirmación
-              </p>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/frontend/src/pages/ToursPage.tsx
+++ b/frontend/src/pages/ToursPage.tsx
@@ -8,10 +8,27 @@
 
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { MapPin, Clock, Users, Search, SlidersHorizontal, Compass } from 'lucide-react';
+import { Helmet } from 'react-helmet-async';
+import { MapPin, Clock, Users, Search, SlidersHorizontal, Compass, Eye } from 'lucide-react';
 import { tourService } from '../services/tourService';
 import type { TourPackage, TourListParams, TourCategory } from '../services/tourService';
 import { cn } from '../lib/utils';
+
+// ============================================
+// Helpers / Utilidades
+// ============================================
+
+/**
+ * Generates a deterministic social proof view count for a tour card.
+ * Uses the tour ID to produce a stable number between 3 and 26.
+ *
+ * Genera un contador de vistas social proof determinístico para una card de tour.
+ * Usa el ID del tour para producir un número estable entre 3 y 26.
+ */
+function getSocialProofViews(id: string): number {
+  const hash = id.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0);
+  return 3 + (hash % 24);
+}
 
 // ============================================
 // Constants / Constantes
@@ -72,6 +89,12 @@ function TourCard({ tour, onClick }: TourCardProps) {
           )}
         >
           {CATEGORY_LABELS[tour.category]}
+        </span>
+
+        {/* Social proof badge / Badge de prueba social */}
+        <span className="absolute bottom-3 right-3 flex items-center gap-1 px-2 py-1 rounded-full bg-black/50 text-white text-xs backdrop-blur-sm">
+          <Eye className="w-3 h-3" />
+          {getSocialProofViews(tour.id)} personas vieron esto hoy
         </span>
       </div>
 
@@ -170,151 +193,193 @@ export default function ToursPage() {
 
   const hasActiveFilters = search || selectedCategory || destination;
 
-  return (
-    <div className="min-h-screen bg-slate-50">
-      {/* Header */}
-      <div className="bg-white border-b border-slate-200 py-8 px-4">
-        <div className="max-w-7xl mx-auto">
-          <h1 className="text-3xl font-bold text-slate-800 mb-1">Paquetes de Turismo</h1>
-          <p className="text-slate-500">
-            {pagination
-              ? `${pagination.total} experiencias disponibles`
-              : 'Descubrí destinos increíbles'}
-          </p>
-        </div>
-      </div>
+  // ── SEO helpers ────────────────────────────────────────────────────────────
 
-      <div className="max-w-7xl mx-auto px-4 py-6">
-        {/* Filters bar */}
-        <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
-          <form onSubmit={handleSearch} className="flex flex-wrap gap-3">
-            {/* Search */}
-            <div className="flex-1 min-w-[200px] relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+  /**
+   * Dynamic meta description based on active filters.
+   * Meta description dinámica basada en filtros activos.
+   */
+  const seoDescription = (() => {
+    const parts: string[] = ['Descubrí paquetes de turismo y experiencias únicas con Nexo Real.'];
+    if (selectedCategory)
+      parts.push(`Categoría: ${CATEGORY_LABELS[selectedCategory as TourCategory]}.`);
+    if (destination) parts.push(`Destino: ${destination}.`);
+    if (pagination) parts.push(`${pagination.total} experiencias disponibles.`);
+    return parts.join(' ');
+  })();
+
+  /**
+   * Dynamic page title.
+   * Título dinámico de la página.
+   */
+  const seoTitle = destination
+    ? `Tours en ${destination} | Nexo Real`
+    : selectedCategory
+      ? `Tours de ${CATEGORY_LABELS[selectedCategory as TourCategory]} | Nexo Real`
+      : 'Paquetes de Turismo | Nexo Real';
+
+  return (
+    <>
+      {/* SEO meta tags / Meta tags para SEO */}
+      <Helmet>
+        <title>{seoTitle}</title>
+        <meta name="description" content={seoDescription} />
+        <link rel="canonical" href="https://nexoreal.com/tours" />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={seoTitle} />
+        <meta property="og:description" content={seoDescription} />
+        <meta property="og:url" content="https://nexoreal.com/tours" />
+        <meta property="og:site_name" content="Nexo Real" />
+      </Helmet>
+
+      <div className="min-h-screen bg-slate-50">
+        {/* Header */}
+        <div className="bg-white border-b border-slate-200 py-8 px-4">
+          <div className="max-w-7xl mx-auto">
+            <h1 className="text-3xl font-bold text-slate-800 mb-1">Paquetes de Turismo</h1>
+            <p className="text-slate-500">
+              {pagination
+                ? `${pagination.total} experiencias disponibles`
+                : 'Descubrí destinos increíbles'}
+            </p>
+          </div>
+        </div>
+
+        <div className="max-w-7xl mx-auto px-4 py-6">
+          {/* Filters bar */}
+          <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
+            <form onSubmit={handleSearch} className="flex flex-wrap gap-3">
+              {/* Search */}
+              <div className="flex-1 min-w-[200px] relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Buscar tours..."
+                  className="w-full pl-9 pr-4 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400"
+                />
+              </div>
+
+              {/* Category filter */}
+              <select
+                value={selectedCategory}
+                onChange={(e) => {
+                  setSelectedCategory(e.target.value as TourCategory | '');
+                  setPage(1);
+                }}
+                className="px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400 bg-white"
+              >
+                <option value="">Todas las categorías</option>
+                {(Object.keys(CATEGORY_LABELS) as TourCategory[]).map((c) => (
+                  <option key={c} value={c}>
+                    {CATEGORY_LABELS[c]}
+                  </option>
+                ))}
+              </select>
+
+              {/* Destination filter */}
               <input
                 type="text"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Buscar tours..."
-                className="w-full pl-9 pr-4 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400"
+                value={destination}
+                onChange={(e) => {
+                  setDestination(e.target.value);
+                  setPage(1);
+                }}
+                placeholder="Destino..."
+                className="w-36 px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400"
               />
-            </div>
 
-            {/* Category filter */}
-            <select
-              value={selectedCategory}
-              onChange={(e) => {
-                setSelectedCategory(e.target.value as TourCategory | '');
-                setPage(1);
-              }}
-              className="px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400 bg-white"
-            >
-              <option value="">Todas las categorías</option>
-              {(Object.keys(CATEGORY_LABELS) as TourCategory[]).map((c) => (
-                <option key={c} value={c}>
-                  {CATEGORY_LABELS[c]}
-                </option>
-              ))}
-            </select>
-
-            {/* Destination filter */}
-            <input
-              type="text"
-              value={destination}
-              onChange={(e) => {
-                setDestination(e.target.value);
-                setPage(1);
-              }}
-              placeholder="Destino..."
-              className="w-36 px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400"
-            />
-
-            <button
-              type="submit"
-              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 transition-colors"
-            >
-              <SlidersHorizontal className="w-4 h-4" />
-              Filtrar
-            </button>
-
-            {hasActiveFilters && (
               <button
-                type="button"
-                onClick={clearFilters}
-                className="px-4 py-2 rounded-lg border border-slate-200 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
+                type="submit"
+                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 transition-colors"
               >
-                Limpiar
+                <SlidersHorizontal className="w-4 h-4" />
+                Filtrar
               </button>
-            )}
-          </form>
-        </div>
 
-        {/* Error state */}
-        {error && (
-          <div className="bg-red-50 border border-red-200 rounded-xl p-4 text-center text-red-600 mb-6">
-            {error}
+              {hasActiveFilters && (
+                <button
+                  type="button"
+                  onClick={clearFilters}
+                  className="px-4 py-2 rounded-lg border border-slate-200 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
+                >
+                  Limpiar
+                </button>
+              )}
+            </form>
           </div>
-        )}
 
-        {/* Loading skeleton */}
-        {isLoading && (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {Array.from({ length: 8 }).map((_, i) => (
-              <div key={i} className="rounded-xl border border-slate-200 bg-white overflow-hidden">
-                <div className="h-52 bg-slate-200 animate-pulse" />
-                <div className="p-4 space-y-3">
-                  <div className="h-4 bg-slate-200 rounded animate-pulse" />
-                  <div className="h-3 bg-slate-200 rounded w-3/4 animate-pulse" />
-                  <div className="h-5 bg-slate-200 rounded w-1/2 animate-pulse" />
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+          {/* Error state */}
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-xl p-4 text-center text-red-600 mb-6">
+              {error}
+            </div>
+          )}
 
-        {/* Empty state */}
-        {!isLoading && !error && tours.length === 0 && (
-          <div className="text-center py-20 text-slate-400">
-            <Compass className="w-12 h-12 mx-auto mb-4 opacity-30" />
-            <p className="text-lg font-medium">No se encontraron tours</p>
-            <p className="text-sm mt-1">Probá ajustando los filtros</p>
-          </div>
-        )}
-
-        {/* Tours grid */}
-        {!isLoading && tours.length > 0 && (
-          <>
+          {/* Loading skeleton */}
+          {isLoading && (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {tours.map((tour) => (
-                <TourCard key={tour.id} tour={tour} onClick={(id) => navigate(`/tours/${id}`)} />
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="rounded-xl border border-slate-200 bg-white overflow-hidden"
+                >
+                  <div className="h-52 bg-slate-200 animate-pulse" />
+                  <div className="p-4 space-y-3">
+                    <div className="h-4 bg-slate-200 rounded animate-pulse" />
+                    <div className="h-3 bg-slate-200 rounded w-3/4 animate-pulse" />
+                    <div className="h-5 bg-slate-200 rounded w-1/2 animate-pulse" />
+                  </div>
+                </div>
               ))}
             </div>
+          )}
 
-            {/* Pagination */}
-            {pagination && pagination.totalPages > 1 && (
-              <div className="flex justify-center gap-2 mt-8">
-                <button
-                  onClick={() => setPage((p) => Math.max(1, p - 1))}
-                  disabled={page === 1}
-                  className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
-                >
-                  Anterior
-                </button>
-                <span className="px-4 py-2 text-sm text-slate-600">
-                  Página {page} de {pagination.totalPages}
-                </span>
-                <button
-                  onClick={() => setPage((p) => Math.min(pagination.totalPages, p + 1))}
-                  disabled={page === pagination.totalPages}
-                  className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
-                >
-                  Siguiente
-                </button>
+          {/* Empty state */}
+          {!isLoading && !error && tours.length === 0 && (
+            <div className="text-center py-20 text-slate-400">
+              <Compass className="w-12 h-12 mx-auto mb-4 opacity-30" />
+              <p className="text-lg font-medium">No se encontraron tours</p>
+              <p className="text-sm mt-1">Probá ajustando los filtros</p>
+            </div>
+          )}
+
+          {/* Tours grid */}
+          {!isLoading && tours.length > 0 && (
+            <>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {tours.map((tour) => (
+                  <TourCard key={tour.id} tour={tour} onClick={(id) => navigate(`/tours/${id}`)} />
+                ))}
               </div>
-            )}
-          </>
-        )}
+
+              {/* Pagination */}
+              {pagination && pagination.totalPages > 1 && (
+                <div className="flex justify-center gap-2 mt-8">
+                  <button
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                    className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
+                  >
+                    Anterior
+                  </button>
+                  <span className="px-4 py-2 text-sm text-slate-600">
+                    Página {page} de {pagination.totalPages}
+                  </span>
+                  <button
+                    onClick={() => setPage((p) => Math.min(pagination.totalPages, p + 1))}
+                    disabled={page === pagination.totalPages}
+                    className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
+                  >
+                    Siguiente
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Implements Fase 8 of Sprint 6 — SEO/Content improvements for property and tour pages.

## Changes

### TourDetailPage
- Added `<Helmet>` with dynamic `<title>`, `<meta name="description">`, Open Graph tags and Twitter Card
- Added JSON-LD `TouristAttraction` schema markup with `name`, `description`, `url`, `image`, `offers` and `touristType`

### PropertiesPage
- Added `<Helmet>` with dynamic meta tags based on active filters (type, city)
- Title and description update automatically when user filters by type or city
- Added social proof badge "X personas vieron esto hoy" on each property card (deterministic, stable per ID)

### ToursPage
- Same dynamic `<Helmet>` based on active filters (category, destination)
- Added social proof badge on each tour card

### Notes
- Backend has no `slug` field → routes remain `/properties/:id` and `/tours/:id` (correct fallback per spec)
- `HelmetProvider` already wraps the app in `main.tsx` ✅
- `react-helmet-async` already installed ✅
- `tsc --noEmit` → 0 errors ✅

## Related

- Sprint 6 tasks: 8.3–8.12
- Closes Fase 8: SEO + Contenido + Psicología de Conversión