### PR TITLE
feat(bot): n8n Schedule Visit workflow — Google Calendar [S8/8.2]

### DIFF
--- a/bot/n8n/README.md
+++ b/bot/n8n/README.md
@@ -1,0 +1,159 @@
+# bot/n8n — Workflows de Automatización Nexo Real
+
+This directory contains n8n workflow definitions for the Nexo Real bot integrations.
+
+---
+
+## Workflows
+
+### `schedule-visit.json` — Agendar Visita (Google Calendar)
+
+**Trigger**: `POST /webhook/schedule-visit`
+
+**Description**: Receives a visit scheduling request from the bot and creates a Google Calendar event, notifying the sales team.
+
+**Input payload**:
+
+```json
+{
+  "phone": "+573001234567",
+  "name": "Juan Pérez",
+  "preferredDate": "2026-04-15T10:00:00-05:00",
+  "propertyId": "PROP-001",
+  "agentName": "Sophia"
+}
+```
+
+**Response (success)**:
+
+```json
+{
+  "success": true,
+  "eventId": "abc123xyz",
+  "calendarLink": "https://calendar.google.com/calendar/event?eid=...",
+  "scheduledAt": "2026-04-15T10:00:00.000Z"
+}
+```
+
+**Response (error)**:
+
+```json
+{
+  "success": false,
+  "error": "Missing required field: phone"
+}
+```
+
+**Required environment variables**:
+
+| Variable             | Description                            | Example               |
+| -------------------- | -------------------------------------- | --------------------- |
+| `GOOGLE_CALENDAR_ID` | Google Calendar ID for the team        | `team@nexoreal.com`   |
+| `SALES_TEAM_EMAIL`   | Email to add as attendee to all events | `ventas@nexoreal.com` |
+
+**Required n8n credentials**:
+
+- `googleCalendarOAuth2Api` — OAuth2 connection to Google Calendar
+
+---
+
+### `human-handoff.json` — Handoff a Agente Humano (Notion + Brevo)
+
+**Trigger**: `POST /webhook/human-handoff`
+
+**Description**: When the bot escalates to a human agent, this workflow captures the lead in Notion and sends an email notification to the sales team via Brevo.
+
+**Input payload**:
+
+```json
+{
+  "phone": "+573001234567",
+  "name": "María García",
+  "summary": "Interesada en apartamento 2 habitaciones, presupuesto $200M",
+  "agentName": "Max",
+  "language": "es"
+}
+```
+
+**Response (success)**:
+
+```json
+{
+  "success": true,
+  "notionPageId": "abc-123-def",
+  "emailSent": true
+}
+```
+
+**Required environment variables**:
+
+| Variable                    | Description                           | Example                                |
+| --------------------------- | ------------------------------------- | -------------------------------------- |
+| `NOTION_LEADS_DB_ID`        | Notion database ID for leads          | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
+| `BREVO_HANDOFF_TEMPLATE_ID` | Brevo transactional email template ID | `42`                                   |
+| `SALES_TEAM_EMAIL`          | Email to notify on handoff            | `ventas@nexoreal.com`                  |
+
+**Required n8n credentials**:
+
+- `notionApi` — Notion integration API key
+- `brevoApi` — Brevo (Sendinblue) API key
+
+---
+
+## Setup
+
+### 1. Import workflows
+
+In n8n:
+
+1. Go to **Workflows** → **Import from file**
+2. Select the `.json` file from this directory
+3. Configure credentials (see above)
+4. Set environment variables in n8n Settings → Variables
+5. Activate the workflow
+
+### 2. Configure bot environment
+
+Add to `bot/.env`:
+
+```env
+# n8n Webhook URLs
+N8N_SCHEDULE_VISIT_URL=https://your-n8n-instance.com/webhook/schedule-visit
+N8N_HUMAN_HANDOFF_URL=https://your-n8n-instance.com/webhook/human-handoff
+```
+
+### 3. Test
+
+Use the included Postman collection or:
+
+```bash
+# Test schedule-visit
+curl -X POST https://your-n8n-instance.com/webhook/schedule-visit \
+  -H "Content-Type: application/json" \
+  -d '{"phone":"+573001234567","name":"Test User","preferredDate":"2026-04-15T10:00:00-05:00","propertyId":"PROP-001"}'
+
+# Test human-handoff
+curl -X POST https://your-n8n-instance.com/webhook/human-handoff \
+  -H "Content-Type: application/json" \
+  -d '{"phone":"+573001234567","name":"Test User","summary":"Test handoff","agentName":"Sophia"}'
+```
+
+---
+
+## Architecture
+
+```
+WhatsApp Bot (BuilderBot)
+        │
+        ▼
+   n8n Webhook
+        │
+   ┌────┴─────┐
+   │          │
+   ▼          ▼
+Google      Notion
+Calendar    Leads DB
+   +           +
+Sales       Brevo
+Notify      Email
+```

--- a/bot/n8n/workflows/schedule-visit.json
+++ b/bot/n8n/workflows/schedule-visit.json
@@ -1,0 +1,165 @@
+{
+  "name": "Nexo Real — Schedule Visit (Google Calendar)",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "schedule-visit",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook — Receive Visit Request",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "schedule-visit-nexo-real"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate required fields\nconst body = $input.first().json.body || $input.first().json;\nconst required = ['phone', 'name', 'preferredDate', 'propertyId'];\n\nfor (const field of required) {\n  if (!body[field]) {\n    throw new Error(`Missing required field: ${field}`);\n  }\n}\n\n// Parse preferredDate (ISO 8601 expected)\nconst startDate = new Date(body.preferredDate);\nif (isNaN(startDate.getTime())) {\n  throw new Error('Invalid preferredDate format. Expected ISO 8601.');\n}\n\n// End time = start + 1 hour\nconst endDate = new Date(startDate.getTime() + 60 * 60 * 1000);\n\nreturn [\n  {\n    json: {\n      phone: body.phone,\n      name: body.name,\n      propertyId: body.propertyId,\n      agentName: body.agentName || 'Equipo Nexo Real',\n      summary: `Visita Nexo Real — ${body.name} | Prop. ${body.propertyId}`,\n      description: `Prospecto: ${body.name}\\nTeléfono: ${body.phone}\\nPropiedad: ${body.propertyId}\\nAgendado vía bot WhatsApp`,\n      startDateTime: startDate.toISOString(),\n      endDateTime: endDate.toISOString()\n    }\n  }\n];"
+      },
+      "id": "validate-transform",
+      "name": "Validate & Transform Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "resource": "event",
+        "operation": "create",
+        "calendarId": "={{ $env.GOOGLE_CALENDAR_ID }}",
+        "summary": "={{ $json.summary }}",
+        "description": "={{ $json.description }}",
+        "start": "={{ $json.startDateTime }}",
+        "end": "={{ $json.endDateTime }}",
+        "additionalFields": {
+          "attendees": [
+            {
+              "email": "={{ $env.SALES_TEAM_EMAIL }}"
+            }
+          ],
+          "sendUpdates": "all",
+          "colorId": "2"
+        }
+      },
+      "id": "google-calendar-create",
+      "name": "Google Calendar — Create Event",
+      "type": "n8n-nodes-base.googleCalendar",
+      "typeVersion": 1.1,
+      "position": [680, 300],
+      "credentials": {
+        "googleCalendarOAuth2Api": {
+          "id": "google-calendar-credentials",
+          "name": "Google Calendar — Nexo Real"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={\n  \"success\": true,\n  \"eventId\": \"{{ $json.id }}\",\n  \"calendarLink\": \"{{ $json.htmlLink }}\",\n  \"scheduledAt\": \"{{ $node['Validate & Transform Input'].json.startDateTime }}\"\n}"
+      },
+      "id": "respond-success",
+      "name": "Respond — Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [900, 220]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseCode": 400,
+        "responseBody": "={\n  \"success\": false,\n  \"error\": \"{{ $json.message }}\"\n}"
+      },
+      "id": "respond-error",
+      "name": "Respond — Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [900, 400]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "string": [
+            {
+              "value1": "={{ $json.id }}",
+              "operation": "isNotEmpty"
+            }
+          ]
+        }
+      },
+      "id": "check-event-created",
+      "name": "Event Created?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [900, 300]
+    }
+  ],
+  "connections": {
+    "Webhook — Receive Visit Request": {
+      "main": [
+        [
+          {
+            "node": "Validate & Transform Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate & Transform Input": {
+      "main": [
+        [
+          {
+            "node": "Google Calendar — Create Event",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Calendar — Create Event": {
+      "main": [
+        [
+          {
+            "node": "Event Created?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Event Created?": {
+      "main": [
+        [
+          {
+            "node": "Respond — Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond — Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "pinData": {},
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true,
+    "callerPolicy": "workflowsFromSameOwner",
+    "errorWorkflow": ""
+  },
+  "staticData": null,
+  "tags": ["nexo-real", "bot", "calendar", "sprint8"],
+  "triggerCount": 0,
+  "updatedAt": "2026-04-09T00:00:00.000Z",
+  "versionId": "1.0.0"
+}


### PR DESCRIPTION
Closes #108

## Summary
- Adds `bot/n8n/workflows/schedule-visit.json` — n8n workflow that creates Google Calendar events when the bot detects visit intent
- Adds `bot/n8n/README.md` — complete setup guide with env vars, curl examples, and architecture diagram

## Workflow
`POST /webhook/schedule-visit` → validates input → creates GCal event → notifies sales team → returns `{ success, eventId, calendarLink }`

## Required config (not in this PR — external)
- `GOOGLE_CALENDAR_ID` env var in n8n
- `SALES_TEAM_EMAIL` env var in n8n  
- `googleCalendarOAuth2Api` n8n credential