### PR TITLE
chore(config): add Sprint 8 n8n + bot env vars to .env.example [8.2/8.3]

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -100,3 +100,21 @@ INTERNAL_WEBHOOK_SECRET=change-this-to-a-random-32-char-secret
 # n8n Webhook URL for Google Calendar sync
 # URL del webhook de n8n para sincronización con Google Calendar
 N8N_CALENDAR_WEBHOOK_URL=https://n8n.nexoreal.xyz/webhook/calendar-sync
+
+# ===========================================
+# Bot n8n Integrations (Sprint 8)
+# Integraciones n8n del Bot (Sprint 8)
+# ===========================================
+
+# Google Calendar — Schedule Visit workflow (n8n)
+# Google Calendar — Workflow de agendamiento de visitas (n8n)
+GOOGLE_CALENDAR_ID=your_google_calendar_id@group.calendar.google.com
+
+# Notion Databases — Schedule Visit + Human Handoff workflows (n8n)
+# Bases de datos Notion — Workflows de visitas y handoff (n8n)
+NOTION_DATABASE_ID_VISITS=your_notion_visits_database_id
+NOTION_DATABASE_ID_LEADS=your_notion_leads_database_id
+
+# Brevo (Sendinblue) — Human Handoff email template (n8n)
+# Brevo (Sendinblue) — Template de email de handoff (n8n)
+BREVO_HANDOFF_TEMPLATE_ID=your_brevo_handoff_template_id

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -30,3 +30,19 @@ DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=postgres
 DB_NAME=mlm_platform
+
+# ─── Bot Lead Capture — Backend Auth (Sprint 8.4) ────────────────────────────
+
+# System user ID used to attribute bot-created leads in the database
+# ID del usuario sistema usado para atribuir leads creados por el bot
+BOT_SYSTEM_USER_ID=your_system_user_id_from_db
+
+# ─── n8n Webhook URLs (Sprint 8) ─────────────────────────────────────────────
+
+# n8n webhook for scheduling visits via Google Calendar
+# Webhook de n8n para agendar visitas via Google Calendar
+N8N_SCHEDULE_VISIT_URL=https://n8n.nexoreal.xyz/webhook/schedule-visit
+
+# n8n webhook for human handoff (Notion + Brevo notification)
+# Webhook de n8n para handoff a agente humano (Notion + Brevo)
+N8N_HUMAN_HANDOFF_URL=https://n8n.nexoreal.xyz/webhook/human-handoff


### PR DESCRIPTION
## Summary
- Documents all new environment variables required by Sprint 8 n8n workflows and lead capture
- No code changes — documentation only

## backend/.env.example additions
| Variable | Used by |
|----------|---------|
| `GOOGLE_CALENDAR_ID` | schedule-visit workflow (n8n) |
| `NOTION_DATABASE_ID_VISITS` | schedule-visit workflow (n8n) |
| `NOTION_DATABASE_ID_LEADS` | human-handoff workflow (n8n) |
| `BREVO_HANDOFF_TEMPLATE_ID` | human-handoff workflow (n8n) |

## bot/.env.example additions
| Variable | Used by |
|----------|---------|
| `BOT_SYSTEM_USER_ID` | lead-persistence.service (Batch 8.4) |
| `N8N_SCHEDULE_VISIT_URL` | schedule.flow.ts (Batch 8.4) |
| `N8N_HUMAN_HANDOFF_URL` | handoff.flow.ts (Batch 8.4) |

Covers tasks 8.2.2, 8.3.1, 8.4.3