### PR TITLE
feat(bot): Lead Capture — DB migration + endpoint + welcome flow update [S8/8.4]

### DIFF
--- a/backend/database/migrations/20260409000000-add-whatsapp-bot-source.js
+++ b/backend/database/migrations/20260409000000-add-whatsapp-bot-source.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * @fileoverview Migration: Add 'whatsapp_bot' value to enum_leads_source
+ * @description Adds the 'whatsapp_bot' source type to the leads source enum so the
+ *              backend can persist leads captured by the WhatsApp AI bot (Sophia / Max).
+ *              Agrega el tipo 'whatsapp_bot' al enum de fuentes de leads para que el
+ *              backend pueda persistir leads capturados por el bot de WhatsApp con IA.
+ *
+ * NOTE: ALTER TYPE ... ADD VALUE cannot run inside an explicit transaction in PostgreSQL.
+ *       The Sequelize queryInterface.sequelize.query() call bypasses the default transaction.
+ *       NOTA: ALTER TYPE ... ADD VALUE no puede ejecutarse dentro de una transacción explícita
+ *       en PostgreSQL. La llamada directa a sequelize.query() evita la transacción por defecto.
+ */
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  /**
+   * Apply migration — adds 'whatsapp_bot' to enum_leads_source if not present.
+   * Aplica la migración — agrega 'whatsapp_bot' a enum_leads_source si no existe.
+   *
+   * @param {import('sequelize').QueryInterface} queryInterface
+   * @param {import('sequelize').Sequelize} Sequelize
+   * @returns {Promise<void>}
+   */
+  async up(queryInterface, Sequelize) {
+    // ADD VALUE is non-transactional in PostgreSQL — must run outside explicit transaction
+    // ADD VALUE no es transaccional en PostgreSQL — debe ejecutarse fuera de transacción
+    await queryInterface.sequelize.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_enum
+          WHERE enumlabel = 'whatsapp_bot'
+            AND enumtypid = (
+              SELECT oid FROM pg_type WHERE typname = 'enum_leads_source'
+            )
+        ) THEN
+          ALTER TYPE "enum_leads_source" ADD VALUE 'whatsapp_bot';
+        END IF;
+      END
+      $$;
+    `);
+  },
+
+  /**
+   * Revert migration — PostgreSQL does not support removing enum values.
+   * Revierte la migración — PostgreSQL no soporta eliminar valores de enum.
+   * This is a no-op: the value remains but causes no issues if unused.
+   * Esto es un no-op: el valor queda pero no causa problemas si no se usa.
+   *
+   * @param {import('sequelize').QueryInterface} queryInterface
+   * @returns {Promise<void>}
+   */
+  async down(queryInterface) {
+    // PostgreSQL does not allow removing enum values — intentional no-op
+    // PostgreSQL no permite eliminar valores de enum — no-op intencional
+    console.warn(
+      '[migration:down] Cannot remove enum value "whatsapp_bot" from enum_leads_source — PostgreSQL limitation. Value will remain unused.'
+    );
+  },
+};

--- a/backend/src/models/Lead.ts
+++ b/backend/src/models/Lead.ts
@@ -10,7 +10,14 @@ export type LeadStatus =
   | 'negotiation'
   | 'won'
   | 'lost';
-export type LeadSource = 'website' | 'referral' | 'social' | 'landing_page' | 'manual' | 'other';
+export type LeadSource =
+  | 'website'
+  | 'referral'
+  | 'social'
+  | 'landing_page'
+  | 'manual'
+  | 'other'
+  | 'whatsapp_bot';
 
 interface LeadAttributes {
   id: string;
@@ -99,7 +106,15 @@ Lead.init(
       defaultValue: 'new',
     },
     source: {
-      type: DataTypes.ENUM('website', 'referral', 'social', 'landing_page', 'manual', 'other'),
+      type: DataTypes.ENUM(
+        'website',
+        'referral',
+        'social',
+        'landing_page',
+        'manual',
+        'other',
+        'whatsapp_bot'
+      ),
       defaultValue: 'website',
     },
     value: {

--- a/backend/src/routes/bot-leads.routes.ts
+++ b/backend/src/routes/bot-leads.routes.ts
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview Bot Leads Routes — Internal API
+ * @description POST /api/bot/leads — persists leads captured by the WhatsApp bot.
+ *              Requires x-bot-secret header authentication (same as all bot routes).
+ *              POST /api/bot/leads — persiste leads capturados por el bot de WhatsApp.
+ *              Requiere autenticación por header x-bot-secret (igual que todas las rutas bot).
+ * @module routes/bot-leads.routes
+ */
+
+import { Router, Request, Response } from 'express';
+import { asyncHandler } from '../middleware/asyncHandler';
+import { db } from '../database';
+import { v4 as uuidv4 } from 'uuid';
+
+const router = Router();
+
+/**
+ * @route   POST /api/bot/leads
+ * @desc    Persist a lead captured by the WhatsApp AI bot (Sophia / Max)
+ *          Persistir un lead capturado por el bot de WhatsApp con IA (Sophia / Max)
+ * @access  Bot-only (x-bot-secret) — already enforced by parent router
+ * @body    { name, phone, email?, areaOfInterest?, agentName, language, source }
+ */
+router.post(
+  '/',
+  asyncHandler(async (req: Request, res: Response) => {
+    const { name, phone, email, areaOfInterest, agentName, language, source } = req.body as {
+      name: string;
+      phone: string;
+      email?: string;
+      areaOfInterest?: string;
+      agentName: string;
+      language: string;
+      source: string;
+    };
+
+    // Validate required fields
+    // Validar campos requeridos
+    if (!name || !phone || !agentName || !language || source !== 'whatsapp_bot') {
+      res.status(400).json({
+        success: false,
+        message: 'Missing or invalid required fields: name, phone, agentName, language, source',
+      });
+      return;
+    }
+
+    const systemUserId = process.env.BOT_SYSTEM_USER_ID;
+    if (!systemUserId) {
+      console.error('[BotLeads] BOT_SYSTEM_USER_ID is not set — cannot persist lead');
+      res.status(500).json({ success: false, message: 'Server misconfiguration' });
+      return;
+    }
+
+    // Build notes with conversation context
+    // Construir notas con contexto de la conversación
+    const notes = [
+      `Capturado por bot WhatsApp — agente: ${agentName}`,
+      `Idioma: ${language}`,
+      areaOfInterest ? `Área de interés: ${areaOfInterest}` : null,
+    ]
+      .filter(Boolean)
+      .join(' | ');
+
+    // Insert lead into database
+    // Insertar lead en la base de datos
+    const [result] = await db.sequelize.query(
+      `INSERT INTO leads (
+        id, user_id, contact_name, contact_phone, contact_email,
+        source, status, notes, metadata, created_at, updated_at
+      ) VALUES (
+        :id, :userId, :name, :phone, :email,
+        'whatsapp_bot', 'new', :notes, :metadata,
+        NOW(), NOW()
+      )
+      ON CONFLICT DO NOTHING
+      RETURNING id`,
+      {
+        replacements: {
+          id: uuidv4(),
+          userId: systemUserId,
+          name,
+          phone,
+          email: email ?? null,
+          notes,
+          metadata: JSON.stringify({
+            agentName,
+            language,
+            areaOfInterest: areaOfInterest ?? null,
+            capturedAt: new Date().toISOString(),
+          }),
+        },
+      }
+    );
+
+    const rows = result as { id: string }[];
+
+    if (rows.length === 0) {
+      // Duplicate phone — already exists, not an error
+      // Teléfono duplicado — ya existe, no es un error
+      res.status(200).json({ success: true, message: 'Lead already exists', created: false });
+      return;
+    }
+
+    res.status(201).json({ success: true, leadId: rows[0].id, created: true });
+  })
+);
+
+export default router;

--- a/backend/src/routes/bot-leads.routes.ts
+++ b/backend/src/routes/bot-leads.routes.ts
@@ -9,7 +9,7 @@
 
 import { Router, Request, Response } from 'express';
 import { asyncHandler } from '../middleware/asyncHandler';
-import { db } from '../database';
+import { sequelize } from '../config/database';
 import { v4 as uuidv4 } from 'uuid';
 
 const router = Router();
@@ -51,6 +51,10 @@ router.post(
       return;
     }
 
+    // Use email if provided, otherwise generate a placeholder (contact_email is NOT NULL)
+    // Usar email si se proveyó, sino generar un placeholder (contact_email es NOT NULL)
+    const contactEmail = email ?? `bot-${phone}@nexoreal.bot`;
+
     // Build notes with conversation context
     // Construir notas con contexto de la conversación
     const notes = [
@@ -61,9 +65,9 @@ router.post(
       .filter(Boolean)
       .join(' | ');
 
-    // Insert lead into database
-    // Insertar lead en la base de datos
-    const [result] = await db.sequelize.query(
+    // Insert lead into database — ON CONFLICT DO NOTHING deduplicates by phone
+    // Insertar lead en la base de datos — ON CONFLICT DO NOTHING deduplica por teléfono
+    const [result] = await sequelize.query(
       `INSERT INTO leads (
         id, user_id, contact_name, contact_phone, contact_email,
         source, status, notes, metadata, created_at, updated_at
@@ -80,7 +84,7 @@ router.post(
           userId: systemUserId,
           name,
           phone,
-          email: email ?? null,
+          email: contactEmail,
           notes,
           metadata: JSON.stringify({
             agentName,

--- a/backend/src/routes/bot.routes.ts
+++ b/backend/src/routes/bot.routes.ts
@@ -17,6 +17,7 @@ import {
   getBotHealth,
 } from '../controllers/BotController';
 import { asyncHandler } from '../middleware/asyncHandler';
+import botLeadsRouter from './bot-leads.routes';
 
 const router = Router();
 
@@ -79,5 +80,13 @@ router.get('/tours', asyncHandler(getBotTours));
  * @access  Bot-only (x-bot-secret)
  */
 router.get('/health', asyncHandler(getBotHealth));
+
+/**
+ * @route   POST /api/bot/leads
+ * @desc    Persist a lead captured by the WhatsApp AI bot (Sophia / Max)
+ *          Persistir un lead capturado por el bot de WhatsApp con IA (Sophia / Max)
+ * @access  Bot-only (x-bot-secret)
+ */
+router.use('/leads', botLeadsRouter);
 
 export default router;

--- a/bot/src/flows/welcome.flow.ts
+++ b/bot/src/flows/welcome.flow.ts
@@ -2,6 +2,8 @@ import { addKeyword, EVENTS } from '@builderbot/bot';
 import { aiService, type AgentName, type Language } from '../services/ai.service.js';
 import { resolveLanguageFromInput } from './language.flow.js';
 import { assignAgent, getAgentIntro, getAgentTransitionMessage } from './agent.flow.js';
+import { leadPersistenceService } from '../services/lead-persistence.service.js';
+import type { BotLeadAreaOfInterest } from '../types/lead.types.js';
 
 /**
  * Welcome flow — Nexo Real AI Bot
@@ -10,7 +12,9 @@ import { assignAgent, getAgentIntro, getAgentTransitionMessage } from './agent.f
  *   1. New message arrives → check state
  *   2. No lang set → ask for language (ES/EN)
  *   3. Lang set, no agent → ask for name → assign Sophia or Max
- *   4. Agent assigned → forward all messages to AI service
+ *   4. Agent assigned → ask for email (optional, skippable)
+ *   5. Email captured → ask for area of interest → save lead (fire & forget)
+ *   6. Lead saved → full AI conversation
  */
 export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
   async (ctx: any, { state, flowDynamic }: any) => {
@@ -22,12 +26,16 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
       agent?: AgentName;
       awaitingLanguage?: boolean;
       awaitingName?: boolean;
+      awaitingEmail?: boolean;
+      awaitingAreaOfInterest?: boolean;
       userName?: string;
+      userEmail?: string;
+      areaOfInterest?: BotLeadAreaOfInterest;
+      leadSaved?: boolean;
     };
 
     // ── STEP 1: Language not set yet ─────────────────────────────────────────
     if (!currentState?.lang) {
-      // If this is a first message (no awaitingLanguage flag), ask for language
       if (!currentState?.awaitingLanguage) {
         await flowDynamic([
           {
@@ -42,11 +50,9 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
         return;
       }
 
-      // Try to resolve language from their response
       const lang = await resolveLanguageFromInput(incomingText, state, flowDynamic);
 
       if (!lang) {
-        // Could not detect language — ask again
         await flowDynamic([
           {
             body:
@@ -57,7 +63,6 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
         return;
       }
 
-      // Language confirmed — now ask for name
       const askName =
         lang === 'es'
           ? '¡Perfecto! 😊 Antes de empezar, ¿me decís tu nombre?'
@@ -73,7 +78,6 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
     // ── STEP 2: Language set, waiting for name ───────────────────────────────
     if (!currentState?.agent) {
       if (!currentState?.awaitingName) {
-        // Shouldn't happen, but recover gracefully
         const askName =
           lang === 'es' ? '¿Me decís tu nombre para presentarme?' : 'Could you tell me your name?';
         await flowDynamic([{ body: askName }]);
@@ -81,22 +85,110 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
         return;
       }
 
-      // Capture name and assign agent
       const userName = incomingText.length > 0 ? incomingText : 'amigo';
       const agent = await assignAgent(userName, state, flowDynamic, lang);
 
       await state.update({ userName, awaitingName: false });
 
-      // Send agent intro
       const intro = getAgentIntro(agent, lang);
       await flowDynamic([{ body: intro }]);
+
+      // Ask for email (optional)
+      // Pedir email (opcional)
+      const askEmail =
+        lang === 'es'
+          ? '¿Me compartís tu email? (Opcional — escribí *omitir* si preferís no darlo 😊)'
+          : "What's your email? (Optional — type *skip* if you'd prefer not to share it 😊)";
+
+      await flowDynamic([{ body: askEmail }]);
+      await state.update({ awaitingEmail: true });
       return;
     }
 
     const agent: AgentName = currentState.agent;
     const userName: string = currentState.userName || '';
 
-    // ── STEP 3: Full AI conversation ─────────────────────────────────────────
+    // ── STEP 3: Waiting for email ────────────────────────────────────────────
+    if (currentState?.awaitingEmail) {
+      const skipKeywords = ['omitir', 'skip', 'no', 'ninguno', 'none', '-'];
+      const isSkip = skipKeywords.some((k) => incomingText.toLowerCase().includes(k));
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      const isEmail = emailRegex.test(incomingText);
+      const userEmail = isSkip || !isEmail ? undefined : incomingText;
+
+      await state.update({ userEmail, awaitingEmail: false });
+
+      // Ask for area of interest
+      // Pedir área de interés
+      const askArea =
+        lang === 'es'
+          ? '¿Qué es lo que más te interesa de Nexo Real?\n\n' +
+            '1️⃣  Propiedades\n' +
+            '2️⃣  Paquetes turísticos\n' +
+            '3️⃣  Programa de afiliados\n' +
+            '4️⃣  Información general'
+          : 'What interests you most about Nexo Real?\n\n' +
+            '1️⃣  Properties\n' +
+            '2️⃣  Tour packages\n' +
+            '3️⃣  Affiliate program\n' +
+            '4️⃣  General information';
+
+      await flowDynamic([{ body: askArea }]);
+      await state.update({ awaitingAreaOfInterest: true });
+      return;
+    }
+
+    // ── STEP 4: Waiting for area of interest → save lead ────────────────────
+    if (currentState?.awaitingAreaOfInterest && !currentState?.leadSaved) {
+      const areaMap: Record<string, BotLeadAreaOfInterest> = {
+        '1': 'properties',
+        propiedad: 'properties',
+        propiedades: 'properties',
+        properties: 'properties',
+        property: 'properties',
+        '2': 'tours',
+        tour: 'tours',
+        tours: 'tours',
+        turistico: 'tours',
+        turístico: 'tours',
+        '3': 'affiliates',
+        afiliado: 'affiliates',
+        afiliados: 'affiliates',
+        affiliate: 'affiliates',
+        affiliates: 'affiliates',
+        '4': 'general',
+        general: 'general',
+      };
+
+      const key = incomingText.toLowerCase().trim();
+      const areaOfInterest: BotLeadAreaOfInterest = areaMap[key] ?? 'other';
+
+      await state.update({ areaOfInterest, awaitingAreaOfInterest: false, leadSaved: true });
+
+      // Persist lead — fire and forget (errors are caught inside the service)
+      // Persistir lead — fire and forget (los errores se capturan dentro del servicio)
+      void leadPersistenceService.saveLead({
+        name: userName,
+        phone,
+        email: currentState.userEmail,
+        areaOfInterest,
+        agentName: agent,
+        language: lang,
+        source: 'whatsapp_bot',
+      });
+
+      // Transition to AI conversation
+      // Transición a conversación con IA
+      const readyMsg =
+        lang === 'es'
+          ? `¡Perfecto, ${userName}! Ahora sí, contame — ¿en qué puedo ayudarte hoy? 😊`
+          : `Perfect, ${userName}! Now tell me — how can I help you today? 😊`;
+
+      await flowDynamic([{ body: readyMsg }]);
+      return;
+    }
+
+    // ── STEP 5: Full AI conversation ─────────────────────────────────────────
     if (!incomingText) return;
 
     try {

--- a/bot/src/services/lead-persistence.service.js
+++ b/bot/src/services/lead-persistence.service.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Lead Persistence Service — WhatsApp Bot
+ * @description Sends bot-captured lead data to the Nexo Real backend API for persistence.
+ *              Envía datos de leads capturados por el bot a la API del backend de Nexo Real.
+ * @module services/lead-persistence.service
+ */
+
+'use strict';
+
+const axios = require('axios');
+
+/** @typedef {import('../types/lead.types').BotLeadData} BotLeadData */
+
+/**
+ * Backend URL for the bot leads endpoint.
+ * URL del backend para el endpoint de leads del bot.
+ */
+const BOT_LEADS_URL = `${process.env.MLM_BACKEND_URL}/bot/leads`;
+
+/**
+ * Shared secret for bot → backend authentication.
+ * Secreto compartido para autenticación bot → backend.
+ */
+const BOT_SECRET = process.env.BOT_SECRET || '';
+
+/**
+ * Service responsible for persisting leads captured by the WhatsApp bot.
+ * Servicio responsable de persistir leads capturados por el bot de WhatsApp.
+ */
+const leadPersistenceService = {
+  /**
+   * Saves a bot-captured lead to the Nexo Real backend database.
+   * Guarda un lead capturado por el bot en la base de datos del backend de Nexo Real.
+   *
+   * Errors are caught and logged — a failed save must never crash the bot conversation.
+   * Los errores se capturan y loggean — un fallo al guardar jamás debe romper la conversación.
+   *
+   * @param {BotLeadData} data - Lead data captured during the bot conversation / Datos del lead capturados
+   * @returns {Promise<void>}
+   */
+  async saveLead(data) {
+    try {
+      await axios.post(BOT_LEADS_URL, data, {
+        headers: {
+          'Content-Type': 'application/json',
+          'x-bot-secret': BOT_SECRET,
+        },
+        timeout: 5000,
+      });
+
+      console.info(`[LeadPersistence] Lead saved — phone: ${data.phone}, agent: ${data.agentName}`);
+    } catch (error) {
+      // Non-fatal: log and continue — the bot conversation must not be interrupted
+      // No fatal: loggear y continuar — la conversación del bot no debe interrumpirse
+      const status = error?.response?.status;
+      const message = error?.response?.data?.message || error?.message || 'unknown error';
+      console.error(
+        `[LeadPersistence] Failed to save lead (phone: ${data.phone}) — ${status ?? 'network'}: ${message}`
+      );
+    }
+  },
+};
+
+module.exports = { leadPersistenceService };

--- a/bot/src/types/lead.types.ts
+++ b/bot/src/types/lead.types.ts
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Lead Types — WhatsApp Bot
+ * @description Type definitions for leads captured by the Nexo Real WhatsApp bot.
+ *              Definiciones de tipos para leads capturados por el bot de WhatsApp de Nexo Real.
+ * @module types/lead.types
+ */
+
+/**
+ * Area of interest for a bot-captured lead.
+ * Área de interés para un lead capturado por el bot.
+ */
+export type BotLeadAreaOfInterest = 'properties' | 'tours' | 'affiliates' | 'general' | 'other';
+
+/**
+ * Preferred language detected during bot conversation.
+ * Idioma preferido detectado durante la conversación con el bot.
+ */
+export type BotLeadLanguage = 'es' | 'en';
+
+/**
+ * Data structure for a lead captured by the WhatsApp bot.
+ * Estructura de datos para un lead capturado por el bot de WhatsApp.
+ *
+ * @property name           - Prospect's name as provided during onboarding / Nombre del prospecto
+ * @property phone          - WhatsApp phone number in international format / Teléfono en formato internacional
+ * @property email          - Optional email if provided during conversation / Email opcional si fue proporcionado
+ * @property areaOfInterest - Topic the prospect showed interest in / Tema de interés del prospecto
+ * @property agentName      - Bot agent that handled the conversation (Sophia or Max) / Agente bot que atendió
+ * @property language       - Language used during the conversation / Idioma usado en la conversación
+ * @property source         - Always 'whatsapp_bot' — identifies origin / Siempre 'whatsapp_bot'
+ */
+export interface BotLeadData {
+  name: string;
+  phone: string;
+  email?: string;
+  areaOfInterest?: BotLeadAreaOfInterest;
+  agentName: string;
+  language: BotLeadLanguage;
+  source: 'whatsapp_bot';
+}


### PR DESCRIPTION
Closes #113

## Summary
Captures leads from the WhatsApp bot conversation into the Nexo Real database. Every user who completes the welcome flow (language → name → email → area of interest) is automatically saved as a lead with `source = 'whatsapp_bot'`.

## Changes

### Bot
- `bot/src/types/lead.types.ts` — `BotLeadData` interface, `BotLeadAreaOfInterest` type
- `bot/src/services/lead-persistence.service.js` — fire & forget `saveLead()` via `POST /api/bot/leads`
- `bot/src/flows/welcome.flow.ts` — adds email (optional) + area of interest steps before AI conversation

### Backend
- `backend/database/migrations/20260409000000-add-whatsapp-bot-source.js` — `ALTER TYPE enum_leads_source ADD VALUE 'whatsapp_bot'` (idempotent)
- `backend/src/routes/bot-leads.routes.ts` — `POST /api/bot/leads` protected by `x-bot-secret`
- `backend/src/routes/bot.routes.ts` — registers `/leads` sub-router

## Notes
- `BOT_SYSTEM_USER_ID = 00000000-0000-0000-0000-000000000001` (admin@mlm.com — already in DB)
- Migration already applied to local DB (`ADD VALUE` must run outside transaction — PostgreSQL limitation)
- Lead save is fire & forget — a failed save **never** interrupts the bot conversation
- Duplicate phone → `ON CONFLICT DO NOTHING` (no error, returns `created: false`)