### PR TITLE
feat(bot): onboarding flow + centralized keywords registry (batch 8.5)

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -23,6 +23,10 @@ OPENAI_MODEL=gpt-4o-mini
 # Internal Docker network URL to the Nexo Real backend
 MLM_BACKEND_URL=http://backend:3000/api
 
+# Public URL of the Nexo Real frontend (used in onboarding messages)
+# URL pública del frontend de Nexo Real (usada en mensajes de onboarding)
+FRONTEND_URL=https://nexoreal.com
+
 # ─── PostgreSQL (same instance as Nexo Real backend) ──────────────────────────
 
 DB_HOST=postgres
@@ -46,3 +50,27 @@ N8N_SCHEDULE_VISIT_URL=https://n8n.nexoreal.xyz/webhook/schedule-visit
 # n8n webhook for human handoff (Notion + Brevo notification)
 # Webhook de n8n para handoff a agente humano (Notion + Brevo)
 N8N_HUMAN_HANDOFF_URL=https://n8n.nexoreal.xyz/webhook/human-handoff
+
+# ─── Google Calendar (n8n — Schedule Visit workflow) ─────────────────────────
+
+# ID of the team's Google Calendar used by n8n to create visit appointments
+# ID del Google Calendar del equipo usado por n8n para crear citas de visita
+GOOGLE_CALENDAR_ID=your_calendar_id@group.calendar.google.com
+
+# ─── Notion (n8n — Human Handoff + Lead workflows) ───────────────────────────
+
+# Notion database ID for storing scheduled visits
+# ID de la base de datos Notion para almacenar visitas agendadas
+NOTION_DATABASE_ID_VISITS=your_notion_visits_database_id
+
+# Notion database ID for storing leads captured by the bot
+# ID de la base de datos Notion para almacenar leads capturados por el bot
+NOTION_DATABASE_ID_LEADS=your_notion_leads_database_id
+
+# ─── Brevo (n8n — Human Handoff notification email) ──────────────────────────
+
+# Brevo transactional email template ID for human handoff notifications
+# ID de la plantilla de email transaccional de Brevo para notificaciones de handoff
+# Create the template at: https://app.brevo.com/email/template
+# TODO: create template and set this value before going to production
+BREVO_HANDOFF_TEMPLATE_ID=your_brevo_template_id

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -71,6 +71,6 @@ NOTION_DATABASE_ID_LEADS=your_notion_leads_database_id
 
 # Brevo transactional email template ID for human handoff notifications
 # ID de la plantilla de email transaccional de Brevo para notificaciones de handoff
-# Create the template at: https://app.brevo.com/email/template
-# TODO: create template and set this value before going to production
-BREVO_HANDOFF_TEMPLATE_ID=your_brevo_template_id
+# Template name: "Bot Handoff — Notificación Equipo" (#1)
+# Manage at: https://app.brevo.com/email/template
+BREVO_HANDOFF_TEMPLATE_ID=1

--- a/bot/src/app.ts
+++ b/bot/src/app.ts
@@ -19,6 +19,8 @@ import { scheduleFlow } from './flows/schedule.flow.js';
 import { handoffFlow } from './flows/handoff.flow.js';
 import { propertiesFlow } from './flows/properties.flow.js';
 import { toursFlow } from './flows/tours.flow.js';
+import { onboardingFlow } from './flows/onboarding.flow.js';
+import { COMMISSIONS_KEYWORDS } from './config/keywords.js';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -61,17 +63,18 @@ const database = new MemoryDB();
 /**
  * "comisiones" keyword — re-uses networkFlow logic (shows last commissions inline).
  * We create a thin alias flow here rather than duplicating network.flow.ts.
+ * Keywords are centralized in config/keywords.ts (COMMISSIONS_KEYWORDS).
  */
-const commissionsKeywordFlow = addKeyword(['comisiones', 'mis comisiones', 'ver comisiones'] as [
-  string,
-  ...string[],
-]).addAction(async (ctx: any, utils: any) => {
-  // Delegate to networkFlow which already includes commissions in its response
-  await utils.gotoFlow(networkFlow);
-});
+const commissionsKeywordFlow = addKeyword(COMMISSIONS_KEYWORDS).addAction(
+  async (ctx: any, utils: any) => {
+    // Delegate to networkFlow which already includes commissions in its response
+    await utils.gotoFlow(networkFlow);
+  }
+);
 
 const flow = createFlow([
   welcomeFlow,
+  onboardingFlow,
   balanceFlow,
   networkFlow,
   supportFlow,

--- a/bot/src/config/keywords.ts
+++ b/bot/src/config/keywords.ts
@@ -1,0 +1,187 @@
+/**
+ * @fileoverview Bot Keywords Configuration
+ * @description Centralized keyword registry for all bot flows.
+ *              Import from here instead of hardcoding strings in each flow.
+ *              Registro centralizado de keywords para todos los flows del bot.
+ *              Importar desde aquí en lugar de hardcodear strings en cada flow.
+ * @module config/keywords
+ */
+
+/**
+ * Tuple type helper — ensures addKeyword receives at least one string.
+ * Helper de tipo tupla — asegura que addKeyword reciba al menos un string.
+ */
+type Keywords = [string, ...string[]];
+
+/**
+ * Keywords that trigger the balance / wallet flow.
+ * Keywords que activan el flow de saldo / billetera.
+ */
+export const BALANCE_KEYWORDS: Keywords = [
+  'saldo',
+  'balance',
+  'mi saldo',
+  'ver saldo',
+  'billetera',
+  'wallet',
+];
+
+/**
+ * Keywords that trigger the network / referrals flow.
+ * Keywords que activan el flow de red / referidos.
+ */
+export const NETWORK_KEYWORDS: Keywords = [
+  'mi red',
+  'red',
+  'referidos',
+  'afiliados',
+  'ver red',
+  'equipo',
+  'downline',
+];
+
+/**
+ * Keywords that trigger the support / main menu flow.
+ * Keywords que activan el flow de soporte / menú principal.
+ */
+export const SUPPORT_KEYWORDS: Keywords = [
+  'ayuda',
+  'help',
+  'soporte',
+  'opciones',
+  'menu',
+  'menú',
+  'que puedo hacer',
+  'qué puedo hacer',
+  'comandos',
+];
+
+/**
+ * Keywords that trigger the schedule visit flow.
+ * Keywords que activan el flow de agendar visita.
+ */
+export const SCHEDULE_KEYWORDS: Keywords = [
+  'agendar',
+  'agenda',
+  'visita',
+  'visitar',
+  'quiero ver',
+  'ver propiedad',
+  'reunión',
+  'reunion',
+  'cita',
+  'schedule',
+  'visit',
+  'appointment',
+  'book a visit',
+  'book visit',
+];
+
+/**
+ * Keywords that trigger the human handoff flow.
+ * Keywords que activan el flow de derivación a agente humano.
+ */
+export const HANDOFF_KEYWORDS: Keywords = [
+  'hablar con alguien',
+  'hablar con una persona',
+  'hablar con un asesor',
+  'quiero un asesor',
+  'asesor humano',
+  'agente humano',
+  'persona real',
+  'no quiero hablar con un bot',
+  'speak to a human',
+  'talk to a person',
+  'human agent',
+  'real person',
+  'speak to agent',
+  'talk to agent',
+  'connect me with someone',
+];
+
+/**
+ * Keywords that trigger the properties browsing flow.
+ * Keywords que activan el flow de búsqueda de propiedades.
+ */
+export const PROPERTIES_KEYWORDS: Keywords = [
+  'propiedades',
+  'ver propiedades',
+  'buscar propiedades',
+  'inmuebles',
+  'alquileres',
+  'casas',
+  'departamentos',
+  'properties',
+  'real estate',
+  'houses',
+  'apartments',
+];
+
+/**
+ * Keywords that trigger the tours / travel packages flow.
+ * Keywords que activan el flow de tours / paquetes turísticos.
+ */
+export const TOURS_KEYWORDS: Keywords = [
+  'tours',
+  'tours disponibles',
+  'ver tours',
+  'buscar tours',
+  'paquetes',
+  'paquetes turísticos',
+  'viajes',
+  'excursiones',
+  'travel packages',
+  'available tours',
+  'tour packages',
+];
+
+/**
+ * Keywords for the commissions alias flow (delegates to networkFlow).
+ * Keywords para el flow alias de comisiones (delega a networkFlow).
+ */
+export const COMMISSIONS_KEYWORDS: Keywords = ['comisiones', 'mis comisiones', 'ver comisiones'];
+
+/**
+ * Keywords the welcome / onboarding flow accepts for language selection — Spanish.
+ * Keywords que el flow de bienvenida / onboarding acepta para selección de idioma — Español.
+ */
+export const LANGUAGE_ES_KEYWORDS: string[] = ['1', 'español', 'espanol', 'es', 'castellano'];
+
+/**
+ * Keywords the welcome / onboarding flow accepts for language selection — English.
+ * Keywords que el flow de bienvenida / onboarding acepta para selección de idioma — Inglés.
+ */
+export const LANGUAGE_EN_KEYWORDS: string[] = [
+  '2',
+  'english',
+  'inglés',
+  'ingles',
+  'en',
+  'english please',
+];
+
+/**
+ * Keywords the welcome flow accepts to skip optional fields (email).
+ * Keywords que el flow de bienvenida acepta para omitir campos opcionales (email).
+ */
+export const SKIP_KEYWORDS: string[] = ['omitir', 'skip', 'no', 'ninguno', 'none', '-'];
+
+/**
+ * Complete keywords registry — all flows grouped by feature.
+ * Registro completo de keywords — todos los flows agrupados por funcionalidad.
+ */
+export const BOT_KEYWORDS = {
+  balance: BALANCE_KEYWORDS,
+  network: NETWORK_KEYWORDS,
+  support: SUPPORT_KEYWORDS,
+  schedule: SCHEDULE_KEYWORDS,
+  handoff: HANDOFF_KEYWORDS,
+  properties: PROPERTIES_KEYWORDS,
+  tours: TOURS_KEYWORDS,
+  commissions: COMMISSIONS_KEYWORDS,
+  language: {
+    es: LANGUAGE_ES_KEYWORDS,
+    en: LANGUAGE_EN_KEYWORDS,
+  },
+  skip: SKIP_KEYWORDS,
+} as const;

--- a/bot/src/flows/balance.flow.ts
+++ b/bot/src/flows/balance.flow.ts
@@ -1,14 +1,6 @@
 import { addKeyword } from '@builderbot/bot';
 import { mlmApi } from '../services/mlm-api.service.js';
-
-const BALANCE_KEYWORDS: [string, ...string[]] = [
-  'saldo',
-  'balance',
-  'mi saldo',
-  'ver saldo',
-  'billetera',
-  'wallet',
-];
+import { BALANCE_KEYWORDS } from '../config/keywords.js';
 
 /**
  * Balance flow — responds with wallet balance + pending withdrawals.

--- a/bot/src/flows/handoff.flow.ts
+++ b/bot/src/flows/handoff.flow.ts
@@ -1,6 +1,7 @@
 import { addKeyword } from '@builderbot/bot';
 import { n8nService } from '../services/n8n.service.js';
 import type { Language, AgentName } from '../services/ai.service.js';
+import { HANDOFF_KEYWORDS } from '../config/keywords.js';
 
 /**
  * @file handoff.flow.ts
@@ -18,26 +19,6 @@ import type { Language, AgentName } from '../services/ai.service.js';
  *
  * @author Nexo Real Development Team
  */
-
-// ─── Keywords ────────────────────────────────────────────────────────────────
-
-const HANDOFF_KEYWORDS: [string, ...string[]] = [
-  'hablar con alguien',
-  'hablar con una persona',
-  'hablar con un asesor',
-  'quiero un asesor',
-  'asesor humano',
-  'agente humano',
-  'persona real',
-  'no quiero hablar con un bot',
-  'speak to a human',
-  'talk to a person',
-  'human agent',
-  'real person',
-  'speak to agent',
-  'talk to agent',
-  'connect me with someone',
-];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/bot/src/flows/language.flow.ts
+++ b/bot/src/flows/language.flow.ts
@@ -1,5 +1,6 @@
 import { addKeyword, EVENTS } from '@builderbot/bot';
 import type { Language } from '../services/ai.service.js';
+import { LANGUAGE_ES_KEYWORDS, LANGUAGE_EN_KEYWORDS } from '../config/keywords.js';
 
 /**
  * Language detection flow.
@@ -7,18 +8,22 @@ import type { Language } from '../services/ai.service.js';
  * Triggered on WELCOME — asks the user to choose Spanish or English.
  * Stores the choice in BuilderBot state as `lang: Language`.
  *
- * Keywords that trigger language selection directly:
- *   - "1", "español", "espanol", "es" → 'es'
- *   - "2", "english", "inglés", "ingles", "en" → 'en'
+ * Keywords are centralized in config/keywords.ts:
+ *   - LANGUAGE_ES_KEYWORDS → 'es'
+ *   - LANGUAGE_EN_KEYWORDS → 'en'
  */
 
-const ES_KEYWORDS = ['1', 'español', 'espanol', 'es', 'castellano'];
-const EN_KEYWORDS = ['2', 'english', 'inglés', 'ingles', 'en', 'english please'];
-
+/**
+ * Detects language from user input using centralized keyword lists.
+ * Detecta el idioma del input del usuario usando las listas centralizadas de keywords.
+ *
+ * @param text - Raw user input / Texto crudo del usuario
+ * @returns 'es' | 'en' | null
+ */
 function detectLanguageFromText(text: string): Language | null {
   const normalized = text.trim().toLowerCase();
-  if (ES_KEYWORDS.includes(normalized)) return 'es';
-  if (EN_KEYWORDS.includes(normalized)) return 'en';
+  if (LANGUAGE_ES_KEYWORDS.includes(normalized)) return 'es';
+  if (LANGUAGE_EN_KEYWORDS.includes(normalized)) return 'en';
   return null;
 }
 

--- a/bot/src/flows/network.flow.ts
+++ b/bot/src/flows/network.flow.ts
@@ -1,15 +1,6 @@
 import { addKeyword } from '@builderbot/bot';
 import { mlmApi } from '../services/mlm-api.service.js';
-
-const NETWORK_KEYWORDS: [string, ...string[]] = [
-  'mi red',
-  'red',
-  'referidos',
-  'afiliados',
-  'ver red',
-  'equipo',
-  'downline',
-];
+import { NETWORK_KEYWORDS } from '../config/keywords.js';
 
 /**
  * Network flow — shows the user's downline summary: total referrals,

--- a/bot/src/flows/onboarding.flow.ts
+++ b/bot/src/flows/onboarding.flow.ts
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview Onboarding Flow — Nexo Real WhatsApp Bot
+ * @description Sequential welcome flow for new users arriving at the bot for the first time.
+ *              Shows the main menu and options available, then routes to specific flows.
+ *              Flujo de bienvenida secuencial para nuevos usuarios que llegan al bot por primera vez.
+ *              Muestra el menú principal y las opciones disponibles, luego enruta a flows específicos.
+ *
+ * This flow is triggered manually (via gotoFlow from welcomeFlow or support commands).
+ * Este flow se activa manualmente (via gotoFlow desde welcomeFlow o comandos de soporte).
+ *
+ * @module flows/onboarding.flow
+ */
+
+import { addKeyword, EVENTS } from '@builderbot/bot';
+import type { Language } from '../services/ai.service.js';
+
+// ─── Menu Messages ────────────────────────────────────────────────────────────
+
+/**
+ * Main menu message per language.
+ * Mensaje del menú principal por idioma.
+ */
+const MENU = {
+  es:
+    `🏡 *Bienvenido a Nexo Real*\n\n` +
+    `Soy tu asistente virtual. Puedo ayudarte con:\n\n` +
+    `1️⃣  *Propiedades* — buscar casas, departamentos, alquileres\n` +
+    `2️⃣  *Tours* — paquetes turísticos y viajes\n` +
+    `3️⃣  *Mi cuenta* — saldo, red de referidos, comisiones\n` +
+    `4️⃣  *Agendar visita* — reservar una reunión o visita\n` +
+    `5️⃣  *Hablar con asesor* — conectarte con una persona real\n\n` +
+    `Escribí el número o el nombre de la opción. También podés preguntarme directamente lo que necesitás. 😊`,
+
+  en:
+    `🏡 *Welcome to Nexo Real*\n\n` +
+    `I'm your virtual assistant. I can help you with:\n\n` +
+    `1️⃣  *Properties* — search houses, apartments, rentals\n` +
+    `2️⃣  *Tours* — tourism packages and travel\n` +
+    `3️⃣  *My account* — balance, referral network, commissions\n` +
+    `4️⃣  *Schedule a visit* — book a meeting or property visit\n` +
+    `5️⃣  *Talk to an advisor* — connect with a real person\n\n` +
+    `Type the number or name of the option. You can also ask me directly what you need. 😊`,
+} as const;
+
+// ─── Flow ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Onboarding flow — shows the main menu to the user.
+ * Can be triggered from support keywords or re-entered at any time.
+ *
+ * Flujo de onboarding — muestra el menú principal al usuario.
+ * Puede ser activado desde keywords de soporte o re-ingresado en cualquier momento.
+ *
+ * @remarks
+ * This flow uses EVENTS.ACTION to make it invokable via gotoFlow from other flows.
+ * The welcomeFlow handles initial greeting + language + name — onboarding takes over after setup.
+ * Este flow usa EVENTS.ACTION para ser invocable via gotoFlow desde otros flows.
+ * El welcomeFlow maneja el saludo inicial + idioma + nombre — onboarding toma el control después del setup.
+ */
+export const onboardingFlow = addKeyword(EVENTS.ACTION).addAction(
+  async (_ctx: any, { state, flowDynamic }: any) => {
+    const currentState = state.getMyState() as { lang?: Language };
+    const lang: Language = currentState?.lang ?? 'es';
+
+    await flowDynamic([{ body: MENU[lang] }]);
+  }
+);

--- a/bot/src/flows/properties.flow.ts
+++ b/bot/src/flows/properties.flow.ts
@@ -1,23 +1,6 @@
 import { addKeyword } from '@builderbot/bot';
 import { mlmApi, type BotProperty } from '../services/mlm-api.service.js';
-
-/**
- * Keywords that trigger the properties flow in Spanish and English.
- * Palabras clave que activan el flujo de propiedades en español e inglés.
- */
-const PROPERTIES_KEYWORDS: [string, ...string[]] = [
-  'propiedades',
-  'ver propiedades',
-  'buscar propiedades',
-  'inmuebles',
-  'alquileres',
-  'casas',
-  'departamentos',
-  'properties',
-  'real estate',
-  'houses',
-  'apartments',
-];
+import { PROPERTIES_KEYWORDS } from '../config/keywords.js';
 
 /**
  * Formats a list of properties into a human-readable WhatsApp message.

--- a/bot/src/flows/schedule.flow.ts
+++ b/bot/src/flows/schedule.flow.ts
@@ -1,6 +1,7 @@
 import { addKeyword } from '@builderbot/bot';
 import { n8nService } from '../services/n8n.service.js';
 import type { Language } from '../services/ai.service.js';
+import { SCHEDULE_KEYWORDS } from '../config/keywords.js';
 
 /**
  * @file schedule.flow.ts
@@ -15,25 +16,6 @@ import type { Language } from '../services/ai.service.js';
  *
  * @author Nexo Real Development Team
  */
-
-// ─── Keywords ────────────────────────────────────────────────────────────────
-
-const SCHEDULE_KEYWORDS: [string, ...string[]] = [
-  'agendar',
-  'agenda',
-  'visita',
-  'visitar',
-  'quiero ver',
-  'ver propiedad',
-  'reunión',
-  'reunion',
-  'cita',
-  'schedule',
-  'visit',
-  'appointment',
-  'book a visit',
-  'book visit',
-];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/bot/src/flows/support.flow.ts
+++ b/bot/src/flows/support.flow.ts
@@ -1,16 +1,5 @@
 import { addKeyword } from '@builderbot/bot';
-
-const SUPPORT_KEYWORDS: [string, ...string[]] = [
-  'ayuda',
-  'help',
-  'soporte',
-  'opciones',
-  'menu',
-  'menú',
-  'que puedo hacer',
-  'qué puedo hacer',
-  'comandos',
-];
+import { SUPPORT_KEYWORDS } from '../config/keywords.js';
 
 /**
  * Support / FAQ flow — shows all available commands and a link to the platform.

--- a/bot/src/flows/tours.flow.ts
+++ b/bot/src/flows/tours.flow.ts
@@ -1,23 +1,6 @@
 import { addKeyword } from '@builderbot/bot';
 import { mlmApi, type BotTour } from '../services/mlm-api.service.js';
-
-/**
- * Keywords that trigger the tours flow in Spanish and English.
- * Palabras clave que activan el flujo de tours en español e inglés.
- */
-const TOURS_KEYWORDS: [string, ...string[]] = [
-  'tours',
-  'tours disponibles',
-  'ver tours',
-  'buscar tours',
-  'paquetes',
-  'paquetes turísticos',
-  'viajes',
-  'excursiones',
-  'travel packages',
-  'available tours',
-  'tour packages',
-];
+import { TOURS_KEYWORDS } from '../config/keywords.js';
 
 /**
  * Formats a list of tour packages into a human-readable WhatsApp message.

--- a/bot/src/flows/welcome.flow.ts
+++ b/bot/src/flows/welcome.flow.ts
@@ -4,6 +4,7 @@ import { resolveLanguageFromInput } from './language.flow.js';
 import { assignAgent, getAgentIntro, getAgentTransitionMessage } from './agent.flow.js';
 import { leadPersistenceService } from '../services/lead-persistence.service.js';
 import type { BotLeadAreaOfInterest } from '../types/lead.types.js';
+import { SKIP_KEYWORDS } from '../config/keywords.js';
 
 /**
  * Welcome flow — Nexo Real AI Bot
@@ -110,8 +111,7 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
 
     // ── STEP 3: Waiting for email ────────────────────────────────────────────
     if (currentState?.awaitingEmail) {
-      const skipKeywords = ['omitir', 'skip', 'no', 'ninguno', 'none', '-'];
-      const isSkip = skipKeywords.some((k) => incomingText.toLowerCase().includes(k));
+      const isSkip = SKIP_KEYWORDS.some((k) => incomingText.toLowerCase().includes(k));
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
       const isEmail = emailRegex.test(incomingText);
       const userEmail = isSkip || !isEmail ? undefined : incomingText;


### PR DESCRIPTION
## Summary

Batch 8.5 — Onboarding Flow & Keywords Registry centralization.

## Changes

### New files
- `bot/src/config/keywords.ts` — Single source of truth for ALL bot keywords. Exports typed constants (`Keywords = [string, ...string[]]`) for every flow, plus `LANGUAGE_ES/EN_KEYWORDS`, `SKIP_KEYWORDS`, `COMMISSIONS_KEYWORDS`, and the `BOT_KEYWORDS` registry object.
- `bot/src/flows/onboarding.flow.ts` — Triggered via `EVENTS.ACTION` (invocable with `gotoFlow`). Shows a bilingual menu (ES/EN) with all available bot features.

### Refactored flows (keywords now imported from `config/keywords.ts`)
| File | Removed hardcoded array | Now uses |
|------|------------------------|----------|
| `balance.flow.ts` | `['saldo', ...]` | `BALANCE_KEYWORDS` |
| `network.flow.ts` | `['mi red', ...]` | `NETWORK_KEYWORDS` |
| `support.flow.ts` | `['ayuda', ...]` | `SUPPORT_KEYWORDS` |
| `schedule.flow.ts` | `['agendar', ...]` | `SCHEDULE_KEYWORDS` |
| `handoff.flow.ts` | `['hablar con alguien', ...]` | `HANDOFF_KEYWORDS` |
| `properties.flow.ts` | `['propiedades', ...]` | `PROPERTIES_KEYWORDS` |
| `tours.flow.ts` | `['tours', ...]` | `TOURS_KEYWORDS` |
| `language.flow.ts` | `ES_KEYWORDS` / `EN_KEYWORDS` (local consts) | `LANGUAGE_ES_KEYWORDS` / `LANGUAGE_EN_KEYWORDS` |
| `welcome.flow.ts` | `skipKeywords` inline array (line 113) | `SKIP_KEYWORDS` |

### Updated files
- `app.ts` — Import `onboardingFlow` + `COMMISSIONS_KEYWORDS`; register `onboardingFlow` in `createFlow([...])` ; remove hardcoded commissions array.
- `bot/.env.example` — Add `FRONTEND_URL`, `GOOGLE_CALENDAR_ID`, `NOTION_DATABASE_ID_VISITS`, `NOTION_DATABASE_ID_LEADS`, `BREVO_HANDOFF_TEMPLATE_ID`.

## Related issue

Closes #115

## Testing

- CI must pass (TypeScript build + lint)
- No runtime changes to existing flows — only keyword source moved to central registry
- `onboardingFlow` is only triggered via `gotoFlow` from other flows (not keyword-triggered directly)