### PR TITLE
fix(n8n): replace deprecated sendInBlue node with httpRequest for Brevo API

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -118,3 +118,7 @@ NOTION_DATABASE_ID_LEADS=your_notion_leads_database_id
 # Brevo (Sendinblue) — Human Handoff email template (n8n)
 # Brevo (Sendinblue) — Template de email de handoff (n8n)
 BREVO_HANDOFF_TEMPLATE_ID=your_brevo_handoff_template_id
+
+# Sales team email — Human Handoff notifications (n8n)
+# Email del equipo de ventas — Notificaciones de handoff (n8n)
+SALES_TEAM_EMAIL=sales@yourdomain.com

--- a/bot/n8n/workflows/human-handoff.json
+++ b/bot/n8n/workflows/human-handoff.json
@@ -85,35 +85,38 @@
     },
     {
       "parameters": {
-        "resource": "email",
-        "operation": "send",
-        "templateId": "={{ $env.BREVO_HANDOFF_TEMPLATE_ID }}",
-        "to": [
-          {
-            "email": "={{ $env.SALES_TEAM_EMAIL }}",
-            "name": "Equipo de Ventas Nexo Real"
-          }
-        ],
-        "params": {
-          "lead_name": "={{ $node['Validate & Transform Input'].json.name }}",
-          "lead_phone": "={{ $node['Validate & Transform Input'].json.phone }}",
-          "lead_summary": "={{ $node['Validate & Transform Input'].json.summary }}",
-          "bot_agent": "={{ $node['Validate & Transform Input'].json.agentName }}",
-          "handoff_time": "={{ $node['Validate & Transform Input'].json.handoffAt }}",
-          "notion_url": "=https://notion.so/{{ $json.id.replace(/-/g, '') }}"
-        }
+        "method": "POST",
+        "url": "https://api.brevo.com/v3/smtp/email",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "api-key",
+              "value": "={{ $env.BREVO_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": []
+        },
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"to\": [{\"email\": \"{{ $env.SALES_TEAM_EMAIL }}\", \"name\": \"Equipo Nexo Real\"}],\n  \"templateId\": {{ $env.BREVO_HANDOFF_TEMPLATE_ID }},\n  \"params\": {\n    \"lead_name\": \"{{ $node['Validate & Transform Input'].json.name }}\",\n    \"lead_phone\": \"{{ $node['Validate & Transform Input'].json.phone }}\",\n    \"lead_summary\": \"{{ $node['Validate & Transform Input'].json.summary }}\",\n    \"bot_agent\": \"{{ $node['Validate & Transform Input'].json.agentName }}\",\n    \"handoff_time\": \"{{ $node['Validate & Transform Input'].json.handoffAt }}\",\n    \"notion_url\": \"https://notion.so/{{ $node['Notion — Create Lead'].json.id.replace(/-/g, '') }}\"\n  }\n}",
+        "options": {}
       },
       "id": "brevo-send-email",
       "name": "Brevo — Send Handoff Email",
-      "type": "n8n-nodes-base.sendInBlue",
-      "typeVersion": 1,
-      "position": [680, 400],
-      "credentials": {
-        "sendInBlueApi": {
-          "id": "brevo-credentials",
-          "name": "Brevo — Nexo Real"
-        }
-      }
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [680, 400]
     },
     {
       "parameters": {
@@ -222,5 +225,5 @@
   "tags": ["nexo-real", "bot", "handoff", "notion", "brevo", "sprint8"],
   "triggerCount": 0,
   "updatedAt": "2026-04-09T00:00:00.000Z",
-  "versionId": "1.0.0"
+  "versionId": "1.1.0"
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -201,9 +201,17 @@ services:
       # ── Google Calendar integration ────────────────────────────────────
       # Credentials are configured via the n8n UI, not env vars.
       # See docs/N8N-SETUP.md for the setup guide.
+      GOOGLE_CALENDAR_ID: ${GOOGLE_CALENDAR_ID}
 
       # ── Notion integration ─────────────────────────────────────────────
       # Credentials are configured via the n8n UI, not env vars.
+      NOTION_LEADS_DB_ID: ${NOTION_DATABASE_ID_LEADS}
+      NOTION_DATABASE_ID_VISITS: ${NOTION_DATABASE_ID_VISITS}
+
+      # ── Brevo — Human Handoff email (httpRequest node, no credential needed) ─
+      BREVO_API_KEY: ${BREVO_API_KEY}
+      BREVO_HANDOFF_TEMPLATE_ID: ${BREVO_HANDOFF_TEMPLATE_ID:-1}
+      SALES_TEAM_EMAIL: ${SALES_TEAM_EMAIL}
 
     volumes:
       - n8n_data:/home/node/.n8n


### PR DESCRIPTION
## Problem

`n8n-nodes-base.sendInBlue` was removed in n8n v2.x. The `human-handoff` workflow failed to load the Brevo credential because the node type no longer exists in the container.

## Solution

Replace the `sendInBlue` node with a standard `httpRequest` node that calls the Brevo REST API v3 directly:

- `POST https://api.brevo.com/v3/smtp/email`
- API Key passed via `$env.BREVO_API_KEY` header (no credential object needed)
- Template ID read from `$env.BREVO_HANDOFF_TEMPLATE_ID` (= `1`)
- All params preserved: `lead_name`, `lead_phone`, `lead_summary`, `bot_agent`, `handoff_time`, `notion_url`

## Required n8n env var

Add to n8n environment:
```
BREVO_API_KEY=xkeysib-...   # full API key from app.brevo.com
SALES_TEAM_EMAIL=team@nexoreal.xyz
```

## Files changed

- `bot/n8n/workflows/human-handoff.json` — node replaced, connections unchanged