### PR TITLE
feat(rbac): expand user roles to 9 granular roles with full RBAC implementation

### DIFF
--- a/backend/src/__tests__/fixtures.ts
+++ b/backend/src/__tests__/fixtures.ts
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Test fixtures for integration tests
  * @description Provides reusable factory functions for creating test data
+ * Provee funciones de fábrica reutilizables para crear datos de prueba
  *
  * @module __tests__/fixtures
  */
@@ -9,16 +10,21 @@ import { User, UserClosure } from '../models';
 import { sequelize } from '../config/database';
 import bcrypt from 'bcryptjs';
 import { generateToken } from '../services/AuthService';
+import type { UserRole } from '../types';
 
 /**
- * Create a test user with valid credentials
- * Populates the closure table if sponsorId is provided
+ * Create a test user with valid credentials.
+ * Populates the closure table if sponsorId is provided.
+ *
+ * Crea un usuario de prueba con credenciales válidas.
+ * Rellena la tabla de cierre si se provee sponsorId.
  */
 export async function createTestUser(
   overrides: {
     email?: string;
     password?: string;
-    role?: 'admin' | 'user';
+    /** Any valid UserRole — defaults to 'user' */
+    role?: UserRole;
     sponsorId?: string | null;
     position?: 'left' | 'right' | null;
     referralCode?: string;
@@ -78,7 +84,8 @@ export async function createTestUser(
 }
 
 /**
- * Create an admin user for testing
+ * Create an admin user for testing.
+ * Crea un usuario con rol 'admin' para pruebas.
  */
 export async function createAdminUser(): Promise<User> {
   const unique = Math.random().toString(36).substring(7).toUpperCase();
@@ -90,7 +97,8 @@ export async function createAdminUser(): Promise<User> {
 }
 
 /**
- * Create a regular user for testing
+ * Create a regular user for testing.
+ * Crea un usuario con rol 'user' para pruebas.
  */
 export async function createRegularUser(): Promise<User> {
   const unique = Math.random().toString(36).substring(7).toUpperCase();
@@ -98,6 +106,72 @@ export async function createRegularUser(): Promise<User> {
     email: `user_${Date.now()}_${unique}@mlm.test`,
     role: 'user',
     referralCode: `USR${unique}`,
+  });
+}
+
+/**
+ * Create a vendor user for testing.
+ * Crea un usuario con rol 'vendor' para pruebas.
+ */
+export async function createVendorUser(): Promise<User> {
+  const unique = Math.random().toString(36).substring(7).toUpperCase();
+  return createTestUser({
+    email: `vendor_${Date.now()}_${unique}@mlm.test`,
+    role: 'vendor',
+    referralCode: `VND${unique}`,
+  });
+}
+
+/**
+ * Create a finance user for testing.
+ * Crea un usuario con rol 'finance' para pruebas.
+ */
+export async function createFinanceUser(): Promise<User> {
+  const unique = Math.random().toString(36).substring(7).toUpperCase();
+  return createTestUser({
+    email: `finance_${Date.now()}_${unique}@mlm.test`,
+    role: 'finance',
+    referralCode: `FIN${unique}`,
+  });
+}
+
+/**
+ * Create a sales user for testing.
+ * Crea un usuario con rol 'sales' para pruebas.
+ */
+export async function createSalesUser(): Promise<User> {
+  const unique = Math.random().toString(36).substring(7).toUpperCase();
+  return createTestUser({
+    email: `sales_${Date.now()}_${unique}@mlm.test`,
+    role: 'sales',
+    referralCode: `SAL${unique}`,
+  });
+}
+
+/**
+ * Create a guest user for testing.
+ * Crea un usuario con rol 'guest' para pruebas.
+ */
+export async function createGuestUser(): Promise<User> {
+  const unique = Math.random().toString(36).substring(7).toUpperCase();
+  return createTestUser({
+    email: `guest_${Date.now()}_${unique}@mlm.test`,
+    role: 'guest',
+    referralCode: `GST${unique}`,
+  });
+}
+
+/**
+ * Create a super_admin user for testing.
+ * NOTE: In production, super_admin is set directly in DB — this is for test coverage only.
+ * NOTA: En producción, super_admin se asigna directo en DB — esto es solo para cobertura de tests.
+ */
+export async function createSuperAdminUser(): Promise<User> {
+  const unique = Math.random().toString(36).substring(7).toUpperCase();
+  return createTestUser({
+    email: `superadmin_${Date.now()}_${unique}@mlm.test`,
+    role: 'super_admin',
+    referralCode: `SUP${unique}`,
   });
 }
 

--- a/backend/src/__tests__/integration/rbac.test.ts
+++ b/backend/src/__tests__/integration/rbac.test.ts
@@ -1,12 +1,20 @@
 /**
  * @fileoverview RBAC Integration Tests
  * @description Tests for Role-Based Access Control - admin vs regular user permissions
+ * Tests para Control de Acceso Basado en Roles — permisos de admin vs usuario regular
  *
  * @module __tests__/integration/rbac
  */
 
 import { testAgent } from '../setup';
-import { createTestUser, createAdminUser, createRegularUser, getAuthHeaders } from '../fixtures';
+import {
+  createTestUser,
+  createAdminUser,
+  createRegularUser,
+  createGuestUser,
+  createSuperAdminUser,
+  getAuthHeaders,
+} from '../fixtures';
 
 describe('RBAC Integration Tests', () => {
   describe('Admin Endpoints - Access Control', () => {
@@ -209,6 +217,159 @@ describe('RBAC Integration Tests', () => {
         const res = await testAgent.get('/api/admin/reports/commissions').set(headers).expect(403);
 
         expect(res.body.success).toBe(false);
+      });
+    });
+
+    describe('PATCH /api/admin/users/:userId/role', () => {
+      it('should allow admin to assign a valid role to a user', async () => {
+        const admin = await createAdminUser();
+        const target = await createRegularUser();
+        const headers = getAuthHeaders(admin);
+
+        const res = await testAgent
+          .patch(`/api/admin/users/${target.id}/role`)
+          .set(headers)
+          .send({ role: 'vendor' })
+          .expect(200);
+
+        expect(res.body.success).toBe(true);
+        expect(res.body.data.role).toBe('vendor');
+      });
+
+      it('should deny regular user from changing roles', async () => {
+        const user = await createRegularUser();
+        const target = await createRegularUser();
+        const headers = getAuthHeaders(user);
+
+        const res = await testAgent
+          .patch(`/api/admin/users/${target.id}/role`)
+          .set(headers)
+          .send({ role: 'vendor' })
+          .expect(403);
+
+        expect(res.body.success).toBe(false);
+      });
+
+      it('should deny unauthenticated request', async () => {
+        const target = await createRegularUser();
+
+        const res = await testAgent
+          .patch(`/api/admin/users/${target.id}/role`)
+          .send({ role: 'vendor' });
+
+        expect([401, 403]).toContain(res.status);
+        expect(res.body.success).toBe(false);
+      });
+
+      it('should reject assigning super_admin via API', async () => {
+        const admin = await createAdminUser();
+        const target = await createRegularUser();
+        const headers = getAuthHeaders(admin);
+
+        const res = await testAgent
+          .patch(`/api/admin/users/${target.id}/role`)
+          .set(headers)
+          .send({ role: 'super_admin' })
+          .expect(400);
+
+        expect(res.body.success).toBe(false);
+      });
+
+      it('should reject an invalid/unknown role', async () => {
+        const admin = await createAdminUser();
+        const target = await createRegularUser();
+        const headers = getAuthHeaders(admin);
+
+        const res = await testAgent
+          .patch(`/api/admin/users/${target.id}/role`)
+          .set(headers)
+          .send({ role: 'wizard' })
+          .expect(400);
+
+        expect(res.body.success).toBe(false);
+      });
+
+      it('should not allow admin to change their own role', async () => {
+        const admin = await createAdminUser();
+        const headers = getAuthHeaders(admin);
+
+        const res = await testAgent
+          .patch(`/api/admin/users/${admin.id}/role`)
+          .set(headers)
+          .send({ role: 'user' })
+          .expect(400);
+
+        expect(res.body.success).toBe(false);
+      });
+
+      it('should not allow demoting an existing super_admin', async () => {
+        const admin = await createAdminUser();
+        const superAdmin = await createSuperAdminUser();
+        const headers = getAuthHeaders(admin);
+
+        const res = await testAgent
+          .patch(`/api/admin/users/${superAdmin.id}/role`)
+          .set(headers)
+          .send({ role: 'user' })
+          .expect(403);
+
+        expect(res.body.success).toBe(false);
+      });
+
+      it('should return 404 for non-existent user', async () => {
+        const admin = await createAdminUser();
+        const headers = getAuthHeaders(admin);
+
+        const res = await testAgent
+          .patch('/api/admin/users/00000000-0000-0000-0000-000000000000/role')
+          .set(headers)
+          .send({ role: 'user' })
+          .expect(404);
+
+        expect(res.body.success).toBe(false);
+      });
+
+      it('should promote guest to user and return updated role in response', async () => {
+        const admin = await createAdminUser();
+        const guest = await createGuestUser();
+        const headers = getAuthHeaders(admin);
+
+        const res = await testAgent
+          .patch(`/api/admin/users/${guest.id}/role`)
+          .set(headers)
+          .send({ role: 'user' })
+          .expect(200);
+
+        expect(res.body.success).toBe(true);
+        expect(res.body.data.role).toBe('user');
+        expect(res.body.message).toMatch(/guest.*user/i);
+      });
+
+      it('should allow all valid assignable roles to be set', async () => {
+        const admin = await createAdminUser();
+        const headers = getAuthHeaders(admin);
+        const assignableRoles = [
+          'admin',
+          'finance',
+          'sales',
+          'advisor',
+          'vendor',
+          'user',
+          'guest',
+          'bot',
+        ];
+
+        for (const role of assignableRoles) {
+          const target = await createRegularUser();
+          const res = await testAgent
+            .patch(`/api/admin/users/${target.id}/role`)
+            .set(headers)
+            .send({ role })
+            .expect(200);
+
+          expect(res.body.success).toBe(true);
+          expect(res.body.data.role).toBe(role);
+        }
       });
     });
   });

--- a/backend/src/controllers/AdminController.ts
+++ b/backend/src/controllers/AdminController.ts
@@ -18,4 +18,5 @@ export {
   getUserById,
   updateUserStatus,
   promoteToAdmin,
+  updateUserRole,
 } from './admin/UsersAdminController';

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -36,6 +36,7 @@ import type { ApiResponse, UserAttributes } from '../types';
 import { AppError } from '../middleware/error.middleware';
 import type { AuthenticatedRequest } from '../middleware/auth.middleware';
 import { asyncHandler } from '../middleware/asyncHandler';
+import { Lead } from '../models/Lead';
 
 // Re-export profile controller (maintains backward compatibility)
 export { me } from './auth/ProfileController';
@@ -61,6 +62,25 @@ export const registerValidation = [
 export const loginValidation = [
   body('email').isEmail().withMessage('Valid email is required').normalizeEmail(),
   body('password').notEmpty().withMessage('Password is required'),
+];
+
+/**
+ * Validation rules for guest registration
+ * Reglas de validación para registro de invitado
+ *
+ * @description Minimal registration: only name, email, and optional phone/sponsor.
+ *              No password required — guest accounts cannot log in until role is promoted.
+ *              Registro mínimo: solo nombre, email, y teléfono/sponsor opcionales.
+ *              No requiere contraseña — los guests no pueden iniciar sesión hasta que se promueva el rol.
+ */
+export const registerGuestValidation = [
+  body('email').isEmail().withMessage('Valid email is required').normalizeEmail(),
+  body('name')
+    .trim()
+    .isLength({ min: 2, max: 100 })
+    .withMessage('Name must be between 2 and 100 characters'),
+  body('phone').optional().isMobilePhone('any').withMessage('Invalid phone number'),
+  body('sponsor_code').optional().isString().withMessage('Sponsor code must be a string'),
 ];
 
 /**
@@ -215,5 +235,87 @@ export const login: RequestHandler = asyncHandler(
     };
 
     res.json(response);
+  }
+);
+
+/**
+ * Register a guest user (no password required)
+ * Registra un usuario invitado (sin contraseña)
+ *
+ * @description Creates a User with role='guest' and automatically creates a Lead in the CRM.
+ *              The guest cannot log in — they must be promoted (PATCH /admin/users/:id/role)
+ *              to user|vendor|advisor before they receive full access.
+ *
+ *              Crea un User con role='guest' y automáticamente crea un Lead en el CRM.
+ *              El guest no puede iniciar sesión — debe ser promovido (PATCH /admin/users/:id/role)
+ *              a user|vendor|advisor para recibir acceso completo.
+ *
+ * @param req - Express request with name, email, and optional phone/sponsor_code
+ * @param res - Express response with created user data (no token)
+ * @throws {AppError} 400 - If email already registered
+ *
+ * @example
+ * // English: Register a guest from landing page contact form
+ * POST /auth/register/guest
+ * { "name": "Juan Pérez", "email": "juan@example.com", "phone": "+54911234567" }
+ *
+ * // Español: Registrar un invitado desde formulario de contacto
+ * POST /auth/register/guest
+ * { "name": "Juan Pérez", "email": "juan@example.com", "phone": "+54911234567" }
+ */
+export const registerGuest: RequestHandler = asyncHandler(
+  async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const { name, email, phone, sponsor_code } = req.body;
+
+    // Check for existing user / Verificar usuario existente
+    const existingUser = await userService.findByEmail(email);
+    if (existingUser) {
+      throw new AppError(400, 'VALIDATION_ERROR', 'Email already registered');
+    }
+
+    // Guests get a random placeholder password — they cannot log in
+    // Los guests reciben una contraseña aleatoria — no pueden iniciar sesión
+    const placeholderPassword = `guest_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    const passwordHash = await hashPassword(placeholderPassword);
+
+    const user = await userService.createUser({
+      email,
+      passwordHash,
+      sponsorCode: sponsor_code,
+      currency: 'USD',
+      role: 'guest',
+    });
+
+    // Auto-create a Lead in the CRM for this guest
+    // Crear automáticamente un Lead en el CRM para este invitado
+    await Lead.create({
+      userId: user.sponsorId || user.id, // Assign to sponsor if exists, otherwise self
+      contactName: name,
+      contactEmail: email,
+      contactPhone: phone || null,
+      status: 'new',
+      source: 'website',
+      value: 0,
+      currency: 'USD',
+      referredBy: user.sponsorId || null,
+      metadata: {
+        guestUserId: user.id,
+        registeredAt: new Date().toISOString(),
+      },
+    });
+
+    const response: ApiResponse<{ user: Partial<UserAttributes> }> = {
+      success: true,
+      data: {
+        user: {
+          id: user.id,
+          email: user.email,
+          referralCode: user.referralCode,
+          role: user.role,
+        },
+      },
+    };
+
+    res.status(201).json(response);
   }
 );

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -25,6 +25,7 @@
  * router.post('/auth/login', loginValidation, login);
  * router.get('/auth/me', authenticateToken, me);
  */
+import { randomBytes } from 'crypto';
 import { Response, RequestHandler } from 'express';
 import { body } from 'express-validator';
 import { userService } from '../services/UserService';
@@ -273,9 +274,9 @@ export const registerGuest: RequestHandler = asyncHandler(
       throw new AppError(400, 'VALIDATION_ERROR', 'Email already registered');
     }
 
-    // Guests get a random placeholder password — they cannot log in
-    // Los guests reciben una contraseña aleatoria — no pueden iniciar sesión
-    const placeholderPassword = `guest_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    // Guests get a cryptographically secure random placeholder password — they cannot log in
+    // Los guests reciben una contraseña aleatoria segura — no pueden iniciar sesión
+    const placeholderPassword = `guest_${Date.now()}_${randomBytes(16).toString('hex')}`;
     const passwordHash = await hashPassword(placeholderPassword);
 
     const user = await userService.createUser({

--- a/backend/src/controllers/admin/UsersAdminController.ts
+++ b/backend/src/controllers/admin/UsersAdminController.ts
@@ -7,13 +7,28 @@
 import { Response } from 'express';
 import { Op, WhereOptions } from 'sequelize';
 import { User, Commission } from '../../models';
-import type { UserAttributes } from '../../types';
+import type { UserAttributes, UserRole, USER_ROLES } from '../../types';
 
 // Type for User where clauses
 type UserWhereClause = WhereOptions<UserAttributes>;
 import { TreeService } from '../../services/TreeService';
 import type { AuthenticatedRequest } from '../../middleware/auth.middleware';
 import { ApiResponse } from '../../utils/response.util';
+import { Lead } from '../../models/Lead';
+import { ADMIN_ROLES } from '../../types';
+
+// All roles assignable via API — super_admin is excluded for security
+// Todos los roles asignables por API — super_admin se excluye por seguridad
+const ASSIGNABLE_ROLES: readonly UserRole[] = [
+  'admin',
+  'finance',
+  'sales',
+  'advisor',
+  'vendor',
+  'user',
+  'guest',
+  'bot',
+] as const;
 
 const treeService = new TreeService();
 
@@ -225,5 +240,89 @@ export async function promoteToAdmin(req: AuthenticatedRequest, res: Response): 
     });
   } catch {
     res.status(500).json(ApiResponse.error('INTERNAL_ERROR', 'Error promoting user', 500));
+  }
+}
+
+/**
+ * Update user role with full RBAC business rules
+ * Actualiza el rol del usuario con reglas de negocio RBAC completas
+ *
+ * @route PATCH /api/admin/users/:userId/role
+ * @access Admin only (super_admin | admin)
+ *
+ * Business rules / Reglas de negocio:
+ * - super_admin cannot be assigned via API (manual DB only)
+ * - Cannot demote an existing super_admin
+ * - Cannot change your own role
+ * - When guest → user|vendor|advisor: update associated Lead to status='won'
+ *
+ * @param req - Path: userId, Body: role (new role)
+ * @param res - Success response with updated user
+ */
+export async function updateUserRole(req: AuthenticatedRequest, res: Response): Promise<void> {
+  try {
+    const { userId } = req.params;
+    const { role: newRole } = req.body as { role: UserRole };
+    const requester = req.user!;
+
+    // Validate role is provided and assignable
+    if (!newRole || !ASSIGNABLE_ROLES.includes(newRole)) {
+      res
+        .status(400)
+        .json(
+          ApiResponse.error(
+            'INVALID_PARAMS',
+            `Invalid role. Assignable roles: ${ASSIGNABLE_ROLES.join(', ')}`,
+            400
+          )
+        );
+      return;
+    }
+
+    // Cannot change your own role
+    if (requester.id === userId) {
+      res.status(400).json(ApiResponse.error('INVALID_PARAMS', 'Cannot change your own role', 400));
+      return;
+    }
+
+    const user = await User.findByPk(userId);
+    if (!user) {
+      res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+      return;
+    }
+
+    // Cannot demote a super_admin
+    if (user.role === 'super_admin') {
+      res
+        .status(403)
+        .json(ApiResponse.error('FORBIDDEN', 'Cannot change role of a super_admin', 403));
+      return;
+    }
+
+    const previousRole = user.role;
+    await user.update({ role: newRole });
+
+    // When guest is promoted to an active role, update their CRM lead to 'won'
+    // Cuando un guest es promovido a un rol activo, actualizar su Lead en CRM a 'won'
+    const activeRoles: readonly UserRole[] = ['user', 'vendor', 'advisor', 'sales', 'finance'];
+    if (previousRole === 'guest' && activeRoles.includes(newRole)) {
+      await Lead.update(
+        { status: 'won' },
+        {
+          where: {
+            metadata: { guestUserId: userId } as unknown as Record<string, unknown>,
+            status: { [Op.ne]: 'won' } as WhereOptions,
+          } as WhereOptions,
+        }
+      );
+    }
+
+    res.json({
+      success: true,
+      message: `User role updated from '${previousRole}' to '${newRole}'`,
+      data: { id: user.id, role: user.role },
+    });
+  } catch {
+    res.status(500).json(ApiResponse.error('INTERNAL_ERROR', 'Error updating user role', 500));
   }
 }

--- a/backend/src/database/migrations/20260410100000-expand-user-roles.js
+++ b/backend/src/database/migrations/20260410100000-expand-user-roles.js
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Expand User Roles Enum Migration
+ * @description Migración para agregar 6 nuevos roles al ENUM enum_users_role:
+ *              super_admin, finance, sales, advisor, guest, bot
+ *              This is an ADDITIVE migration - NO destructive changes
+ * @module database/migrations/expandUserRoles
+ * @author MLM Development Team
+ *
+ * @example
+ * // English: Run migration to expand user roles
+ * npx sequelize-cli db:migrate
+ *
+ * // Español: Ejecutar migración para expandir roles de usuario
+ * npx sequelize-cli db:migrate
+ */
+'use strict';
+
+module.exports = {
+  /**
+   * Up: Add new roles to enum_users_role enum
+   * Roles added: super_admin, finance, sales, advisor, guest, bot
+   *
+   * @param {Object} queryInterface - Sequelize query interface
+   * @param {Object} Sequelize - Sequelize library
+   */
+  async up(queryInterface, Sequelize) {
+    const dialect = queryInterface.sequelize.getDialect();
+
+    if (dialect === 'postgres') {
+      // Add all new role values - IF NOT EXISTS ensures idempotency
+      await queryInterface.sequelize.query(`
+        ALTER TYPE "enum_users_role" ADD VALUE IF NOT EXISTS 'super_admin';
+      `);
+      await queryInterface.sequelize.query(`
+        ALTER TYPE "enum_users_role" ADD VALUE IF NOT EXISTS 'finance';
+      `);
+      await queryInterface.sequelize.query(`
+        ALTER TYPE "enum_users_role" ADD VALUE IF NOT EXISTS 'sales';
+      `);
+      await queryInterface.sequelize.query(`
+        ALTER TYPE "enum_users_role" ADD VALUE IF NOT EXISTS 'advisor';
+      `);
+      await queryInterface.sequelize.query(`
+        ALTER TYPE "enum_users_role" ADD VALUE IF NOT EXISTS 'guest';
+      `);
+      await queryInterface.sequelize.query(`
+        ALTER TYPE "enum_users_role" ADD VALUE IF NOT EXISTS 'bot';
+      `);
+    }
+  },
+
+  /**
+   * Down: Cannot remove enum values in PostgreSQL
+   * NOTE: PostgreSQL does not support removing ENUM values directly.
+   *       Manual intervention required for rollback.
+   *
+   * @param {Object} queryInterface - Sequelize query interface
+   * @param {Object} Sequelize - Sequelize library
+   */
+  async down(queryInterface, Sequelize) {
+    // In PostgreSQL, we cannot remove enum values directly.
+    // This would require dropping and recreating the entire type.
+    // For production, do NOT roll back - this is for development only.
+    console.warn(
+      '[expand-user-roles] Cannot remove enum values in PostgreSQL - manual intervention required'
+    );
+  },
+};

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -5,12 +5,14 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { config } from '../config/env';
+import { UserRole, ADMIN_ROLES, FINANCE_ROLES, CRM_ROLES, PROPERTY_MGMT_ROLES } from '../types';
 
 // ============================================
 // TYPES
 // ============================================
 
-export type UserRole = 'admin' | 'user' | 'vendor';
+// Re-export for backward compatibility with consumers that import UserRole from here
+export type { UserRole } from '../types';
 
 interface TokenPayload {
   userId: string;
@@ -166,7 +168,15 @@ export function requireRole(...allowedRoles: UserRole[]) {
 }
 
 export function requireAdmin(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
-  return requireRole('admin')(req, res, next);
+  return requireRole(...(ADMIN_ROLES as UserRole[]))(req, res, next);
+}
+
+export function requireSuperAdmin(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): void {
+  return requireRole('super_admin')(req, res, next);
 }
 
 export function requireUser(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
@@ -175,6 +185,42 @@ export function requireUser(req: AuthenticatedRequest, res: Response, next: Next
 
 export function requireVendor(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
   return requireRole('vendor')(req, res, next);
+}
+
+/**
+ * Requires finance module access (super_admin, admin, finance)
+ * Requiere acceso al módulo financiero
+ */
+export function requireFinance(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
+  return requireRole(...(FINANCE_ROLES as UserRole[]))(req, res, next);
+}
+
+/**
+ * Requires CRM module access (super_admin, admin, sales, advisor)
+ * Requiere acceso al módulo CRM
+ */
+export function requireCRM(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
+  return requireRole(...(CRM_ROLES as UserRole[]))(req, res, next);
+}
+
+/**
+ * Requires property management access (super_admin, admin, sales)
+ * Requiere acceso a gestión de propiedades
+ */
+export function requirePropertyMgmt(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): void {
+  return requireRole(...(PROPERTY_MGMT_ROLES as UserRole[]))(req, res, next);
+}
+
+/**
+ * Requires bot/programmatic access
+ * Requiere acceso programático de bot
+ */
+export function requireBot(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
+  return requireRole('bot')(req, res, next);
 }
 
 export function requireVendorOrAdmin(
@@ -193,7 +239,7 @@ export function requireVendorOrAdmin(
     return;
   }
 
-  if (req.user.role !== 'vendor' && req.user.role !== 'admin') {
+  if (req.user.role !== 'vendor' && !ADMIN_ROLES.includes(req.user.role)) {
     res.status(403).json({
       success: false,
       error: {
@@ -225,8 +271,8 @@ export function canManageProduct(
   userRole: UserRole,
   product: { vendorId: string | null } | null
 ): boolean {
-  // Admins can manage any product
-  if (userRole === 'admin') {
+  // Admins (super_admin, admin) can manage any product
+  if (ADMIN_ROLES.includes(userRole)) {
     return true;
   }
 
@@ -261,8 +307,8 @@ export function restrictToOwnResource(resourceField: 'userId' | 'sponsorId' = 'u
       return;
     }
 
-    // Admins can access any resource
-    if (req.user.role === 'admin') {
+    // Admins (super_admin, admin) can access any resource
+    if (ADMIN_ROLES.includes(req.user.role)) {
       return next();
     }
 
@@ -289,7 +335,7 @@ export function canAccessResource(
   resourceOwnerId: string,
   resourceSponsorId?: string | null
 ): boolean {
-  if (requester.role === 'admin') return true;
+  if (ADMIN_ROLES.includes(requester.role)) return true;
   if (requester.id === resourceOwnerId) return true;
   if (resourceSponsorId && requester.id === resourceSponsorId) return true;
   return false;

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -22,7 +22,8 @@
 
 import { DataTypes, Model, Optional } from 'sequelize';
 import { sequelize } from '../config/database';
-import type { UserAttributes } from '../types';
+import type { UserAttributes, UserRole } from '../types';
+import { USER_ROLES } from '../types';
 
 type UserCreation = Optional<UserAttributes, 'id' | 'createdAt' | 'updatedAt'>;
 
@@ -35,7 +36,7 @@ export class User extends Model<UserAttributes, UserCreation> {
   declare position: 'left' | 'right' | null;
   declare level: number;
   declare status: 'active' | 'inactive';
-  declare role: 'admin' | 'user' | 'vendor';
+  declare role: UserRole;
   declare currency: 'USD' | 'COP' | 'MXN';
   // Notification preferences
   declare emailNotifications: boolean;
@@ -102,7 +103,7 @@ User.init(
       defaultValue: 'USD',
     },
     role: {
-      type: DataTypes.ENUM('admin', 'user', 'vendor'),
+      type: DataTypes.ENUM(...(USER_ROLES as unknown as [string, ...string[]])),
       defaultValue: 'user',
     },
     // Notification preferences / Preferencias de notificación

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -7,13 +7,17 @@ import {
   updateUserStatus,
   getCommissionsReport,
   promoteToAdmin,
+  updateUserRole,
 } from '../controllers/AdminController';
 import { asyncHandler } from '../middleware/asyncHandler';
+import { body } from 'express-validator';
+import { validate } from '../middleware/validate.middleware';
+import { USER_ROLES, ADMIN_ROLES } from '../types';
 
 const router: ExpressRouter = Router();
 
 router.use(authenticate);
-router.use(requireRole('admin'));
+router.use(requireRole(...(ADMIN_ROLES as import('../types').UserRole[])));
 
 /**
  * @swagger
@@ -157,6 +161,55 @@ router.patch('/users/:userId/status', asyncHandler(updateUserStatus));
  *         description: Usuario no encontrado / User not found
  */
 router.patch('/users/:userId/promote', asyncHandler(promoteToAdmin));
+
+/**
+ * @swagger
+ * /admin/users/{userId}/role:
+ *   patch:
+ *     summary: Actualizar rol del usuario / Update user role
+ *     description: |
+ *       Actualiza el rol de un usuario con validación RBAC completa.
+ *       Reglas: super_admin no puede asignarse por API, no podés cambiar tu propio rol,
+ *       no podés degradar a un super_admin. Cuando guest es promovido a user|vendor|advisor,
+ *       el Lead CRM asociado se marca como 'won'.
+ *
+ *       Updates a user's role with full RBAC validation.
+ *       Rules: super_admin cannot be assigned via API, cannot change own role,
+ *       cannot demote a super_admin. When guest is promoted to user|vendor|advisor,
+ *       the associated CRM Lead is marked as 'won'.
+ *     tags: [admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - role
+ *             properties:
+ *               role:
+ *                 type: string
+ *                 enum: [admin, finance, sales, advisor, vendor, user, guest, bot]
+ *     responses:
+ *       200:
+ *         description: Rol actualizado / Role updated
+ *       400:
+ *         description: Rol inválido o cambio propio / Invalid role or self-change
+ *       403:
+ *         description: No se puede cambiar super_admin / Cannot change super_admin
+ *       404:
+ *         description: Usuario no encontrado / User not found
+ */
+const updateRoleValidation = [body('role').isString().notEmpty().withMessage('Role is required')];
+router.patch('/users/:userId/role', validate(updateRoleValidation), asyncHandler(updateUserRole));
 
 /**
  * @swagger

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -5,6 +5,8 @@ import {
   me,
   registerValidation,
   loginValidation,
+  registerGuest,
+  registerGuestValidation,
 } from '../controllers/AuthController';
 import { authenticateToken } from '../middleware/auth.middleware';
 import { validate } from '../middleware/validate.middleware';
@@ -142,5 +144,46 @@ router.post('/login', validate(loginValidation), login);
  *               $ref: '#/components/schemas/Error'
  */
 router.get('/me', authenticateToken, me);
+
+/**
+ * @swagger
+ * /auth/register/guest:
+ *   post:
+ *     summary: Registrar usuario invitado / Register guest user
+ *     description: |
+ *       Crea una cuenta de tipo 'guest' sin contraseña y genera automáticamente un Lead en el CRM.
+ *       El invitado no puede iniciar sesión hasta que un admin promueva su rol.
+ *       Creates a 'guest' account without password and auto-generates a CRM Lead.
+ *       The guest cannot log in until an admin promotes their role.
+ *     tags: [auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - email
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Nombre completo / Full name
+ *               email:
+ *                 type: string
+ *                 format: email
+ *               phone:
+ *                 type: string
+ *                 description: Teléfono opcional / Optional phone
+ *               sponsor_code:
+ *                 type: string
+ *                 description: Código de referido opcional / Optional referral code
+ *     responses:
+ *       201:
+ *         description: Invitado registrado y Lead creado / Guest registered and Lead created
+ *       400:
+ *         description: Email ya registrado o validación fallida / Email already registered or validation failed
+ */
+router.post('/register/guest', validate(registerGuestValidation), registerGuest);
 
 export default router;

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,3 +1,62 @@
+// ============================================
+// USER ROLES — Canonical RBAC definitions
+// ROLES DE USUARIO — Definiciones RBAC canónicas
+// ============================================
+
+/**
+ * All valid user roles in the system.
+ * Todos los roles de usuario válidos en el sistema.
+ *
+ * @constant {readonly string[]} USER_ROLES
+ *
+ * @example
+ * // English: Check if a role is valid
+ * const isValid = USER_ROLES.includes(someRole);
+ *
+ * // Español: Verificar si un rol es válido
+ * const isValid = USER_ROLES.includes(someRole);
+ */
+export const USER_ROLES = [
+  'super_admin',
+  'admin',
+  'finance',
+  'sales',
+  'advisor',
+  'vendor',
+  'user',
+  'guest',
+  'bot',
+] as const;
+
+/** Canonical user role type — single source of truth */
+export type UserRole = (typeof USER_ROLES)[number];
+
+// ============================================
+// ROLE GROUPS — Permission arrays by module
+// GRUPOS DE ROLES — Arrays de permisos por módulo
+// ============================================
+
+/** Roles with full admin access / Roles con acceso admin completo */
+export const ADMIN_ROLES: readonly UserRole[] = ['super_admin', 'admin'] as const;
+
+/** Roles with financial module access / Roles con acceso al módulo financiero */
+export const FINANCE_ROLES: readonly UserRole[] = ['super_admin', 'admin', 'finance'] as const;
+
+/** Roles with CRM module access / Roles con acceso al módulo CRM */
+export const CRM_ROLES: readonly UserRole[] = ['super_admin', 'admin', 'sales', 'advisor'] as const;
+
+/** Roles with property management access / Roles con gestión de propiedades */
+export const PROPERTY_MGMT_ROLES: readonly UserRole[] = ['super_admin', 'admin', 'sales'] as const;
+
+/** Roles with buyer access (personal wallet, purchases) / Roles con acceso de comprador */
+export const BUYER_ROLES: readonly UserRole[] = [
+  'super_admin',
+  'admin',
+  'finance',
+  'vendor',
+  'user',
+] as const;
+
 export interface UserAttributes {
   id: string;
   email: string;
@@ -7,7 +66,7 @@ export interface UserAttributes {
   position: 'left' | 'right' | null;
   level: number;
   status: 'active' | 'inactive';
-  role: 'admin' | 'user';
+  role: UserRole;
   currency: 'USD' | 'COP' | 'MXN';
   // Notification preferences
   emailNotifications: boolean;
@@ -27,7 +86,7 @@ export interface UserCreationAttributes {
   position?: 'left' | 'right' | null;
   level?: number;
   status?: 'active' | 'inactive';
-  role?: 'admin' | 'user';
+  role?: UserRole;
   currency?: 'USD' | 'COP' | 'MXN';
 }
 
@@ -84,7 +143,7 @@ export interface ApiResponse<T> {
 export interface JwtPayload {
   userId: string;
   email: string;
-  role: 'admin' | 'user';
+  role: UserRole;
 }
 
 export interface TreeNode {


### PR DESCRIPTION
## Summary

Implements a complete Role-Based Access Control (RBAC) system, expanding the existing 3-role model (`admin | user | vendor`) to **9 granular roles** with typed permission arrays and full business rule enforcement.

## New Roles

| Role | Description |
|------|-------------|
| `super_admin` | Full control + system config — **DB-only assignment** |
| `admin` | Daily operations, user management |
| `finance` | Wallet, withdrawals, commissions, financial reports |
| `sales` | Full CRM, leads, properties, tours |
| `advisor` | Own assigned leads only |
| `vendor` | Own products and orders |
| `user` | Personal account, own wallet, purchases |
| `guest` | Initial registration — public read + forms only |
| `bot` | Programmatic access via internal webhook |

## Changes

### Layer 1 — DB Migration
- `20260410100000-expand-user-roles.js`: Adds 6 new ENUM values to `enum_users_role` using `ADD VALUE IF NOT EXISTS`

### Layer 2 — Types (`types/index.ts`)
- Canonical `UserRole` type (replaces local definitions)
- Role arrays: `USER_ROLES`, `ADMIN_ROLES`, `FINANCE_ROLES`, `CRM_ROLES`, `PROPERTY_MGMT_ROLES`, `BUYER_ROLES`

### Layer 3 — Middleware (`auth.middleware.ts`)
- Removed local `UserRole` definition (now imported from types)
- New helpers: `requireSuperAdmin`, `requireFinance`, `requireCRM`, `requirePropertyMgmt`, `requireBot`
- Updated `requireAdmin` to include `super_admin`

### Layers 4–5 — Guest Registration
- `POST /auth/register/guest` — creates `User(role='guest')` + `Lead(status='new', source='website')` with `metadata.guestUserId` for CRM tracking

### Layers 6–7 — Role Assignment
- `PATCH /admin/users/:userId/role` — enforces business rules:
  - `super_admin` cannot be assigned via API
  - Cannot demote an existing `super_admin`
  - Cannot change your own role
  - `guest → active role` automatically updates CRM Lead to `status='won'`

### Layer 8 — User Model
- `User.ts` ENUM updated to all 9 roles using `DataTypes.ENUM(...USER_ROLES)`

### Layer 9 — Tests
- `fixtures.ts`: `UserRole` typed + factories `createVendorUser`, `createFinanceUser`, `createSalesUser`, `createGuestUser`, `createSuperAdminUser`
- `rbac.test.ts`: Full coverage for `PATCH /admin/users/:userId/role` — access control, all business rules, 9 assignable roles, guest promotion flow, 404 handling

## Security Notes
- `super_admin` is intentionally excluded from the API-assignable roles array (`ASSIGNABLE_ROLES`). It can only be set via direct DB intervention.
- All admin routes enforce `requireRole(...ADMIN_ROLES)` at the router level.

## Pre-existing Issues
No new TypeScript errors introduced. Verified with `npx tsc --noEmit` before and after changes. Existing `TS2834/TS2835` errors are project-wide and pre-date this PR.

## Post-merge Steps
Run the DB migration in the `mlm-postgres-1` container:
\`\`\`bash
docker exec mlm-postgres-1 npx sequelize-cli db:migrate
\`\`\`