### PR TITLE
feat(bot): migrate to PostgreSQLAdapter + bake prompt_kb + CD Docker Hub

### DIFF
--- a/.github/workflows/cd-bot.yml
+++ b/.github/workflows/cd-bot.yml
@@ -1,0 +1,59 @@
+name: CD Bot
+
+on:
+  push:
+    branches: [release]
+    tags: ['v*']
+
+env:
+  REGISTRY: docker.io
+  BOT_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/mlm-bot
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push-bot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push bot
+        uses: docker/build-push-action@v6
+        with:
+          # Context is ./bot (not repo root) — pnpm-lock.yaml lives at root but
+          # the bot Dockerfile uses --no-frozen-lockfile, so monorepo root is not needed.
+          context: ./bot
+          file: ./bot/Dockerfile
+          push: true
+          tags: |
+            ${{ env.BOT_IMAGE }}:${{ github.ref_name }}
+            ${{ env.BOT_IMAGE }}:latest
+            ${{ env.BOT_IMAGE }}:release
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  summary:
+    runs-on: ubuntu-latest
+    needs: build-and-push-bot
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Summary
+        run: |
+          echo "## 🤖 Bot Deployed to Docker Hub"
+          echo "**Version:** \`${{ github.ref_name }}\`"
+          echo ""
+          echo "\`\`\`bash"
+          echo "docker pull ${{ env.BOT_IMAGE }}:${{ github.ref_name }}"
+          echo "docker compose -f docker-compose.prod.yml up -d bot"
+          echo "\`\`\`"

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,8 @@ deploy.prod.sh
 *.tar.gz
 
 # ===========================================
-# AI Prompts & Knowledge Base (PRIVATE - never commit)
+# AI Prompts & Knowledge Base
+# Files live at bot/src/prompt_kb/ and are baked into the Docker image.
+# No longer gitignored — must be tracked to be included in the Docker build context.
 # ===========================================
-/prompt_kb/
+# /prompt_kb/  ← removed: prompt_kb is now baked into the bot Docker image

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -19,6 +19,8 @@ COPY src/ ./src/
 RUN pnpm build
 
 # ─── Stage 2: Production ──────────────────────────────────────────────────────
+
+# ─── Stage 2: Production ──────────────────────────────────────────────────────
 FROM node:20-slim AS production
 
 # Required by Baileys (Chromium/canvas native deps) + git for libsignal-node GitHub dep
@@ -48,12 +50,18 @@ RUN pnpm install --no-frozen-lockfile --prod
 
 COPY --from=builder /app/dist ./dist
 
+# prompt_kb/ contains AI prompts and knowledge base files — baked into image.
+# Previously gitignored and mounted at runtime; now tracked in git and embedded
+# in the Docker image so the bot works without host-mounted volumes.
+#
+# prompt_kb/ contiene prompts de IA y base de conocimiento — embebido en la imagen.
+# Antes estaba en .gitignore y se montaba en tiempo de ejecución; ahora se rastrea
+# en git y se embebe en la imagen para que el bot funcione sin volúmenes del host.
+COPY --from=builder /app/src/prompt_kb ./prompt_kb
+
 # bot_sessions/ is mounted as a Docker volume to persist WhatsApp session
 # If this directory disappears, the bot needs to re-pair via pairing code
 RUN mkdir -p /app/bot_sessions
-
-# prompt_kb/ is mounted at runtime via docker-compose volume (never baked into image)
-RUN mkdir -p /app/prompt_kb
 
 ENV NODE_ENV=production
 

--- a/bot/package.json
+++ b/bot/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@builderbot/bot": "latest",
+    "@builderbot/database-postgres": "^1.4.1",
     "@builderbot/provider-baileys": "latest",
     "axios": "^1.15.0",
     "dotenv": "^16.6.1",

--- a/bot/src/app.ts
+++ b/bot/src/app.ts
@@ -1,15 +1,11 @@
 import 'dotenv/config';
-import {
-  createBot,
-  createProvider,
-  createFlow,
-  addKeyword,
-  EVENTS,
-  MemoryDB,
-} from '@builderbot/bot';
+import { createBot, createProvider, createFlow, addKeyword, EVENTS } from '@builderbot/bot';
 // @ts-ignore — BaileysProvider is exported at runtime but TS NodeNext resolver
 // fails to resolve the re-export chain in provider-baileys' .d.ts files.
 import { BaileysProvider } from '@builderbot/provider-baileys';
+// @ts-ignore — PostgreSQLAdapter ships as CJS (index.cjs) with "type":"module" in its package.json,
+// which confuses NodeNext moduleResolution. The adapter works correctly at runtime.
+import { PostgreSQLAdapter } from '@builderbot/database-postgres';
 
 import { welcomeFlow } from './flows/welcome.flow.js';
 import { balanceFlow } from './flows/balance.flow.js';
@@ -54,10 +50,21 @@ const provider = createProvider(BaileysProvider, {
 });
 
 // ── Database ──────────────────────────────────────────────────────────────────
-// Using MemoryDB for MVP — conversation state is managed in ai.service.ts.
-// Can be upgraded to PostgreSQLDB in a future sprint for persistence across restarts.
+// PostgreSQLAdapter persists conversation history and contact data across restarts.
+// Tables `contact` and `history` are auto-created on first run via stored procedures.
+// Shares the same PostgreSQL instance as the backend (mlm_db).
+//
+// PostgreSQLAdapter persiste historial de conversaciones y datos de contactos entre reinicios.
+// Las tablas `contact` e `history` se crean automáticamente en el primer arranque.
+// Comparte la misma instancia de PostgreSQL que el backend (mlm_db).
 
-const database = new MemoryDB();
+const database = new PostgreSQLAdapter({
+  host: process.env.DB_HOST ?? 'localhost',
+  port: Number(process.env.DB_PORT ?? 5432),
+  database: process.env.DB_NAME ?? 'mlm_db',
+  user: process.env.DB_USER ?? 'mlm',
+  password: process.env.DB_PASSWORD ?? '',
+});
 
 // ── Flows ─────────────────────────────────────────────────────────────────────
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -126,9 +126,7 @@ services:
 
 
   bot:
-    build:
-      context: ./bot
-      dockerfile: Dockerfile
+    image: ipproyectos/mlm-bot:${VERSION:-latest}
     restart: unless-stopped
     ports:
       - "3002:3002"
@@ -158,8 +156,8 @@ services:
     volumes:
       # Persist WhatsApp session — without this, re-pairing needed on every restart
       - bot_sessions:/app/bot_sessions
-      # prompt_kb is private (gitignored) — mounted from host at runtime, never baked into image
-      - ./prompt_kb:/app/prompt_kb:ro
+      # prompt_kb is now baked into the Docker image (no longer gitignored)
+      # No host volume needed — files are embedded at build time
     depends_on:
       backend:
         condition: service_started

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       '@builderbot/bot':
         specifier: latest
         version: 1.4.1
+      '@builderbot/database-postgres':
+        specifier: ^1.4.1
+        version: 1.4.1
       '@builderbot/provider-baileys':
         specifier: latest
         version: 1.4.1
@@ -1258,6 +1261,9 @@ packages:
 
   '@builderbot/bot@1.4.1':
     resolution: {integrity: sha512-50L22zZigICPA7rCSKcclN8KesheSJhNLRJFK6yIlOG91NuL7CmxQ8qNw9kRR5jEHf8xydCLnAFn48p4TMp4KQ==}
+
+  '@builderbot/database-postgres@1.4.1':
+    resolution: {integrity: sha512-rffoRCMaGVpv6k/S0KNBiHEqN2dZXHzG910hpaEYQidHm4t5Kbjj0z6X30vSBIRuw17BPphyVhVE0zJcu/KI/w==}
 
   '@builderbot/provider-baileys@1.4.1':
     resolution: {integrity: sha512-mG9h3X2wA297QlYKG4ziHp3rrr2zZPzOrnHCqkZ9P59CIVptS+VSB9jy17TQSzVelH/UBf1ocURD/PlgBua/EQ==}
@@ -9530,6 +9536,15 @@ snapshots:
       sharp: 0.33.3
     transitivePeerDependencies:
       - debug
+      - supports-color
+
+  '@builderbot/database-postgres@1.4.1':
+    dependencies:
+      '@builderbot/bot': 1.4.1
+      pg: 8.20.0
+    transitivePeerDependencies:
+      - debug
+      - pg-native
       - supports-color
 
   '@builderbot/provider-baileys@1.4.1':


### PR DESCRIPTION
## Summary

- **PostgreSQLAdapter**: Replace in-memory `MemoryDB` with `@builderbot/database-postgres` PostgreSQLAdapter — conversation history and contacts now persist across bot restarts, sharing the same `mlm_db` PostgreSQL instance as the backend
- **prompt_kb baked into image**: Remove `/prompt_kb/` from `.gitignore`; update `bot/Dockerfile` to `COPY src/prompt_kb ./prompt_kb` in the production stage — no more host-mounted volume dependency
- **CD workflow**: Add `.github/workflows/cd-bot.yml` — builds and pushes `ipproyectos/mlm-bot` to Docker Hub on push to `release` or version tags
- **docker-compose.prod.yml**: Replace `build: context: ./bot` with `image: ipproyectos/mlm-bot:${VERSION:-latest}`; remove `./prompt_kb` host volume

## Changes

| File | Change |
|------|--------|
| `bot/src/app.ts` | MemoryDB → PostgreSQLAdapter + `@ts-ignore` for CJS/ESM bug in v1.4.1 |
| `bot/package.json` | Add `@builderbot/database-postgres@^1.4.1` |
| `pnpm-lock.yaml` | Updated lockfile |
| `.gitignore` | Remove `/prompt_kb/` rule |
| `bot/Dockerfile` | COPY `src/prompt_kb` in production stage |
| `docker-compose.prod.yml` | `image:` instead of `build:`, removed prompt_kb volume |
| `.github/workflows/cd-bot.yml` | New CD workflow for bot Docker image |

## Notes

- `@builderbot/database-postgres` v1.4.1 ships CJS (`.cjs`) with `"type": "module"` in its `package.json`, which confuses NodeNext moduleResolution — `// @ts-ignore` applied (same pattern as BaileysProvider)
- TypeScript build passes ✅
- The bot's `bot/src/prompt_kb/` files were already tracked in git (they were in `bot/src/`, which was never gitignored) — only the root-level `/prompt_kb/` was gitignored