### PR TITLE
fix(backend): rename class ApiResponse to ResponseUtil to resolve Vercel PARSE_ERROR

### DIFF
--- a/backend/src/controllers/LandingPageController.ts
+++ b/backend/src/controllers/LandingPageController.ts
@@ -11,7 +11,7 @@ import { Response } from 'express';
 import { landingPageService } from '../services/LandingPageService';
 import type { ApiResponse } from '../types';
 import type { AuthenticatedRequest } from '../middleware/auth.middleware';
-import { ApiResponse as ResponseUtil } from '../utils/response.util';
+import { ResponseUtil } from '../utils/response.util';
 import type { Request } from 'express';
 
 /**

--- a/backend/src/controllers/NotificationController.ts
+++ b/backend/src/controllers/NotificationController.ts
@@ -21,7 +21,7 @@
 import { Request, Response } from 'express';
 import { User } from '../models/User';
 import { smsService } from '../services/SMSService';
-import { ApiResponse } from '../utils/response.util';
+import { ResponseUtil } from '../utils/response.util';
 
 // In-memory store for 2FA codes (use Redis in production)
 // Almacenamiento en memoria para códigos 2FA (usar Redis en producción)
@@ -40,14 +40,14 @@ export async function getNotificationPreferences(req: Request, res: Response): P
     const userId = (req as any).user?.id;
 
     if (!userId) {
-      res.status(401).json(ApiResponse.error('UNAUTHORIZED', 'Unauthorized', 401));
+      res.status(401).json(ResponseUtil.error('UNAUTHORIZED', 'Unauthorized', 401));
       return;
     }
 
     const user = await User.findByPk(userId);
 
     if (!user) {
-      res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+      res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
       return;
     }
 
@@ -63,7 +63,7 @@ export async function getNotificationPreferences(req: Request, res: Response): P
     });
   } catch (error) {
     console.error('Error getting notification preferences:', error);
-    res.status(500).json(ApiResponse.error('INTERNAL_ERROR', 'Internal server error', 500));
+    res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Internal server error', 500));
   }
 }
 
@@ -81,14 +81,14 @@ export async function updateNotificationPreferences(req: Request, res: Response)
     const { emailNotifications, smsNotifications, weeklyDigest } = req.body;
 
     if (!userId) {
-      res.status(401).json(ApiResponse.error('UNAUTHORIZED', 'Unauthorized', 401));
+      res.status(401).json(ResponseUtil.error('UNAUTHORIZED', 'Unauthorized', 401));
       return;
     }
 
     const user = await User.findByPk(userId);
 
     if (!user) {
-      res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+      res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
       return;
     }
 
@@ -117,7 +117,7 @@ export async function updateNotificationPreferences(req: Request, res: Response)
     });
   } catch (error) {
     console.error('Error updating notification preferences:', error);
-    res.status(500).json(ApiResponse.error('INTERNAL_ERROR', 'Internal server error', 500));
+    res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Internal server error', 500));
   }
 }
 
@@ -135,12 +135,12 @@ export async function enable2FA(req: Request, res: Response): Promise<void> {
     const { phone } = req.body;
 
     if (!userId) {
-      res.status(401).json(ApiResponse.error('UNAUTHORIZED', 'Unauthorized', 401));
+      res.status(401).json(ResponseUtil.error('UNAUTHORIZED', 'Unauthorized', 401));
       return;
     }
 
     if (!phone) {
-      res.status(400).json(ApiResponse.error('INVALID_PARAMS', 'Phone number is required', 400));
+      res.status(400).json(ResponseUtil.error('INVALID_PARAMS', 'Phone number is required', 400));
       return;
     }
 
@@ -150,7 +150,7 @@ export async function enable2FA(req: Request, res: Response): Promise<void> {
       res
         .status(400)
         .json(
-          ApiResponse.error(
+          ResponseUtil.error(
             'INVALID_FORMAT',
             'Invalid phone number format. Use E.164 format (+1234567890)',
             400
@@ -166,7 +166,7 @@ export async function enable2FA(req: Request, res: Response): Promise<void> {
       res
         .status(500)
         .json(
-          ApiResponse.error('SEND_FAILED', result.error || 'Failed to send verification code', 500)
+          ResponseUtil.error('SEND_FAILED', result.error || 'Failed to send verification code', 500)
         );
       return;
     }
@@ -187,7 +187,7 @@ export async function enable2FA(req: Request, res: Response): Promise<void> {
     });
   } catch (error) {
     console.error('Error enabling 2FA:', error);
-    res.status(500).json(ApiResponse.error('INTERNAL_ERROR', 'Internal server error', 500));
+    res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Internal server error', 500));
   }
 }
 
@@ -205,12 +205,14 @@ export async function verify2FA(req: Request, res: Response): Promise<void> {
     const { code, phone } = req.body;
 
     if (!userId) {
-      res.status(401).json(ApiResponse.error('UNAUTHORIZED', 'Unauthorized', 401));
+      res.status(401).json(ResponseUtil.error('UNAUTHORIZED', 'Unauthorized', 401));
       return;
     }
 
     if (!code || !phone) {
-      res.status(400).json(ApiResponse.error('INVALID_PARAMS', 'Code and phone are required', 400));
+      res
+        .status(400)
+        .json(ResponseUtil.error('INVALID_PARAMS', 'Code and phone are required', 400));
       return;
     }
 
@@ -220,7 +222,7 @@ export async function verify2FA(req: Request, res: Response): Promise<void> {
       res
         .status(400)
         .json(
-          ApiResponse.error(
+          ResponseUtil.error(
             'NOT_FOUND',
             'No verification code found. Request a new code first.',
             400
@@ -235,7 +237,7 @@ export async function verify2FA(req: Request, res: Response): Promise<void> {
     if (!result.valid) {
       res
         .status(400)
-        .json(ApiResponse.error('INVALID_CODE', result.error || 'Invalid verification code', 400));
+        .json(ResponseUtil.error('INVALID_CODE', result.error || 'Invalid verification code', 400));
       return;
     }
 
@@ -243,7 +245,7 @@ export async function verify2FA(req: Request, res: Response): Promise<void> {
     const user = await User.findByPk(userId);
 
     if (!user) {
-      res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+      res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
       return;
     }
 
@@ -260,7 +262,7 @@ export async function verify2FA(req: Request, res: Response): Promise<void> {
     });
   } catch (error) {
     console.error('Error verifying 2FA:', error);
-    res.status(500).json(ApiResponse.error('INTERNAL_ERROR', 'Internal server error', 500));
+    res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Internal server error', 500));
   }
 }
 
@@ -277,14 +279,14 @@ export async function disable2FA(req: Request, res: Response): Promise<void> {
     const userId = (req as any).user?.id;
 
     if (!userId) {
-      res.status(401).json(ApiResponse.error('UNAUTHORIZED', 'Unauthorized', 401));
+      res.status(401).json(ResponseUtil.error('UNAUTHORIZED', 'Unauthorized', 401));
       return;
     }
 
     const user = await User.findByPk(userId);
 
     if (!user) {
-      res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+      res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
       return;
     }
 
@@ -299,6 +301,6 @@ export async function disable2FA(req: Request, res: Response): Promise<void> {
     });
   } catch (error) {
     console.error('Error disabling 2FA:', error);
-    res.status(500).json(ApiResponse.error('INTERNAL_ERROR', 'Internal server error', 500));
+    res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Internal server error', 500));
   }
 }

--- a/backend/src/controllers/PaymentMercadoPagoController.ts
+++ b/backend/src/controllers/PaymentMercadoPagoController.ts
@@ -7,7 +7,7 @@
 import { Request, Response } from 'express';
 import { asyncHandler } from '../middleware/asyncHandler.js';
 import { mercadoPagoService } from '../services/MercadoPagoService.js';
-import { ApiResponse } from '../utils/response.util.js';
+import { ResponseUtil } from '../utils/response.util.js';
 import { config } from '../config/env.js';
 import { Purchase, Order, Product } from '../models/index.js';
 import { CommissionService } from '../services/CommissionService.js';
@@ -23,7 +23,7 @@ export class PaymentMercadoPagoController {
     const userEmail = (req as any).user?.email;
 
     if (!items || !Array.isArray(items) || items.length === 0) {
-      return res.status(400).json(ApiResponse.error('INVALID_ITEMS', 'Items are required', 400));
+      return res.status(400).json(ResponseUtil.error('INVALID_ITEMS', 'Items are required', 400));
     }
 
     const preference = await mercadoPagoService.createPreference({
@@ -77,7 +77,7 @@ export class PaymentMercadoPagoController {
       return res
         .status(400)
         .json(
-          ApiResponse.error(
+          ResponseUtil.error(
             'MISSING_FIELDS',
             'Token, paymentMethodId, transactionAmount and payer email are required',
             400
@@ -122,7 +122,7 @@ export class PaymentMercadoPagoController {
     if (!paymentId) {
       return res
         .status(400)
-        .json(ApiResponse.error('MISSING_PAYMENT_ID', 'Payment ID is required', 400));
+        .json(ResponseUtil.error('MISSING_PAYMENT_ID', 'Payment ID is required', 400));
     }
 
     const payment = await mercadoPagoService.getPayment(paymentId);
@@ -174,7 +174,7 @@ export class PaymentMercadoPagoController {
         console.warn('[MercadoPago Webhook] Invalid signature — rejecting request');
         return res
           .status(401)
-          .json(ApiResponse.error('INVALID_SIGNATURE', 'Invalid webhook signature', 401));
+          .json(ResponseUtil.error('INVALID_SIGNATURE', 'Invalid webhook signature', 401));
       }
     } else {
       console.warn(

--- a/backend/src/controllers/PaymentPayPalController.ts
+++ b/backend/src/controllers/PaymentPayPalController.ts
@@ -7,7 +7,7 @@
 import { Request, Response } from 'express';
 import { asyncHandler } from '../middleware/asyncHandler.js';
 import { paypalService } from '../services/PayPalService.js';
-import { ApiResponse } from '../utils/response.util.js';
+import { ResponseUtil } from '../utils/response.util.js';
 
 /**
  * PayPal order ID format: alphanumeric, 17 characters
@@ -27,7 +27,7 @@ export class PaymentPayPalController {
     if (!amount || amount <= 0) {
       return res
         .status(400)
-        .json(ApiResponse.error('INVALID_AMOUNT', 'Amount must be greater than 0', 400));
+        .json(ResponseUtil.error('INVALID_AMOUNT', 'Amount must be greater than 0', 400));
     }
 
     const order = await paypalService.createOrder({
@@ -61,20 +61,22 @@ export class PaymentPayPalController {
     if (!orderId) {
       return res
         .status(400)
-        .json(ApiResponse.error('MISSING_ORDER_ID', 'PayPal order ID is required', 400));
+        .json(ResponseUtil.error('MISSING_ORDER_ID', 'PayPal order ID is required', 400));
     }
 
     // Validate orderId format to prevent SSRF (CodeQL)
     if (!PAYPAL_ORDER_ID_REGEX.test(orderId)) {
       return res
         .status(400)
-        .json(ApiResponse.error('INVALID_ORDER_ID', 'Invalid PayPal order ID format', 400));
+        .json(ResponseUtil.error('INVALID_ORDER_ID', 'Invalid PayPal order ID format', 400));
     }
 
     if (!internalOrderId) {
       return res
         .status(400)
-        .json(ApiResponse.error('MISSING_INTERNAL_ORDER_ID', 'Internal order ID is required', 400));
+        .json(
+          ResponseUtil.error('MISSING_INTERNAL_ORDER_ID', 'Internal order ID is required', 400)
+        );
     }
 
     const capturedOrder = await paypalService.captureOrder({
@@ -119,7 +121,9 @@ export class PaymentPayPalController {
       console.error('[PayPal Webhook] Invalid signature');
       return res
         .status(403)
-        .json(ApiResponse.error('INVALID_SIGNATURE', 'Webhook signature verification failed', 403));
+        .json(
+          ResponseUtil.error('INVALID_SIGNATURE', 'Webhook signature verification failed', 403)
+        );
     }
 
     const event = req.body;
@@ -172,14 +176,14 @@ export class PaymentPayPalController {
     if (!orderId) {
       return res
         .status(400)
-        .json(ApiResponse.error('MISSING_ORDER_ID', 'Order ID is required', 400));
+        .json(ResponseUtil.error('MISSING_ORDER_ID', 'Order ID is required', 400));
     }
 
     // Validate orderId format to prevent SSRF (CodeQL)
     if (!PAYPAL_ORDER_ID_REGEX.test(orderId)) {
       return res
         .status(400)
-        .json(ApiResponse.error('INVALID_ORDER_ID', 'Invalid PayPal order ID format', 400));
+        .json(ResponseUtil.error('INVALID_ORDER_ID', 'Invalid PayPal order ID format', 400));
     }
 
     const order = await paypalService.getOrder(orderId);

--- a/backend/src/controllers/PublicController.ts
+++ b/backend/src/controllers/PublicController.ts
@@ -13,7 +13,7 @@ import { userService, treeServiceInstance } from '../services/UserService';
 import type { ApiResponse } from '../types';
 import { LEVEL_NAMES } from '../types';
 import type { Request } from 'express';
-import { ApiResponse as ResponseUtil } from '../utils/response.util';
+import { ResponseUtil } from '../utils/response.util';
 
 /**
  * Get public user profile by referral code

--- a/backend/src/controllers/ShipmentTrackingController.ts
+++ b/backend/src/controllers/ShipmentTrackingController.ts
@@ -11,7 +11,8 @@ import { ShipmentTrackingService } from '../services/ShipmentTrackingService';
 import { DeliveryProvider } from '../models/DeliveryProvider';
 import { Order, Product } from '../models';
 import { AppError } from '../middleware/error.middleware';
-import { ApiResponse, ShipmentTrackingStatus } from '../types';
+import type { ApiResponse } from '../types';
+import { ShipmentTrackingStatus } from '../types';
 
 const shipmentTrackingService = new ShipmentTrackingService();
 

--- a/backend/src/controllers/UserController.ts
+++ b/backend/src/controllers/UserController.ts
@@ -14,7 +14,7 @@ import type { ApiResponse } from '../types';
 import { LEVEL_NAMES } from '../types';
 import type { AuthenticatedRequest } from '../middleware/auth.middleware';
 import { AppError } from '../middleware/error.middleware';
-import { ApiResponse } from '../utils/response.util';
+import { ResponseUtil } from '../utils/response.util';
 
 const qrService = new QRService();
 
@@ -61,7 +61,7 @@ export async function getMe(req: AuthenticatedRequest, res: Response): Promise<v
   const fullUser = await userService.findById(userId);
 
   if (!fullUser) {
-    res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+    res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
     return;
   }
 
@@ -236,7 +236,7 @@ export async function updateProfile(req: AuthenticatedRequest, res: Response): P
 
   const user = await userService.updateUser(userId, { firstName, lastName, phone });
   if (!user) {
-    res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+    res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
     return;
   }
 
@@ -257,7 +257,7 @@ export async function changePassword(req: AuthenticatedRequest, res: Response): 
 
   const user = await userService.findById(userId);
   if (!user) {
-    res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+    res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
     return;
   }
 
@@ -286,12 +286,12 @@ export async function deleteAccount(req: AuthenticatedRequest, res: Response): P
 
   const user = await userService.findById(userId);
   if (!user) {
-    res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+    res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
     return;
   }
 
   if (user.role === 'admin') {
-    res.status(403).json(ApiResponse.error('FORBIDDEN', 'Admin accounts cannot be deleted', 403));
+    res.status(403).json(ResponseUtil.error('FORBIDDEN', 'Admin accounts cannot be deleted', 403));
     return;
   }
 

--- a/backend/src/controllers/admin/StatsController.ts
+++ b/backend/src/controllers/admin/StatsController.ts
@@ -9,7 +9,7 @@ import { Op, WhereOptions } from 'sequelize';
 import { User, Commission, Purchase } from '../../models';
 import type { AuthenticatedRequest } from '../../middleware/auth.middleware';
 import type { ApiResponse } from '../../types';
-import { ApiResponse as ResponseUtil } from '../../utils/response.util';
+import { ResponseUtil } from '../../utils/response.util';
 import type { CommissionAttributes } from '../../types';
 
 // Type for Commission where clauses

--- a/backend/src/controllers/admin/UsersAdminController.ts
+++ b/backend/src/controllers/admin/UsersAdminController.ts
@@ -13,7 +13,7 @@ import type { UserAttributes, UserRole, USER_ROLES } from '../../types';
 type UserWhereClause = WhereOptions<UserAttributes>;
 import { TreeService } from '../../services/TreeService';
 import type { AuthenticatedRequest } from '../../middleware/auth.middleware';
-import { ApiResponse } from '../../utils/response.util';
+import { ResponseUtil } from '../../utils/response.util';
 import { Lead } from '../../models/Lead';
 import { ADMIN_ROLES } from '../../types';
 
@@ -95,7 +95,7 @@ export async function getAllUsers(req: AuthenticatedRequest, res: Response): Pro
       },
     });
   } catch {
-    res.status(500).json(ApiResponse.error('INTERNAL_ERROR', 'Error fetching users', 500));
+    res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Error fetching users', 500));
   }
 }
 
@@ -127,7 +127,7 @@ export async function getUserById(req: AuthenticatedRequest, res: Response): Pro
     });
 
     if (!user) {
-      res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+      res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
       return;
     }
 
@@ -162,7 +162,7 @@ export async function getUserById(req: AuthenticatedRequest, res: Response): Pro
     });
   } catch {
     // Invalid UUID format or other DB error - treat as not found
-    res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+    res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
   }
 }
 
@@ -181,13 +181,13 @@ export async function updateUserStatus(req: AuthenticatedRequest, res: Response)
     const { status } = req.body;
 
     if (!['active', 'inactive'].includes(status)) {
-      res.status(400).json(ApiResponse.error('INVALID_PARAMS', 'Invalid status', 400));
+      res.status(400).json(ResponseUtil.error('INVALID_PARAMS', 'Invalid status', 400));
       return;
     }
 
     const user = await User.findByPk(userId);
     if (!user) {
-      res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+      res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
       return;
     }
 
@@ -221,13 +221,15 @@ export async function promoteToAdmin(req: AuthenticatedRequest, res: Response): 
     const currentUser = req.user!;
 
     if (currentUser.id === userId) {
-      res.status(400).json(ApiResponse.error('INVALID_PARAMS', 'Cannot change your own role', 400));
+      res
+        .status(400)
+        .json(ResponseUtil.error('INVALID_PARAMS', 'Cannot change your own role', 400));
       return;
     }
 
     const user = await User.findByPk(userId);
     if (!user) {
-      res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+      res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
       return;
     }
 
@@ -239,7 +241,7 @@ export async function promoteToAdmin(req: AuthenticatedRequest, res: Response): 
       data: { id: user.id, role: user.role },
     });
   } catch {
-    res.status(500).json(ApiResponse.error('INTERNAL_ERROR', 'Error promoting user', 500));
+    res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Error promoting user', 500));
   }
 }
 
@@ -270,7 +272,7 @@ export async function updateUserRole(req: AuthenticatedRequest, res: Response): 
       res
         .status(400)
         .json(
-          ApiResponse.error(
+          ResponseUtil.error(
             'INVALID_PARAMS',
             `Invalid role. Assignable roles: ${ASSIGNABLE_ROLES.join(', ')}`,
             400
@@ -281,13 +283,15 @@ export async function updateUserRole(req: AuthenticatedRequest, res: Response): 
 
     // Cannot change your own role
     if (requester.id === userId) {
-      res.status(400).json(ApiResponse.error('INVALID_PARAMS', 'Cannot change your own role', 400));
+      res
+        .status(400)
+        .json(ResponseUtil.error('INVALID_PARAMS', 'Cannot change your own role', 400));
       return;
     }
 
     const user = await User.findByPk(userId);
     if (!user) {
-      res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+      res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
       return;
     }
 
@@ -295,7 +299,7 @@ export async function updateUserRole(req: AuthenticatedRequest, res: Response): 
     if (user.role === 'super_admin') {
       res
         .status(403)
-        .json(ApiResponse.error('FORBIDDEN', 'Cannot change role of a super_admin', 403));
+        .json(ResponseUtil.error('FORBIDDEN', 'Cannot change role of a super_admin', 403));
       return;
     }
 
@@ -323,6 +327,6 @@ export async function updateUserRole(req: AuthenticatedRequest, res: Response): 
       data: { id: user.id, role: user.role },
     });
   } catch {
-    res.status(500).json(ApiResponse.error('INTERNAL_ERROR', 'Error updating user role', 500));
+    res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Error updating user role', 500));
   }
 }

--- a/backend/src/controllers/dashboard/DashboardController.ts
+++ b/backend/src/controllers/dashboard/DashboardController.ts
@@ -12,7 +12,7 @@ import { User, Commission } from '../../models';
 import type { ApiResponse } from '../../types';
 import { LEVEL_NAMES } from '../../types';
 import type { AuthenticatedRequest } from '../../middleware/auth.middleware';
-import { ApiResponse } from '../../utils/response.util';
+import { ResponseUtil } from '../../utils/response.util';
 
 /**
  * Get user dashboard with stats, referrals, and commissions
@@ -29,7 +29,7 @@ export async function getDashboard(req: AuthenticatedRequest, res: Response): Pr
   const fullUser = await userService.findById(userId);
 
   if (!fullUser) {
-    res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+    res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
     return;
   }
 

--- a/backend/src/controllers/dashboard/DashboardReferralsController.ts
+++ b/backend/src/controllers/dashboard/DashboardReferralsController.ts
@@ -10,7 +10,7 @@ import { userService } from '../../services/UserService';
 import { QRService } from '../../services/QRService';
 import type { AuthenticatedRequest } from '../../middleware/auth.middleware';
 import type { ApiResponse } from '../../types';
-import { ApiResponse as ResponseUtil } from '../../utils/response.util';
+import { ResponseUtil } from '../../utils/response.util';
 
 /**
  * Get recent referrals and referral link for dashboard

--- a/backend/src/controllers/dashboard/DashboardStatsController.ts
+++ b/backend/src/controllers/dashboard/DashboardStatsController.ts
@@ -8,7 +8,7 @@ import { userService, treeServiceInstance } from '../../services/UserService';
 import { CommissionService } from '../../services/CommissionService';
 import type { AuthenticatedRequest } from '../../middleware/auth.middleware';
 import type { ApiResponse } from '../../types';
-import { ApiResponse as ResponseUtil } from '../../utils/response.util';
+import { ResponseUtil } from '../../utils/response.util';
 
 /**
  * Get user stats for dashboard

--- a/backend/src/controllers/dashboard/DashboardUserController.ts
+++ b/backend/src/controllers/dashboard/DashboardUserController.ts
@@ -8,7 +8,7 @@ import { userService } from '../../services/UserService';
 import { LEVEL_NAMES } from '../../types';
 import type { AuthenticatedRequest } from '../../middleware/auth.middleware';
 import type { ApiResponse } from '../../types';
-import { ApiResponse } from '../../utils/response.util';
+import { ResponseUtil } from '../../utils/response.util';
 
 /**
  * Get user info for dashboard
@@ -22,7 +22,7 @@ export async function getDashboardUser(req: AuthenticatedRequest, res: Response)
   const fullUser = await userService.findById(userId);
 
   if (!fullUser) {
-    res.status(404).json(ApiResponse.error('NOT_FOUND', 'User not found', 404));
+    res.status(404).json(ResponseUtil.error('NOT_FOUND', 'User not found', 404));
     return;
   }
 

--- a/backend/src/utils/response.util.ts
+++ b/backend/src/utils/response.util.ts
@@ -1,32 +1,40 @@
 /**
- * @fileoverview ApiResponse utility - Consistent API response format
- * @description Helper functions for consistent success/error responses across controllers
+ * @fileoverview ResponseUtil - Consistent API response format
+ * @description Helper functions for consistent success/error responses across controllers.
+ *              Utilidades para respuestas de API consistentes en todos los controladores.
  * @module utils/response.util
  */
 
 /**
- * Standardized API response helper
- * Provides consistent response format for success and error cases
+ * Standardized API response helper.
+ * Utilidad para generar respuestas de API estandarizadas de éxito y error.
+ *
+ * @example
+ * // English: Usage in a controller
+ * return res.status(200).json(ResponseUtil.success(data));
+ *
+ * // Español: Uso en un controlador
+ * return res.status(400).json(ResponseUtil.error('NOT_FOUND', 'Recurso no encontrado', 404));
  */
-export class ApiResponse {
+export class ResponseUtil {
   /**
-   * Create a success response
-   * @template T - Data type
-   * @param data - Response data
-   * @param status - HTTP status code (default: 200)
-   * @returns Standardized success response object
+   * Create a success response. / Crea una respuesta de éxito.
+   * @template T - Data type / Tipo de dato
+   * @param data - Response data / Datos de la respuesta
+   * @param status - HTTP status code (default: 200) / Código HTTP (por defecto: 200)
+   * @returns Standardized success response object / Objeto de respuesta estandarizado
    */
   static success<T>(data: T, status = 200) {
     return { success: true, data, status };
   }
 
   /**
-   * Create an error response
-   * @param code - Error code (e.g., 'NOT_FOUND', 'INVALID_PARAMS')
-   * @param message - Human-readable error message
-   * @param status - HTTP status code (default: 400)
-   * @param details - Optional additional error details
-   * @returns Standardized error response object
+   * Create an error response. / Crea una respuesta de error.
+   * @param code - Error code (e.g., 'NOT_FOUND', 'INVALID_PARAMS') / Código de error
+   * @param message - Human-readable error message / Mensaje de error legible
+   * @param status - HTTP status code (default: 400) / Código HTTP (por defecto: 400)
+   * @param details - Optional additional error details / Detalles adicionales opcionales
+   * @returns Standardized error response object / Objeto de error estandarizado
    */
   static error(code: string, message: string, status = 400, details?: unknown) {
     return {


### PR DESCRIPTION
## Problem

Vercel CI was failing with:

```
[PARSE_ERROR] Identifier 'ApiResponse' has already been declared
```

Root cause: two exports with the same name:
- `interface ApiResponse<T>` in `backend/src/types/index.ts` — the canonical type annotation
- `class ApiResponse` in `backend/src/utils/response.util.ts` — the static helper class

TypeScript handles this locally via `import type` erasure, but Vercel's stricter build-time parser catches the collision at runtime.

## Solution

Rename the **class** `ApiResponse` → `ResponseUtil` in `response.util.ts`. The interface in `types/index.ts` is untouched — it's used as a type annotation throughout the codebase and is the canonical definition.

## Files changed

| Group | Files | Action |
|-------|-------|--------|
| Core | `utils/response.util.ts` | `export class ApiResponse` → `export class ResponseUtil` |
| A — double import | `DashboardController`, `DashboardUserController`, `UserController` | Remove alias conflict, update import + call sites |
| B — class only | `UsersAdminController`, `NotificationController`, `PaymentMercadoPagoController`, `PaymentPayPalController` | Update import + call sites |
| C — already aliased | `StatsController`, `DashboardReferralsController`, `DashboardStatsController`, `PublicController`, `LandingPageController` | Clean up `import { ApiResponse as ResponseUtil }` → `import { ResponseUtil }` |
| D — missing `type` | `ShipmentTrackingController` | Split import to use `import type` for `ApiResponse` |

## Verification

```bash
cd backend && pnpm build
# ✅ Done in 204ms — 0 errors, 0 warnings
```