### PR TITLE
fix(ci): remove backend from vercel.json experimentalServices

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,10 +4,6 @@
       "entrypoint": "frontend",
       "routePrefix": "/",
       "framework": "vite"
-    },
-    "backend": {
-      "entrypoint": "backend",
-      "routePrefix": "/_/backend"
     }
   }
 }


### PR DESCRIPTION
## Problem

`vercel build` was running `tsc` on the **backend** entrypoint, failing with hundreds of TypeScript errors:

```
Error: TypeScript type check failed
```

Root cause: the root-level `vercel.json` had an `experimentalServices.backend` entry:

```json
{
  "experimentalServices": {
    "frontend": { "entrypoint": "frontend", ... },
    "backend":  { "entrypoint": "backend", ... }  ← this caused vercel to tsc the backend
  }
}
```

This is the **third** Vercel build failure in this series (after #123 ApiResponse rename and #124 WebhookEvent missing import). Vercel's stricter static analysis pipeline was catching errors that esbuild/rolldown silently ignores:
1. `[PARSE_ERROR]` — ApiResponse duplicate identifier → fixed in #123
2. `[EXPORT_UNDEFINED_VARIABLE]` — WebhookEvent missing import → fixed in #124
3. `TypeScript type check failed` — TS2835/TS2307 in backend code → fixed here by removing the backend service from Vercel entirely

## Solution

The backend is deployed via **Docker Hub** (`ipproyectos/mlm-backend:release`), **not Vercel**. Removed the `backend` entry from `experimentalServices` so `vercel build` only processes the frontend (Root Directory: `frontend`, framework: `vite`).

## After this fix

`vercel build` should:
1. Install frontend deps → ✅
2. Run `pnpm build` in `frontend/` → Vite build → ✅
3. Deploy to Vercel CDN → ✅