### PR TITLE
fix(routes): mount 6 orphaned routes + relocate commission-config

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1027.0",
     "@sentry/node": "^10.46.0",
+    "@types/multer": "^2.1.0",
     "axios": "^1.15.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.6",
@@ -60,6 +61,7 @@
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.3",
     "mercadopago": "^2.12.0",
+    "multer": "^2.1.1",
     "mysql2": "^3.20.0",
     "node-cron": "^4.2.1",
     "nodemailer": "^8.0.5",

--- a/backend/src/__tests__/integration/routes.smoke.test.ts
+++ b/backend/src/__tests__/integration/routes.smoke.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Smoke tests for route mounting verification
+ * @description Verifies that all routes are properly mounted in the Express app
+ *              and respond with non-404 status codes. Routes may return 401 (Unauthorized)
+ *              which is expected — the test validates mounting, not authorization.
+ *
+ *              Pruebas de humo para verificación de montaje de rutas.
+ *              Verifica que todas las rutas están correctamente montadas en la app Express
+ *              y responden con códigos de estado distintos a 404. Las rutas pueden retornar
+ *              401 (No autorizado) lo cual es esperado — el test valida montaje, no autorización.
+ *
+ * @module __tests__/integration/routes.smoke
+ * @requires supertest
+ * @see routes/index.ts
+ */
+
+import { testAgent } from '../setup';
+
+describe('Route Mounting Smoke Tests / Pruebas de Montaje de Rutas', () => {
+  /**
+   * Each route must be reachable (not 404).
+   * A 401 response confirms the route IS mounted but requires authentication.
+   *
+   * Cada ruta debe ser alcanzable (no 404).
+   * Una respuesta 401 confirma que la ruta ESTÁ montada pero requiere autenticación.
+   */
+
+  it('GET /api/admin/reservations should be mounted (not 404)', async () => {
+    const res = await testAgent.get('/api/admin/reservations');
+    expect(res.status).not.toBe(404);
+  });
+
+  it('GET /api/admin/tours should be mounted (not 404)', async () => {
+    const res = await testAgent.get('/api/admin/tours');
+    expect(res.status).not.toBe(404);
+  });
+
+  it('GET /api/admin/properties should be mounted (not 404)', async () => {
+    const res = await testAgent.get('/api/admin/properties');
+    expect(res.status).not.toBe(404);
+  });
+
+  it('GET /api/properties should be mounted (not 404)', async () => {
+    const res = await testAgent.get('/api/properties');
+    expect(res.status).not.toBe(404);
+  });
+
+  it('GET /api/tours should be mounted (not 404)', async () => {
+    const res = await testAgent.get('/api/tours');
+    expect(res.status).not.toBe(404);
+  });
+
+  it('GET /api/bot/leads should be mounted (not 404)', async () => {
+    const res = await testAgent.get('/api/bot/leads');
+    expect(res.status).not.toBe(404);
+  });
+
+  it('GET /api/admin/commissions should be mounted after relocation (not 404)', async () => {
+    const res = await testAgent.get('/api/admin/commissions');
+    expect(res.status).not.toBe(404);
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,7 +13,6 @@ import adminRoutes from './routes/admin.routes';
 import crmRoutes from './routes/crm.routes';
 import publicRoutes from './routes/public.routes';
 import landingRoutes from './routes/landing.routes';
-import commissionConfigRoutes from './routes/commission-config.routes';
 import paymentRoutes from './routes/payment.routes';
 import { resolveShortCode } from './controllers/GiftCardController';
 import { asyncHandler } from './middleware/asyncHandler';
@@ -209,7 +208,6 @@ app.use('/api/admin', adminRoutes);
 app.use('/api/crm', crmRoutes);
 app.use('/api/public', publicRoutes);
 app.use('/api', landingRoutes);
-app.use('/api/admin/commissions', commissionConfigRoutes);
 app.use('/api/payment', paymentRoutes);
 
 // ============================================

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -29,6 +29,19 @@ import shippingRoutes from './shipping.routes';
 import achievementRoutes from './achievement.routes';
 import leaderboardRoutes from './leaderboard.routes';
 
+// Sprint 9 — previously orphaned routes (fix #126)
+// Sprint 9 — rutas previamente huérfanas (fix #126)
+import adminReservationRoutes from './admin-reservation.routes';
+import adminTourRoutes from './admin-tour.routes';
+import adminPropertyRoutes from './admin-property.routes';
+import propertyRoutes from './property.routes';
+import tourRoutes from './tour.routes';
+import botLeadsRoutes from './bot-leads.routes';
+
+// Relocated from app.ts → centralised in router index (fix #126)
+// Reubicado de app.ts → centralizado en índice de rutas (fix #126)
+import commissionConfigRoutes from './commission-config.routes';
+
 const router: ExpressRouter = Router();
 
 router.use('/auth', authRoutes);
@@ -79,6 +92,34 @@ router.use('/achievements', achievementRoutes);
 
 // Leaderboard routes
 router.use('/leaderboard', leaderboardRoutes);
+
+// Sprint 9 — Admin reservation routes (previously orphaned)
+// Sprint 9 — Rutas admin de reservas (previamente huérfanas)
+router.use('/admin/reservations', adminReservationRoutes);
+
+// Sprint 9 — Admin tour routes (previously orphaned)
+// Sprint 9 — Rutas admin de tours (previamente huérfanas)
+router.use('/admin/tours', adminTourRoutes);
+
+// Sprint 9 — Admin property routes (previously orphaned)
+// Sprint 9 — Rutas admin de propiedades (previamente huérfanas)
+router.use('/admin/properties', adminPropertyRoutes);
+
+// Sprint 9 — Public property routes (previously orphaned)
+// Sprint 9 — Rutas públicas de propiedades (previamente huérfanas)
+router.use('/properties', propertyRoutes);
+
+// Sprint 9 — Public tour routes (previously orphaned)
+// Sprint 9 — Rutas públicas de tours (previamente huérfanas)
+router.use('/tours', tourRoutes);
+
+// Sprint 9 — Bot leads routes (previously orphaned)
+// Sprint 9 — Rutas de leads del bot (previamente huérfanas)
+router.use('/bot/leads', botLeadsRoutes);
+
+// Sprint 9 — Commission config (relocated from app.ts)
+// Sprint 9 — Config de comisiones (reubicado de app.ts)
+router.use('/admin/commissions', commissionConfigRoutes);
 
 // Profile public routes (MUST be before publicRoutes to avoid /profile/:code conflict)
 import profilePublicRoutes from './profile-public.routes';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@sentry/node':
         specifier: ^10.46.0
         version: 10.47.0
+      '@types/multer':
+        specifier: ^2.1.0
+        version: 2.1.0
       axios:
         specifier: ^1.15.0
         version: 1.15.0
@@ -74,6 +77,9 @@ importers:
       mercadopago:
         specifier: ^2.12.0
         version: 2.12.0
+      multer:
+        specifier: ^2.1.1
+        version: 2.1.1
       mysql2:
         specifier: ^3.20.0
         version: 3.20.0(@types/node@20.19.37)
@@ -3679,6 +3685,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/multer@2.1.0':
+    resolution: {integrity: sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==}
+
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
@@ -4047,6 +4056,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  append-field@1.0.0:
+    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
@@ -4262,6 +4274,10 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -4436,6 +4452,10 @@ packages:
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
 
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
@@ -6148,6 +6168,10 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
@@ -6268,6 +6292,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multer@2.1.1:
+    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
+    engines: {node: '>= 10.16.0'}
 
   music-metadata@11.12.3:
     resolution: {integrity: sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ==}
@@ -7378,6 +7406,10 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -7707,6 +7739,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -7726,6 +7762,9 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
   typescript-eslint@8.58.0:
     resolution: {integrity: sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==}
@@ -12165,6 +12204,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/multer@2.1.0':
+    dependencies:
+      '@types/express': 4.17.25
+
   '@types/mysql@2.15.27':
     dependencies:
       '@types/node': 24.12.0
@@ -12642,6 +12685,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  append-field@1.0.0: {}
+
   arg@4.1.3: {}
 
   argparse@1.0.10:
@@ -12906,6 +12951,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
   bytes@3.1.2: {}
 
   cacache@20.0.4:
@@ -13092,6 +13141,13 @@ snapshots:
   common-tags@1.8.2: {}
 
   component-emitter@1.3.1: {}
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
 
   config-chain@1.1.13:
     dependencies:
@@ -15211,6 +15267,8 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@0.3.0: {}
+
   media-typer@1.1.0: {}
 
   mercadopago@2.12.0:
@@ -15314,6 +15372,13 @@ snapshots:
   moment@2.30.1: {}
 
   ms@2.1.3: {}
+
+  multer@2.1.1:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      type-is: 1.6.18
 
   music-metadata@11.12.3:
     dependencies:
@@ -16502,6 +16567,8 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
+  streamsearch@1.1.0: {}
+
   string-argv@0.3.2: {}
 
   string-length@4.0.2:
@@ -16861,6 +16928,11 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -16899,6 +16971,8 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
+
+  typedarray@0.0.6: {}
 
   typescript-eslint@8.58.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

Monta 6 archivos de rutas huérfanas que existían en `backend/src/routes/` pero nunca fueron importadas, haciendo que sus endpoints fueran inalcanzables en runtime. Reubica `commission-config.routes.ts` de `app.ts` a `routes/index.ts` para consistencia.

Closes #126

## Changes

### Nuevas rutas montadas / New routes mounted
| Archivo | Prefijo | Endpoints |
|---------|---------|-----------|
| `admin-reservation.routes.ts` | `/api/admin/reservations` | 6 |
| `admin-tour.routes.ts` | `/api/admin/tours` | CRUD |
| `admin-property.routes.ts` | `/api/admin/properties` | CRUD |
| `property.routes.ts` | `/api/properties` | Public |
| `tour.routes.ts` | `/api/tours` | Public |
| `bot-leads.routes.ts` | `/api/bot/leads` | Bot integration |
| `commission-config.routes.ts` | `/api/admin/commissions` | Relocated from app.ts |

### Archivos modificados / Files changed
- `backend/src/routes/index.ts` — +7 imports, +7 `router.use()` mounts
- `backend/src/app.ts` — Removed commission-config import + mount (2 lines)
- `backend/src/__tests__/integration/routes.smoke.test.ts` — **NEW**: 7 smoke tests
- `backend/package.json` — Added `multer@2` + `@types/multer` (missing dep discovered)
- `pnpm-lock.yaml` — Updated

### Dependencia descubierta / Discovered dependency
`multer` was used by `upload.middleware.ts` (imported by `admin-tour` and `admin-property` routes) but was never declared in `package.json`. Added as explicit dependency.

## Testing

- ✅ 541 tests passing (534 existing + 7 new smoke tests)
- ✅ 0 failures, 1 skipped (pre-existing)
- ✅ TDD: smoke tests written FIRST (RED), then routes mounted (GREEN)

## Verification

```bash
# All smoke tests pass
cd backend && pnpm test -- --testPathPattern=routes.smoke

# Commission-config removed from app.ts
grep "commissionConfigRoutes" backend/src/app.ts  # → 0 matches
```