### PR TITLE
fix: resolve dashboard 500 error and broken images in production

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -89,11 +89,24 @@ const corsOptions = {
 app.use(cors(corsOptions));
 
 // Security headers with Helmet
+// CSP: allow Unsplash images used in seed/demo data
 app.use(
   helmet({
     noSniff: true,
     xssFilter: true,
     frameguard: { action: 'deny' },
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", 'data:', 'https://images.unsplash.com', 'https://plus.unsplash.com'],
+        connectSrc: ["'self'"],
+        fontSrc: ["'self'"],
+        objectSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+      },
+    },
   })
 );
 

--- a/backend/src/controllers/dashboard/DashboardCommissionsController.ts
+++ b/backend/src/controllers/dashboard/DashboardCommissionsController.ts
@@ -35,7 +35,7 @@ export async function getDashboardCommissions(
     where: {
       userId,
       status: 'completed',
-      createdAt: { [Op.gte]: sixMonthsAgo },
+      created_at: { [Op.gte]: sixMonthsAgo },
     },
     attributes: ['amount', ['created_at', 'createdAt']],
   });

--- a/backend/src/controllers/dashboard/DashboardController.ts
+++ b/backend/src/controllers/dashboard/DashboardController.ts
@@ -58,7 +58,7 @@ export async function getDashboard(req: AuthenticatedRequest, res: Response): Pr
   const referralsByMonth = await User.findAll({
     where: {
       sponsorId: fullUser.id,
-      createdAt: { [Op.gte]: sixMonthsAgo },
+      created_at: { [Op.gte]: sixMonthsAgo },
     },
     attributes: [['created_at', 'createdAt']],
   });
@@ -79,7 +79,7 @@ export async function getDashboard(req: AuthenticatedRequest, res: Response): Pr
     where: {
       userId: fullUser.id,
       status: 'completed',
-      createdAt: { [Op.gte]: sixMonthsAgo },
+      created_at: { [Op.gte]: sixMonthsAgo },
     },
     attributes: ['amount', ['created_at', 'createdAt']],
   });

--- a/backend/src/controllers/dashboard/DashboardReferralsController.ts
+++ b/backend/src/controllers/dashboard/DashboardReferralsController.ts
@@ -48,7 +48,7 @@ export async function getDashboardReferrals(
   const referralsByMonth = await User.findAll({
     where: {
       sponsorId: fullUser.id,
-      createdAt: { [Op.gte]: sixMonthsAgo },
+      created_at: { [Op.gte]: sixMonthsAgo },
     },
     attributes: [['created_at', 'createdAt']],
   });


### PR DESCRIPTION
## Summary

Fixes two critical production bugs blocking the investor pitch demo:

1. **Dashboard 500 Error** — `column User.createdAt does not exist`
2. **Broken Images** — Unsplash images blocked by default Helmet CSP

## Root Cause Analysis

### Bug 1: Dashboard 500

Sequelize 6 with `underscored: true` does **not** auto-translate camelCase keys in `WHERE` clause operators to snake_case. The generated SQL was:

```sql
SELECT "created_at" AS "createdAt" FROM "users" AS "User"
WHERE "User"."createdAt" >= '2025-10-12...'  -- ❌ column does not exist
```

PR #141 fixed `attributes` arrays but missed 4 `WHERE` clauses that still used `createdAt` instead of `created_at`.

### Bug 2: Broken Images

Helmet's default CSP sets `img-src 'self'` which blocks all external image domains. The seed/demo data uses `images.unsplash.com` and `plus.unsplash.com` URLs for property and tour images.

## Changes

| File | Change |
|------|--------|
| `DashboardController.ts` | `createdAt` → `created_at` in 2 WHERE clauses (lines 61, 82) |
| `DashboardReferralsController.ts` | `createdAt` → `created_at` in 1 WHERE clause (line 51) |
| `DashboardCommissionsController.ts` | `createdAt` → `created_at` in 1 WHERE clause (line 38) |
| `app.ts` | Added explicit CSP `contentSecurityPolicy` directives allowing `img-src` from Unsplash domains |

## Testing

- ✅ 540/541 tests passing (1 skipped — pre-existing)
- ✅ No regressions
- ✅ Prettier lint-staged passed

## Verification Steps

After deploying:
1. Login as any user → Dashboard should load without 500 error
2. Visit landing page → Property/Tour images should display
3. Check DevTools console → No CSP violation warnings

Closes the remaining issues from PR #141.