### PR TITLE
fix(dashboard): use correct Commission enum value 'paid' instead of 'completed'

### DIFF
--- a/backend/src/controllers/dashboard/DashboardCommissionsController.ts
+++ b/backend/src/controllers/dashboard/DashboardCommissionsController.ts
@@ -34,7 +34,7 @@ export async function getDashboardCommissions(
   const commissionsByMonth = await Commission.findAll({
     where: {
       userId,
-      status: 'completed',
+      status: 'paid',
       created_at: { [Op.gte]: sixMonthsAgo },
     },
     attributes: ['amount', ['created_at', 'createdAt']],

--- a/backend/src/controllers/dashboard/DashboardController.ts
+++ b/backend/src/controllers/dashboard/DashboardController.ts
@@ -78,7 +78,7 @@ export async function getDashboard(req: AuthenticatedRequest, res: Response): Pr
   const commissionsByMonth = await Commission.findAll({
     where: {
       userId: fullUser.id,
-      status: 'completed',
+      status: 'paid',
       created_at: { [Op.gte]: sixMonthsAgo },
     },
     attributes: ['amount', ['created_at', 'createdAt']],


### PR DESCRIPTION
## Summary

Fix **Dashboard 500 error** caused by querying commissions with `status = 'completed'` — a value that doesn't exist in the PostgreSQL enum `enum_commissions_status`.

## Root Cause

The `Commission` model defines status as `ENUM('pending', 'approved', 'paid')` (line 79 of `Commission.ts`), but both dashboard controllers were filtering by `'completed'`:

```sql
-- Before (fails with: invalid input value for enum enum_commissions_status: "completed")
WHERE "Commission"."status" = 'completed'

-- After (correct enum value)
WHERE "Commission"."status" = 'paid'
```

This was masked during development because the commissions table was empty — the error only surfaces when PostgreSQL validates the enum value in the query even with zero rows.

## Changes

| File | Change |
|------|--------|
| `backend/src/controllers/dashboard/DashboardController.ts` | `'completed'` → `'paid'` (line 81) |
| `backend/src/controllers/dashboard/DashboardCommissionsController.ts` | `'completed'` → `'paid'` (line 37) |

## Testing

- ✅ 540/541 unit tests passing (1 skipped — pre-existing)
- ✅ Verified against PostgreSQL enum: `SELECT enum_range(NULL::enum_commissions_status)` → `{pending, approved, paid}`
- ✅ Verified `Purchase` model correctly uses `'completed'` (its own enum includes it) — no false positive there

## Deploy

After merge → fast-forward `release`, tag `v2.6.1`, deploy Docker container.