### PR TITLE
refactor(backend): replace console.* with centralized Pino logger

### DIFF
--- a/backend/src/__tests__/CalendarService.test.ts
+++ b/backend/src/__tests__/CalendarService.test.ts
@@ -15,7 +15,27 @@
  * @module __tests__/CalendarService
  */
 
+// Mock logger (must come BEFORE imports that use it)
+jest.mock('../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    child: jest.fn().mockReturnValue({
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    }),
+  },
+}));
+
 import { CalendarService, CalendarEventPayload } from '../services/CalendarService';
+import { logger } from '../utils/logger';
+
+const mockedLogger = logger as jest.Mocked<typeof logger>;
 
 // ============================================
 // HELPERS / AYUDANTES
@@ -121,19 +141,16 @@ describe('CalendarService', () => {
       // Preparar — N8N_CALENDAR_WEBHOOK_URL no está configurada
       delete process.env.N8N_CALENDAR_WEBHOOK_URL;
 
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
       const service = new CalendarService();
 
       // Act & Assert — should resolve without calling fetch
       // Actuar y Afirmar — debe resolver sin llamar a fetch
       await expect(service.notifyReservationConfirmed(buildPayload())).resolves.toBeUndefined();
       expect(mockFetch).not.toHaveBeenCalled();
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[CalendarService] N8N_CALENDAR_WEBHOOK_URL not set, skipping calendar sync'
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        { service: 'CalendarService' },
+        'N8N_CALENDAR_WEBHOOK_URL not set, skipping calendar sync'
       );
-
-      warnSpy.mockRestore();
     });
 
     it('should not throw when fetch fails (non-blocking)', async () => {
@@ -143,19 +160,15 @@ describe('CalendarService', () => {
 
       mockFetch.mockRejectedValueOnce(new Error('Network error'));
 
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
       const service = new CalendarService();
 
       // Act & Assert — should resolve even when fetch throws
       // Actuar y Afirmar — debe resolver incluso cuando fetch lanza error
       await expect(service.notifyReservationConfirmed(buildPayload())).resolves.toBeUndefined();
-      expect(errorSpy).toHaveBeenCalledWith(
-        '[CalendarService] Failed to notify n8n webhook:',
-        expect.any(Error)
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        { service: 'CalendarService', err: expect.any(Error) },
+        'Failed to notify n8n webhook'
       );
-
-      errorSpy.mockRestore();
     });
 
     it('should log error when n8n returns non-ok status', async () => {
@@ -168,8 +181,6 @@ describe('CalendarService', () => {
         status: 500,
       });
 
-      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
       const service = new CalendarService();
 
       // Act / Actuar
@@ -177,9 +188,10 @@ describe('CalendarService', () => {
 
       // Assert — should log error but NOT throw
       // Afirmar — debe registrar error pero NO lanzar
-      expect(errorSpy).toHaveBeenCalledWith('[CalendarService] n8n webhook returned 500');
-
-      errorSpy.mockRestore();
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        { service: 'CalendarService', statusCode: 500 },
+        'n8n webhook returned non-OK status'
+      );
     });
   });
 });

--- a/backend/src/__tests__/MercadoPagoWebhook.test.ts
+++ b/backend/src/__tests__/MercadoPagoWebhook.test.ts
@@ -13,6 +13,23 @@
 
 import { createHmac } from 'crypto';
 
+// ─── Mock logger (must come before controller import) ────────────────────────
+jest.mock('../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    child: jest.fn().mockReturnValue({
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    }),
+  },
+}));
+
 // ─── Mock database (must come before any model import) ───────────────────────
 jest.mock('../config/database', () => ({
   sequelize: {
@@ -126,6 +143,9 @@ jest.mock('../utils/response.util.js', () => ({
 // ─── Now import the real service and controller (after all mocks) ─────────────
 import { PaymentMercadoPagoController } from '../controllers/PaymentMercadoPagoController.js';
 import { Order, Purchase, Product } from '../models/index.js';
+import { logger } from '../utils/logger';
+
+const mockedLogger = logger as jest.Mocked<typeof logger>;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -411,8 +431,6 @@ describe('MercadoPago — webhook handler', () => {
 
     mockGetPayment.mockResolvedValue(mockApprovedPayment);
 
-    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
     const { req, res } = buildReqRes({
       query: { topic: 'payment' },
       body: { id: PAYMENT_ID, topic: 'payment' },
@@ -422,7 +440,8 @@ describe('MercadoPago — webhook handler', () => {
     await (PaymentMercadoPagoController.webhook as (...args: unknown[]) => Promise<void>)(req, res);
 
     // Should have logged a warning about missing secret
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(mockedLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ component: 'MercadoPago Webhook' }),
       expect.stringContaining('MERCADOPAGO_WEBHOOK_SECRET not configured')
     );
 
@@ -432,8 +451,6 @@ describe('MercadoPago — webhook handler', () => {
 
     // Returns 200
     expect(res.status).toHaveBeenCalledWith(200);
-
-    consoleSpy.mockRestore();
   });
 
   /**

--- a/backend/src/__tests__/unit/BrevoEmailService.test.ts
+++ b/backend/src/__tests__/unit/BrevoEmailService.test.ts
@@ -11,6 +11,23 @@
 // MOCKS — Deben ir ANTES de los imports
 // ============================================
 
+// Mock logger (must come BEFORE imports that use it)
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    child: jest.fn().mockReturnValue({
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    }),
+  },
+}));
+
 // Mock config/env
 jest.mock('../../config/env', () => ({
   config: {
@@ -39,7 +56,10 @@ const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
 import { BrevoEmailService, brevoEmailService } from '../../services/BrevoEmailService';
+import { logger } from '../../utils/logger';
 import nodemailer from 'nodemailer';
+
+const mockedLogger = logger as jest.Mocked<typeof logger>;
 
 // ============================================
 // TEST HELPERS
@@ -66,15 +86,8 @@ describe('BrevoEmailService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.spyOn(console, 'log').mockImplementation();
-    jest.spyOn(console, 'error').mockImplementation();
-    jest.spyOn(console, 'warn').mockImplementation();
     // Create fresh instance to reset circuit breaker
     service = new BrevoEmailService();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   // ============================================
@@ -264,15 +277,17 @@ describe('BrevoEmailService', () => {
 
       await service.sendEmail(defaultParams);
 
-      expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('[BrevoEmailService] REST API failed:')
-        // Not checking exact message — just that error was logged
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error), service: 'BrevoEmailService' }),
+        'REST API failed'
       );
-      expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('[BrevoEmailService] Falling back to SMTP')
+      expect(mockedLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ service: 'BrevoEmailService' }),
+        'Falling back to SMTP'
       );
-      expect(console.log).toHaveBeenCalledWith(
-        expect.stringContaining('[BrevoEmailService] Circuit breaker:')
+      expect(mockedLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ service: 'BrevoEmailService', failures: expect.any(Number) }),
+        'Circuit breaker failure count incremented'
       );
     });
 

--- a/backend/src/__tests__/unit/GiftCardService.test.ts
+++ b/backend/src/__tests__/unit/GiftCardService.test.ts
@@ -5,6 +5,23 @@
  * @module __tests__/unit/GiftCardService
  */
 
+// Mock logger (must come BEFORE imports that use it)
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    fatal: jest.fn(),
+    child: jest.fn().mockReturnValue({
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    }),
+  },
+}));
+
 // Mock config/database
 jest.mock('../../config/database', () => ({
   sequelize: {
@@ -129,8 +146,6 @@ describe('GiftCardService', () => {
       (GiftCard.create as jest.Mock).mockResolvedValue(mockGiftCard);
       (QrMapping.create as jest.Mock).mockResolvedValue({ id: 'qr-uuid-2' });
 
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-
       const result = await giftCardService.createGiftCard(50, 'admin-uuid');
 
       expect(result).toEqual(mockGiftCard);
@@ -138,7 +153,6 @@ describe('GiftCardService', () => {
         expect.objectContaining({ qrCodeData: null }),
         expect.anything()
       );
-      consoleSpy.mockRestore();
     });
 
     it('should use custom expiresInDays when provided', async () => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,8 +1,8 @@
 import express, { Application } from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
-import pino from 'pino';
 import { pinoHttp } from 'pino-http';
+import { logger } from './utils/logger';
 import rateLimit from 'express-rate-limit';
 import swaggerUi from 'swagger-ui-express';
 import * as Sentry from '@sentry/node';
@@ -25,17 +25,8 @@ const isProduction = process.env.NODE_ENV === 'production';
 // Trust proxy for ngrok/reverse proxy support
 app.set('trust proxy', 1);
 
-/**
- * HTTP request logger — pino-http (ESM-native replacement for morgan)
- * Logger de requests HTTP — pino-http (reemplazo ESM-nativo de morgan)
- * - Production: JSON structured logs (Grafana/Loki-ready)
- * - Development: pino-pretty colorized output
- */
-const logger = pino({
-  level: isProduction ? 'info' : 'debug',
-  ...(isProduction ? {} : { transport: { target: 'pino-pretty' } }),
-});
-
+// HTTP request logger — pino-http powered by centralized logger
+// Logger de requests HTTP — pino-http con logger centralizado
 if (!isTest) {
   app.use(pinoHttp({ logger }));
 }

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -1,5 +1,6 @@
 import { Sequelize } from 'sequelize';
 import { config } from './env';
+import { logger } from '../utils/logger';
 
 // Allow test override
 let _sequelize: Sequelize | null = null;
@@ -59,9 +60,9 @@ export async function resetSequelize(): Promise<void> {
 export async function connectDatabase(): Promise<void> {
   try {
     await sequelize.authenticate();
-    console.log('✅ Database connection established successfully.');
+    logger.info('Database connection established successfully');
   } catch (error) {
-    console.error('❌ Unable to connect to the database:', error);
+    logger.error({ err: error }, 'Unable to connect to the database');
     throw error;
   }
 }
@@ -69,9 +70,9 @@ export async function connectDatabase(): Promise<void> {
 export async function syncDatabase(force: boolean = false): Promise<void> {
   try {
     await sequelize.sync({ force });
-    console.log('✅ Database synchronized.');
+    logger.info('Database synchronized');
   } catch (error) {
-    console.error('❌ Error synchronizing database:', error);
+    logger.error({ err: error }, 'Error synchronizing database');
     throw error;
   }
 }

--- a/backend/src/config/redis.ts
+++ b/backend/src/config/redis.ts
@@ -7,6 +7,7 @@
  */
 
 import Redis from 'ioredis';
+import { logger } from '../utils/logger';
 
 let redis: Redis | null = null;
 
@@ -36,7 +37,7 @@ export function getRedis(): Redis | null {
 
   // Skip Redis if not configured
   if (process.env.REDIS_ENABLED !== 'true') {
-    console.log('⚠️ Redis disabled (set REDIS_ENABLED=true to enable)');
+    logger.warn('Redis disabled (set REDIS_ENABLED=true to enable)');
     return null;
   }
 
@@ -53,17 +54,17 @@ export function getRedis(): Redis | null {
     });
 
     redis.on('connect', () => {
-      console.log('✅ Redis connected');
+      logger.info('Redis connected');
     });
 
     redis.on('error', (err) => {
-      console.error('❌ Redis error:', err.message);
+      logger.error({ err }, 'Redis error');
       redis = null;
     });
 
     return redis;
   } catch (error) {
-    console.error('❌ Redis init failed:', error);
+    logger.error({ err: error }, 'Redis init failed');
     return null;
   }
 }

--- a/backend/src/controllers/AdminContractController.ts
+++ b/backend/src/controllers/AdminContractController.ts
@@ -12,6 +12,7 @@ import {
   UpdateTemplateData,
 } from '../services/ContractService';
 import { requireAdmin, type AuthenticatedRequest } from '../middleware/auth.middleware';
+import { logger } from '../utils/logger';
 
 const contractService = new ContractService();
 
@@ -44,7 +45,7 @@ export async function getTemplates(req: AuthenticatedRequest, res: Response): Pr
       data: contracts,
     });
   } catch (error) {
-    console.error('Error fetching templates:', error);
+    logger.error({ err: error }, 'Error fetching templates');
     res.status(500).json({
       success: false,
       error: {
@@ -120,7 +121,7 @@ export async function createTemplate(req: AuthenticatedRequest, res: Response): 
       data: template,
     });
   } catch (error) {
-    console.error('Error creating template:', error);
+    logger.error({ err: error }, 'Error creating template');
     res.status(500).json({
       success: false,
       error: {
@@ -201,7 +202,7 @@ export async function updateTemplate(req: AuthenticatedRequest, res: Response): 
       return;
     }
 
-    console.error('Error updating template:', error);
+    logger.error({ err: error }, 'Error updating template');
     res.status(500).json({
       success: false,
       error: {
@@ -249,7 +250,7 @@ export async function getUserContracts(req: AuthenticatedRequest, res: Response)
       data: contracts,
     });
   } catch (error) {
-    console.error('Error fetching user contracts:', error);
+    logger.error({ err: error }, 'Error fetching user contracts');
     res.status(500).json({
       success: false,
       error: {
@@ -317,7 +318,7 @@ export async function revokeUserContract(req: AuthenticatedRequest, res: Respons
       return;
     }
 
-    console.error('Error revoking contract:', error);
+    logger.error({ err: error }, 'Error revoking contract');
     res.status(500).json({
       success: false,
       error: {

--- a/backend/src/controllers/AdminVendorController.ts
+++ b/backend/src/controllers/AdminVendorController.ts
@@ -16,6 +16,7 @@ import { vendorService } from '../services/VendorService';
 import { authenticate, requireAdmin } from '../middleware/auth.middleware';
 import type { AuthenticatedRequest } from '../middleware/auth.middleware';
 import { body, validationResult } from 'express-validator';
+import { logger } from '../utils/logger';
 
 /**
  * List vendors with pagination and filters
@@ -47,7 +48,7 @@ export const listVendors = [
         },
       });
     } catch (error: any) {
-      console.error('List vendors error:', error);
+      logger.error({ err: error }, 'List vendors error');
       res.status(500).json({
         success: false,
         error: {
@@ -78,7 +79,7 @@ export const getVendor = [
         data: vendor,
       });
     } catch (error: any) {
-      console.error('Get vendor error:', error);
+      logger.error({ err: error }, 'Get vendor error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -111,7 +112,7 @@ export const approveVendor = [
         message: 'Vendor approved successfully',
       });
     } catch (error: any) {
-      console.error('Approve vendor error:', error);
+      logger.error({ err: error }, 'Approve vendor error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -159,7 +160,7 @@ export const rejectVendor = [
         message: 'Vendor rejected',
       });
     } catch (error: any) {
-      console.error('Reject vendor error:', error);
+      logger.error({ err: error }, 'Reject vendor error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -207,7 +208,7 @@ export const suspendVendor = [
         message: 'Vendor suspended',
       });
     } catch (error: any) {
-      console.error('Suspend vendor error:', error);
+      logger.error({ err: error }, 'Suspend vendor error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -258,7 +259,7 @@ export const updateCommissionRate = [
         message: 'Commission rate updated',
       });
     } catch (error: any) {
-      console.error('Update commission rate error:', error);
+      logger.error({ err: error }, 'Update commission rate error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -35,6 +35,7 @@ import { achievementService } from '../services/AchievementService';
 import { config } from '../config/env';
 import type { ApiResponse, UserAttributes } from '../types';
 import { AppError } from '../middleware/error.middleware';
+import { logger } from '../utils/logger';
 import type { AuthenticatedRequest } from '../middleware/auth.middleware';
 import { asyncHandler } from '../middleware/asyncHandler';
 import { Lead } from '../models/Lead';
@@ -125,7 +126,7 @@ export const register: RequestHandler = asyncHandler(
         referralCode: user.referralCode,
         referralLink,
       })
-      .catch((err) => console.error('Welcome email failed:', err));
+      .catch((err) => logger.error({ err }, 'Welcome email failed'));
 
     // If user has sponsor, notify sponsor about new downline
     // Si el usuario tiene patrocinador, notificar al patrocinador sobre nuevo downline
@@ -139,7 +140,7 @@ export const register: RequestHandler = asyncHandler(
             newUserEmail: user.email,
             position: user.position || 'unknown',
           })
-          .catch((err) => console.error('Downline email failed:', err));
+          .catch((err) => logger.error({ err }, 'Downline email failed'));
       }
     }
 
@@ -215,7 +216,7 @@ export const login: RequestHandler = asyncHandler(
     // Fire-and-forget: check login achievements (future-ready for consistency_30)
     achievementService
       .checkAndUnlock(user.id, 'login')
-      .catch((err) => console.error('[Achievements]', err));
+      .catch((err) => logger.error({ err, component: 'Achievements' }, 'Achievement check failed'));
 
     const response: ApiResponse<{
       user: Partial<UserAttributes>;

--- a/backend/src/controllers/CommissionController.ts
+++ b/backend/src/controllers/CommissionController.ts
@@ -10,6 +10,7 @@ import { CommissionService } from '../services/CommissionService';
 import { Purchase } from '../models';
 import type { ApiResponse } from '../types';
 import type { AuthenticatedRequest } from '../middleware/auth.middleware';
+import { logger } from '../utils/logger';
 
 const commissionService = new CommissionService();
 
@@ -128,7 +129,7 @@ export async function createPurchase(req: AuthenticatedRequest, res: Response): 
   try {
     await commissionService.calculateCommissions(purchase.id);
   } catch (error) {
-    console.error('Error calculating commissions:', error);
+    logger.error({ err: error }, 'Error calculating commissions');
   }
 
   const response: ApiResponse<{

--- a/backend/src/controllers/ContractController.ts
+++ b/backend/src/controllers/ContractController.ts
@@ -8,6 +8,7 @@
 import { Request, Response } from 'express';
 import { ContractService } from '../services/ContractService';
 import { type AuthenticatedRequest } from '../middleware/auth.middleware';
+import { logger } from '../utils/logger';
 
 const contractService = new ContractService();
 
@@ -52,7 +53,7 @@ export async function getContracts(req: AuthenticatedRequest, res: Response): Pr
       data: contracts,
     });
   } catch (error) {
-    console.error('Error fetching contracts:', error);
+    logger.error({ err: error }, 'Error fetching contracts');
     res.status(500).json({
       success: false,
       error: {
@@ -120,7 +121,7 @@ export async function getContract(req: Request, res: Response): Promise<void> {
       return;
     }
 
-    console.error('Error fetching contract:', error);
+    logger.error({ err: error }, 'Error fetching contract');
     res.status(500).json({
       success: false,
       error: {
@@ -204,7 +205,7 @@ export async function acceptContract(req: AuthenticatedRequest, res: Response): 
       return;
     }
 
-    console.error('Error accepting contract:', error);
+    logger.error({ err: error }, 'Error accepting contract');
     res.status(500).json({
       success: false,
       error: {
@@ -266,7 +267,7 @@ export async function declineContract(req: AuthenticatedRequest, res: Response):
       return;
     }
 
-    console.error('Error declining contract:', error);
+    logger.error({ err: error }, 'Error declining contract');
     res.status(500).json({
       success: false,
       error: {

--- a/backend/src/controllers/NotificationController.ts
+++ b/backend/src/controllers/NotificationController.ts
@@ -22,6 +22,7 @@ import { Request, Response } from 'express';
 import { User } from '../models/User';
 import { smsService } from '../services/SMSService';
 import { ResponseUtil } from '../utils/response.util';
+import { logger } from '../utils/logger';
 
 // In-memory store for 2FA codes (use Redis in production)
 // Almacenamiento en memoria para códigos 2FA (usar Redis en producción)
@@ -62,7 +63,7 @@ export async function getNotificationPreferences(req: Request, res: Response): P
       },
     });
   } catch (error) {
-    console.error('Error getting notification preferences:', error);
+    logger.error({ err: error }, 'Error getting notification preferences');
     res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Internal server error', 500));
   }
 }
@@ -116,7 +117,7 @@ export async function updateNotificationPreferences(req: Request, res: Response)
       },
     });
   } catch (error) {
-    console.error('Error updating notification preferences:', error);
+    logger.error({ err: error }, 'Error updating notification preferences');
     res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Internal server error', 500));
   }
 }
@@ -186,7 +187,7 @@ export async function enable2FA(req: Request, res: Response): Promise<void> {
       maskedPhone,
     });
   } catch (error) {
-    console.error('Error enabling 2FA:', error);
+    logger.error({ err: error }, 'Error enabling 2FA');
     res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Internal server error', 500));
   }
 }
@@ -261,7 +262,7 @@ export async function verify2FA(req: Request, res: Response): Promise<void> {
       message: '2FA enabled successfully',
     });
   } catch (error) {
-    console.error('Error verifying 2FA:', error);
+    logger.error({ err: error }, 'Error verifying 2FA');
     res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Internal server error', 500));
   }
 }
@@ -300,7 +301,7 @@ export async function disable2FA(req: Request, res: Response): Promise<void> {
       message: '2FA disabled successfully',
     });
   } catch (error) {
-    console.error('Error disabling 2FA:', error);
+    logger.error({ err: error }, 'Error disabling 2FA');
     res.status(500).json(ResponseUtil.error('INTERNAL_ERROR', 'Internal server error', 500));
   }
 }

--- a/backend/src/controllers/PaymentMercadoPagoController.ts
+++ b/backend/src/controllers/PaymentMercadoPagoController.ts
@@ -9,6 +9,7 @@ import { asyncHandler } from '../middleware/asyncHandler.js';
 import { mercadoPagoService } from '../services/MercadoPagoService.js';
 import { ResponseUtil } from '../utils/response.util.js';
 import { config } from '../config/env.js';
+import { logger } from '../utils/logger';
 import { Purchase, Order, Product } from '../models/index.js';
 import { CommissionService } from '../services/CommissionService.js';
 
@@ -171,14 +172,15 @@ export class PaymentMercadoPagoController {
         !ts ||
         !mercadoPagoService.verifyWebhookSignature(ts, rawBody, xSignature)
       ) {
-        console.warn('[MercadoPago Webhook] Invalid signature — rejecting request');
+        logger.warn({ component: 'MercadoPago Webhook' }, 'Invalid signature — rejecting request');
         return res
           .status(401)
           .json(ResponseUtil.error('INVALID_SIGNATURE', 'Invalid webhook signature', 401));
       }
     } else {
-      console.warn(
-        '[MercadoPago Webhook] MERCADOPAGO_WEBHOOK_SECRET not configured — skipping signature verification (dev mode)'
+      logger.warn(
+        { component: 'MercadoPago Webhook' },
+        'MERCADOPAGO_WEBHOOK_SECRET not configured — skipping signature verification (dev mode)'
       );
     }
 
@@ -193,19 +195,22 @@ export class PaymentMercadoPagoController {
       if (paymentId) {
         try {
           const payment = await mercadoPagoService.getPayment(paymentId.toString());
-          console.log('[MercadoPago Webhook] Payment received:', payment.id, payment.status);
+          logger.info(
+            { component: 'MercadoPago Webhook', paymentId: payment.id, status: payment.status },
+            'Payment received'
+          );
 
           switch (payment.status) {
             case 'approved': {
-              console.log('[MercadoPago] Payment approved:', payment.id);
+              logger.info({ component: 'MercadoPago', paymentId: payment.id }, 'Payment approved');
 
               try {
                 // ── Step 1: Extract buyer info from external_reference (= userId) ──
                 const userId = payment.external_reference;
                 if (!userId) {
-                  console.error(
-                    '[MercadoPago Webhook] No external_reference (userId) in payment',
-                    payment.id
+                  logger.error(
+                    { component: 'MercadoPago Webhook', paymentId: payment.id },
+                    'No external_reference (userId) in payment'
                   );
                   break;
                 }
@@ -215,10 +220,9 @@ export class PaymentMercadoPagoController {
                   where: { notes: `mercadopago:${payment.id}` },
                 });
                 if (existingOrder) {
-                  console.log(
-                    '[MercadoPago Webhook] Order already exists for payment',
-                    payment.id,
-                    '— skipping'
+                  logger.info(
+                    { component: 'MercadoPago Webhook', paymentId: payment.id },
+                    'Order already exists for payment — skipping'
                   );
                   break;
                 }
@@ -237,9 +241,9 @@ export class PaymentMercadoPagoController {
                 }
 
                 if (!productId) {
-                  console.error(
-                    '[MercadoPago Webhook] Could not resolve productId for payment',
-                    payment.id
+                  logger.error(
+                    { component: 'MercadoPago Webhook', paymentId: payment.id },
+                    'Could not resolve productId for payment'
                   );
                   break;
                 }
@@ -274,47 +278,53 @@ export class PaymentMercadoPagoController {
                   notes: `mercadopago:${payment.id}`,
                 });
 
-                console.log(
-                  '[MercadoPago Webhook] Purchase & Order created for payment',
-                  payment.id
+                logger.info(
+                  { component: 'MercadoPago Webhook', paymentId: payment.id },
+                  'Purchase & Order created for payment'
                 );
 
                 // ── Step 6: Trigger commission calculation (fire-and-forget, don't break 200) ──
                 try {
                   const commissionService = new CommissionService();
                   await commissionService.calculateCommissions(purchase.id);
-                  console.log(
-                    '[MercadoPago Webhook] Commissions calculated for purchase',
-                    purchase.id
+                  logger.info(
+                    { component: 'MercadoPago Webhook', purchaseId: purchase.id },
+                    'Commissions calculated for purchase'
                   );
                 } catch (commissionError) {
-                  console.error(
-                    '[MercadoPago Webhook] Commission calculation failed:',
-                    commissionError
+                  logger.error(
+                    { err: commissionError, component: 'MercadoPago Webhook' },
+                    'Commission calculation failed'
                   );
                   // Non-fatal — MP still gets 200
                 }
               } catch (orderError) {
-                console.error('[MercadoPago Webhook] Error creating Purchase/Order:', orderError);
+                logger.error(
+                  { err: orderError, component: 'MercadoPago Webhook' },
+                  'Error creating Purchase/Order'
+                );
                 // Non-fatal — MP must receive 200 regardless
               }
 
               break;
             }
             case 'pending':
-              console.log('[MercadoPago] Payment pending:', payment.id);
+              logger.info({ component: 'MercadoPago', paymentId: payment.id }, 'Payment pending');
               break;
             case 'rejected':
-              console.log('[MercadoPago] Payment rejected:', payment.id);
+              logger.info({ component: 'MercadoPago', paymentId: payment.id }, 'Payment rejected');
               break;
             case 'cancelled':
-              console.log('[MercadoPago] Payment cancelled:', payment.id);
+              logger.info({ component: 'MercadoPago', paymentId: payment.id }, 'Payment cancelled');
               break;
             default:
-              console.log('[MercadoPago] Unknown status:', payment.status);
+              logger.info({ component: 'MercadoPago', status: payment.status }, 'Unknown status');
           }
         } catch (error) {
-          console.error('[MercadoPago Webhook] Error processing payment:', error);
+          logger.error(
+            { err: error, component: 'MercadoPago Webhook' },
+            'Error processing payment'
+          );
         }
       }
     }

--- a/backend/src/controllers/PaymentPayPalController.ts
+++ b/backend/src/controllers/PaymentPayPalController.ts
@@ -8,6 +8,7 @@ import { Request, Response } from 'express';
 import { asyncHandler } from '../middleware/asyncHandler.js';
 import { paypalService } from '../services/PayPalService.js';
 import { ResponseUtil } from '../utils/response.util.js';
+import { logger } from '../utils/logger';
 
 /**
  * PayPal order ID format: alphanumeric, 17 characters
@@ -118,7 +119,7 @@ export class PaymentPayPalController {
     // Verify webhook signature
     const isValid = await paypalService.verifyWebhookSignature(headers, body);
     if (!isValid) {
-      console.error('[PayPal Webhook] Invalid signature');
+      logger.error({ component: 'PayPal Webhook' }, 'Invalid signature');
       return res
         .status(403)
         .json(
@@ -130,32 +131,38 @@ export class PaymentPayPalController {
 
     // Check idempotency
     if (paypalService.isIdempotent(event.resource?.id)) {
-      console.log('[PayPal Webhook] Duplicate event, skipping:', event.resource?.id);
+      logger.info(
+        { component: 'PayPal Webhook', resourceId: event.resource?.id },
+        'Duplicate event, skipping'
+      );
       return res.status(200).json({ received: true, duplicate: true });
     }
 
-    console.log('[PayPal Webhook]', event.event_type, event.resource?.id);
+    logger.info(
+      { component: 'PayPal Webhook', eventType: event.event_type, resourceId: event.resource?.id },
+      'Webhook event received'
+    );
 
     switch (event.event_type) {
       case 'CHECKOUT.ORDER.APPROVED':
         // Order was approved by user
-        console.log('[PayPal] Order approved:', event.resource?.id);
+        logger.info({ component: 'PayPal', resourceId: event.resource?.id }, 'Order approved');
         break;
 
       case 'PAYMENT.CAPTURE.COMPLETED':
         // Payment successfully captured
-        console.log('[PayPal] Payment completed:', event.resource?.id);
+        logger.info({ component: 'PayPal', resourceId: event.resource?.id }, 'Payment completed');
         // TODO: Trigger commission calculation
         break;
 
       case 'PAYMENT.CAPTURE.REFUNDED':
         // Payment was refunded
-        console.log('[PayPal] Payment refunded:', event.resource?.id);
+        logger.info({ component: 'PayPal', resourceId: event.resource?.id }, 'Payment refunded');
         // TODO: Reverse commissions if applicable
         break;
 
       default:
-        console.log('[PayPal] Unhandled event:', event.event_type);
+        logger.info({ component: 'PayPal', eventType: event.event_type }, 'Unhandled event');
     }
 
     // Mark as processed for idempotency

--- a/backend/src/controllers/PropertyController.ts
+++ b/backend/src/controllers/PropertyController.ts
@@ -18,6 +18,7 @@ import { body, param, query, validationResult } from 'express-validator';
 import { authenticate, requireAdmin } from '../middleware/auth.middleware';
 import { propertyService } from '../services/PropertyService';
 import { R2Service } from '../services/R2Service';
+import { logger } from '../utils/logger';
 
 // ============================================
 // VALIDATION RULES
@@ -157,7 +158,7 @@ export const getProperties = [
         },
       });
     } catch (error: any) {
-      console.error('Get properties error:', error);
+      logger.error({ err: error }, 'Get properties error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -200,7 +201,7 @@ export const getProperty = [
         data: property,
       });
     } catch (error: any) {
-      console.error('Get property error:', error);
+      logger.error({ err: error }, 'Get property error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -245,7 +246,7 @@ export const createProperty = [
         data: property,
       });
     } catch (error: any) {
-      console.error('Create property error:', error);
+      logger.error({ err: error }, 'Create property error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -290,7 +291,7 @@ export const updateProperty = [
         data: property,
       });
     } catch (error: any) {
-      console.error('Update property error:', error);
+      logger.error({ err: error }, 'Update property error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -335,7 +336,7 @@ export const deleteProperty = [
         message: 'Property deleted successfully',
       });
     } catch (error: any) {
-      console.error('Delete property error:', error);
+      logger.error({ err: error }, 'Delete property error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {

--- a/backend/src/controllers/ReservationController.ts
+++ b/backend/src/controllers/ReservationController.ts
@@ -17,6 +17,7 @@
  */
 import { Request, Response } from 'express';
 import { reservationService } from '../services/ReservationService';
+import { logger } from '../utils/logger';
 
 // ============================================
 // HANDLERS
@@ -56,7 +57,7 @@ export const getReservations = async (req: Request, res: Response): Promise<void
       },
     });
   } catch (error: any) {
-    console.error('Get reservations error:', error);
+    logger.error({ err: error }, 'Get reservations error');
     res.status(error.statusCode || 500).json({
       success: false,
       error: {
@@ -83,7 +84,7 @@ export const getReservation = async (req: Request, res: Response): Promise<void>
       data: reservation,
     });
   } catch (error: any) {
-    console.error('Get reservation error:', error);
+    logger.error({ err: error }, 'Get reservation error');
     res.status(error.statusCode || 500).json({
       success: false,
       error: {
@@ -110,7 +111,7 @@ export const createReservation = async (req: Request, res: Response): Promise<vo
       data: reservation,
     });
   } catch (error: any) {
-    console.error('Create reservation error:', error);
+    logger.error({ err: error }, 'Create reservation error');
     res.status(error.statusCode || 500).json({
       success: false,
       error: {
@@ -137,7 +138,7 @@ export const updateReservation = async (req: Request, res: Response): Promise<vo
       data: reservation,
     });
   } catch (error: any) {
-    console.error('Update reservation error:', error);
+    logger.error({ err: error }, 'Update reservation error');
     res.status(error.statusCode || 500).json({
       success: false,
       error: {
@@ -164,7 +165,7 @@ export const cancelReservation = async (req: Request, res: Response): Promise<vo
       data: reservation,
     });
   } catch (error: any) {
-    console.error('Cancel reservation error:', error);
+    logger.error({ err: error }, 'Cancel reservation error');
     res.status(error.statusCode || 500).json({
       success: false,
       error: {
@@ -191,7 +192,7 @@ export const confirmReservation = async (req: Request, res: Response): Promise<v
       data: reservation,
     });
   } catch (error: any) {
-    console.error('Confirm reservation error:', error);
+    logger.error({ err: error }, 'Confirm reservation error');
     res.status(error.statusCode || 500).json({
       success: false,
       error: {

--- a/backend/src/controllers/TourPackageController.ts
+++ b/backend/src/controllers/TourPackageController.ts
@@ -21,6 +21,7 @@ import { body, param, query, validationResult } from 'express-validator';
 import { authenticate, requireAdmin } from '../middleware/auth.middleware';
 import { tourPackageService } from '../services/TourPackageService';
 import { R2Service } from '../services/R2Service';
+import { logger } from '../utils/logger';
 
 // ============================================
 // VALIDATION RULES
@@ -172,7 +173,7 @@ export const getTourPackages = [
         },
       });
     } catch (error: any) {
-      console.error('Get tour packages error:', error);
+      logger.error({ err: error }, 'Get tour packages error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -215,7 +216,7 @@ export const getTourPackage = [
         data: tourPackage,
       });
     } catch (error: any) {
-      console.error('Get tour package error:', error);
+      logger.error({ err: error }, 'Get tour package error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -260,7 +261,7 @@ export const createTourPackage = [
         data: tourPackage,
       });
     } catch (error: any) {
-      console.error('Create tour package error:', error);
+      logger.error({ err: error }, 'Create tour package error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -305,7 +306,7 @@ export const updateTourPackage = [
         data: tourPackage,
       });
     } catch (error: any) {
-      console.error('Update tour package error:', error);
+      logger.error({ err: error }, 'Update tour package error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -347,7 +348,7 @@ export const deleteTourPackage = [
 
       res.status(204).send();
     } catch (error: any) {
-      console.error('Delete tour package error:', error);
+      logger.error({ err: error }, 'Delete tour package error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {

--- a/backend/src/controllers/VendorController.ts
+++ b/backend/src/controllers/VendorController.ts
@@ -19,6 +19,7 @@ import { authenticate, requireVendor } from '../middleware/auth.middleware';
 import type { AuthenticatedRequest } from '../middleware/auth.middleware';
 import { body, validationResult } from 'express-validator';
 import { Product } from '../models';
+import { logger } from '../utils/logger';
 
 // Validation rules
 export const vendorValidationRules = {
@@ -76,7 +77,7 @@ export const registerVendor = [
         data: vendor,
       });
     } catch (error: any) {
-      console.error('Register vendor error:', error);
+      logger.error({ err: error }, 'Register vendor error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {
@@ -119,7 +120,7 @@ export const getVendorProfile = [
         data: vendor,
       });
     } catch (error: any) {
-      console.error('Get vendor profile error:', error);
+      logger.error({ err: error }, 'Get vendor profile error');
       res.status(500).json({
         success: false,
         error: {
@@ -179,7 +180,7 @@ export const getVendorProducts = [
         },
       });
     } catch (error: any) {
-      console.error('Get vendor products error:', error);
+      logger.error({ err: error }, 'Get vendor products error');
       res.status(500).json({
         success: false,
         error: {
@@ -224,7 +225,7 @@ export const getVendorDashboard = [
         data: dashboard,
       });
     } catch (error: any) {
-      console.error('Get vendor dashboard error:', error);
+      logger.error({ err: error }, 'Get vendor dashboard error');
       res.status(500).json({
         success: false,
         error: {
@@ -284,7 +285,7 @@ export const requestPayout = [
         data: payout,
       });
     } catch (error: any) {
-      console.error('Request payout error:', error);
+      logger.error({ err: error }, 'Request payout error');
       res.status(error.statusCode || 500).json({
         success: false,
         error: {

--- a/backend/src/controllers/orders/OrderWriteController.ts
+++ b/backend/src/controllers/orders/OrderWriteController.ts
@@ -17,6 +17,7 @@ import { orderService } from '../../services/OrderService';
 import type { ApiResponse, OrderAttributes } from '../../types';
 import type { AuthenticatedRequest } from '../../middleware/auth.middleware';
 import { asyncHandler } from '../../middleware/asyncHandler';
+import { logger } from '../../utils/logger';
 
 /**
  * UUID validation regex
@@ -73,7 +74,7 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
  */
 export const createOrder: RequestHandler = asyncHandler(
   async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-    console.log('[DEBUG] createOrder called, req.user:', req.user?.id);
+    logger.debug({ userId: req.user?.id }, 'createOrder called');
 
     // Check authentication
     if (!req.user) {

--- a/backend/src/middleware/asyncHandler.ts
+++ b/backend/src/middleware/asyncHandler.ts
@@ -1,12 +1,13 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
+import { logger } from '../utils/logger';
 
 type AsyncRequestHandler = (req: Request, res: Response, next: NextFunction) => Promise<void>;
 
 export function asyncHandler(fn: AsyncRequestHandler): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {
-    console.log('[DEBUG] asyncHandler called');
+    logger.debug('asyncHandler called');
     Promise.resolve(fn(req, res, next)).catch((e) => {
-      console.log('[DEBUG] asyncHandler error:', e);
+      logger.debug({ err: e }, 'asyncHandler caught error');
       next(e);
     });
   };

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -6,6 +6,7 @@ import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { config } from '../config/env';
 import { UserRole, ADMIN_ROLES, FINANCE_ROLES, CRM_ROLES, PROPERTY_MGMT_ROLES } from '../types';
+import { logger } from '../utils/logger';
 
 // ============================================
 // TYPES
@@ -60,13 +61,13 @@ export function extractTokenFromHeader(authHeader?: string): string | null {
 // ============================================
 
 export function authenticate(req: AuthenticatedRequest, res: Response, next: NextFunction): void {
-  console.log('[DEBUG] authenticate middleware called');
+  logger.debug('authenticate middleware called');
   try {
     const token = extractTokenFromHeader(req.headers.authorization);
-    console.log('[DEBUG] token extracted:', token ? 'yes' : 'no');
+    logger.debug({ hasToken: !!token }, 'Token extraction result');
 
     if (!token) {
-      console.log('[DEBUG] No token - returning 401');
+      logger.debug('No token present, returning 401');
       res.status(401).json({
         success: false,
         error: {
@@ -78,10 +79,10 @@ export function authenticate(req: AuthenticatedRequest, res: Response, next: Nex
     }
 
     const decoded = verifyToken(token);
-    console.log('[DEBUG] token decoded:', decoded ? 'yes' : 'no');
+    logger.debug({ decoded: !!decoded }, 'Token verification result');
 
     if (!decoded) {
-      console.log('[DEBUG] Invalid token - returning 401');
+      logger.debug('Invalid token, returning 401');
       res.status(401).json({
         success: false,
         error: {
@@ -100,10 +101,10 @@ export function authenticate(req: AuthenticatedRequest, res: Response, next: Nex
     };
     req.userId = decoded.userId;
 
-    console.log('[DEBUG] Calling next()');
+    logger.debug('Authentication successful, calling next()');
     next();
   } catch (e) {
-    console.log('[DEBUG] Error in authenticate:', e);
+    logger.error({ err: e }, 'Error in authenticate middleware');
     res.status(500).json({
       success: false,
       error: {
@@ -364,7 +365,7 @@ export async function logAccess(entry: Omit<AuditLogEntry, 'timestamp'>): Promis
   };
 
   if (process.env.NODE_ENV !== 'production') {
-    console.log('[AUDIT]', JSON.stringify(fullEntry));
+    logger.debug({ audit: fullEntry }, 'Audit log entry');
   }
 }
 

--- a/backend/src/middleware/contract.middleware.ts
+++ b/backend/src/middleware/contract.middleware.ts
@@ -7,6 +7,7 @@
 
 import { Response, NextFunction } from 'express';
 import { ContractService } from '../services/ContractService';
+import { logger } from '../utils/logger';
 import type { AuthenticatedRequest } from './auth.middleware';
 import type { ContractType } from '../types';
 
@@ -69,7 +70,7 @@ export function requireContractAccepted(contractTypes: ContractType[]) {
 
       next();
     } catch (error) {
-      console.error('Error in requireContractAccepted middleware:', error);
+      logger.error({ error }, 'Error in requireContractAccepted middleware');
       res.status(500).json({
         success: false,
         error: {

--- a/backend/src/middleware/error.middleware.ts
+++ b/backend/src/middleware/error.middleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import type { ApiResponse } from '../types';
+import { logger } from '../utils/logger';
 
 export class AppError extends Error {
   constructor(
@@ -59,9 +60,9 @@ export function errorHandler(err: Error, req: Request, res: Response, _next: Nex
 
   // Log based on status code
   if (statusCode >= 500) {
-    console.error('Server Error:', err);
+    logger.error({ err, statusCode }, 'Server error');
   } else {
-    console.warn('Client Error:', err.message);
+    logger.warn({ statusCode }, err.message);
   }
 
   res.status(statusCode).json(response);

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -1,4 +1,5 @@
 import { sequelize } from '../config/database';
+import { logger } from '../utils/logger';
 import { User } from './User';
 import { UserClosure } from './UserClosure';
 import { Commission } from './Commission';
@@ -534,5 +535,5 @@ export {
 };
 
 export function initModels(): void {
-  console.log('✅ Models initialized');
+  logger.info('Models initialized');
 }

--- a/backend/src/routes/bot-leads.routes.ts
+++ b/backend/src/routes/bot-leads.routes.ts
@@ -11,6 +11,7 @@ import { Router, Request, Response } from 'express';
 import { asyncHandler } from '../middleware/asyncHandler';
 import { sequelize } from '../config/database';
 import { v4 as uuidv4 } from 'uuid';
+import { logger } from '../utils/logger';
 
 const router = Router();
 
@@ -46,7 +47,10 @@ router.post(
 
     const systemUserId = process.env.BOT_SYSTEM_USER_ID;
     if (!systemUserId) {
-      console.error('[BotLeads] BOT_SYSTEM_USER_ID is not set — cannot persist lead');
+      logger.error(
+        { component: 'BotLeads' },
+        'BOT_SYSTEM_USER_ID is not set — cannot persist lead'
+      );
       res.status(500).json({ success: false, message: 'Server misconfiguration' });
       return;
     }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,7 @@ import './instrument';
 import app from './app';
 import { connectDatabase, syncDatabase } from './config/database';
 import { config } from './config/env';
+import { logger } from './utils/logger';
 import { initModels, User, Product, CommissionConfig, UserClosure } from './models';
 import { achievementService } from './services/AchievementService';
 import bcrypt from 'bcryptjs';
@@ -23,11 +24,11 @@ async function autoSeed(): Promise<void> {
     // Verificar si ya hay datos / Check if data already exists
     const userCount = await User.count();
     if (userCount > 0) {
-      console.log('✅ Database already seeded (' + userCount + ' users)');
+      logger.info({ userCount }, 'Database already seeded');
       return;
     }
 
-    console.log('🌱 Database empty — running Nexo Real auto-seed...');
+    logger.info('Database empty — running Nexo Real auto-seed...');
 
     // ── Comisiones / Commission configs ─────────────────────────────────────
     const commissionData: Array<{
@@ -75,7 +76,7 @@ async function autoSeed(): Promise<void> {
         });
       }
     }
-    console.log('  ✅ Commission configs seeded (5 types × 5 levels)');
+    logger.info('Commission configs seeded (5 types × 5 levels)');
 
     // ── Productos / Products ─────────────────────────────────────────────────
     const products: Array<{
@@ -205,7 +206,7 @@ async function autoSeed(): Promise<void> {
 
     for (const prod of products) {
       await Product.create(prod);
-      console.log('  ✅ Created product: ' + prod.name);
+      logger.info({ product: prod.name }, 'Created product');
     }
 
     // ── Árbol Unilevel mínimo / Minimal Unilevel tree ────────────────────────
@@ -243,7 +244,7 @@ async function autoSeed(): Promise<void> {
           });
         }
       }
-      console.log('  ✅ Created [' + role + ']: ' + email);
+      logger.info({ role, email }, 'Created user');
       return user;
     }
 
@@ -292,16 +293,14 @@ async function autoSeed(): Promise<void> {
       1
     );
 
-    console.log('');
-    console.log('📋 Nexo Real — Test Credentials:');
-    console.log('   superadmin@nexoreal.xyz  /  Nexo2024!  (super_admin)');
-    console.log('   admin@nexoreal.xyz       /  Nexo2024!  (admin)');
-    console.log('   valentina.ospina@...     /  Nexo2024!  (advisor)');
-    console.log('   andres.martinez@...      /  Nexo2024!  (user)');
-    console.log('   invitado@nexoreal.xyz    /  Nexo2024!  (guest)');
-    console.log('');
+    logger.info('Nexo Real — Test Credentials:');
+    logger.info('  superadmin@nexoreal.xyz  /  Nexo2024!  (super_admin)');
+    logger.info('  admin@nexoreal.xyz       /  Nexo2024!  (admin)');
+    logger.info('  valentina.ospina@...     /  Nexo2024!  (advisor)');
+    logger.info('  andres.martinez@...      /  Nexo2024!  (user)');
+    logger.info('  invitado@nexoreal.xyz    /  Nexo2024!  (guest)');
   } catch (error) {
-    console.error('❌ Auto-seed failed:', error);
+    logger.error({ err: error }, 'Auto-seed failed');
   }
 }
 
@@ -314,32 +313,33 @@ async function startServer(): Promise<void> {
     const forceSync = process.argv.includes('--force-sync');
     if (forceSync) {
       await syncDatabase(true);
-      console.log('⚠️  Database synced with force=true (drop tables)');
+      logger.warn('Database synced with force=true (drop tables)');
     } else {
       await syncDatabase(false);
-      console.log('✅ Database schema synced (alter mode)');
+      logger.info('Database schema synced (alter mode)');
     }
 
     // Auto-seed if database is empty
     await autoSeed();
 
     // Seed achievements (idempotent — safe on every restart)
-    achievementService.seedAchievements().catch((err) => console.error('[Achievements seed]', err));
+    achievementService
+      .seedAchievements()
+      .catch((err) => logger.error({ err }, 'Achievements seed failed'));
 
     app.listen(config.port, () => {
-      console.log(`
-╔═══════════════════════════════════════════════════════════╗
-║                 Nexo Real — Backend Server                 ║
-╠═══════════════════════════════════════════════════════════╣
-║  Environment: ${config.nodeEnv.padEnd(40)}║
-║  Port:        ${config.port.toString().padEnd(40)}║
-║  Database:    ${config.db.name.padEnd(41)}║
-║  Frontend:    ${config.app.frontendUrl.padEnd(41)}║
-╚═══════════════════════════════════════════════════════════╝
-      `);
+      logger.info(
+        {
+          environment: config.nodeEnv,
+          port: config.port,
+          database: config.db.name,
+          frontend: config.app.frontendUrl,
+        },
+        'Nexo Real — Backend Server started'
+      );
     });
   } catch (error) {
-    console.error('❌ Failed to start server:', error);
+    logger.fatal({ err: error }, 'Failed to start server');
     process.exit(1);
   }
 }

--- a/backend/src/services/AchievementService.ts
+++ b/backend/src/services/AchievementService.ts
@@ -18,6 +18,7 @@ import { QueryTypes } from 'sequelize';
 import { sequelize } from '../config/database';
 import { Achievement, Badge, UserAchievement } from '../models';
 import type { AchievementConditionType } from '../models/Achievement';
+import { logger } from '../utils/logger';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -187,7 +188,7 @@ export class AchievementService {
         { conflictFields: ['key'] }
       );
     }
-    console.log('✅ Achievements seeded (8 records upserted)');
+    logger.info({ service: 'AchievementService' }, 'Achievements seeded (8 records upserted)');
   }
 
   // ── Progress helpers ───────────────────────────────────────────────────────
@@ -332,14 +333,20 @@ export class AchievementService {
           });
 
           if (created) {
-            console.log(
-              `[Achievements] 🏆 User ${userId} unlocked "${achievement.name}" (${achievement.key})`
+            logger.info(
+              {
+                service: 'AchievementService',
+                userId,
+                achievementName: achievement.name,
+                achievementKey: achievement.key,
+              },
+              'User unlocked achievement'
             );
           }
         }
       }
     } catch (err) {
-      console.error('[Achievements] checkAndUnlock error:', err);
+      logger.error({ service: 'AchievementService', err }, 'checkAndUnlock error');
       // Never propagate — fire-and-forget safety
     }
   }

--- a/backend/src/services/BrevoEmailService.ts
+++ b/backend/src/services/BrevoEmailService.ts
@@ -28,6 +28,7 @@
 
 import nodemailer from 'nodemailer';
 import { config } from '../config/env';
+import { logger } from '../utils/logger';
 
 // ============================================
 // TYPES — Tipos
@@ -118,7 +119,7 @@ export class BrevoEmailService {
   async sendEmail(params: SendEmailParams): Promise<SendEmailResult> {
     // If circuit breaker has tripped, go directly to SMTP
     if (this.circuitBreaker.fallbackToSMTP) {
-      console.log('[BrevoEmailService] Circuit breaker active — sending via SMTP');
+      logger.info({ service: 'BrevoEmailService' }, 'Circuit breaker active — sending via SMTP');
       return this.sendViaSMTP(params);
     }
 
@@ -128,22 +129,29 @@ export class BrevoEmailService {
       this.circuitBreaker.failures = 0;
       return result;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown REST API error';
-      console.error(`[BrevoEmailService] REST API failed: ${errorMessage}`);
+      logger.error({ err: error, service: 'BrevoEmailService' }, 'REST API failed');
 
       // Increment circuit breaker
       this.circuitBreaker.failures++;
-      console.log(
-        `[BrevoEmailService] Circuit breaker: ${this.circuitBreaker.failures}/${this.circuitBreaker.threshold} failures`
+      logger.info(
+        {
+          service: 'BrevoEmailService',
+          failures: this.circuitBreaker.failures,
+          threshold: this.circuitBreaker.threshold,
+        },
+        'Circuit breaker failure count incremented'
       );
 
       if (this.circuitBreaker.failures >= this.circuitBreaker.threshold) {
         this.circuitBreaker.fallbackToSMTP = true;
-        console.warn('[BrevoEmailService] Circuit breaker TRIPPED — switching to SMTP permanently');
+        logger.warn(
+          { service: 'BrevoEmailService' },
+          'Circuit breaker TRIPPED — switching to SMTP permanently'
+        );
       }
 
       // Fallback to SMTP
-      console.log('[BrevoEmailService] Falling back to SMTP');
+      logger.info({ service: 'BrevoEmailService' }, 'Falling back to SMTP');
       return this.sendViaSMTP(params);
     }
   }
@@ -155,7 +163,7 @@ export class BrevoEmailService {
   resetCircuitBreaker(): void {
     this.circuitBreaker.failures = 0;
     this.circuitBreaker.fallbackToSMTP = false;
-    console.log('[BrevoEmailService] Circuit breaker reset — REST API re-enabled');
+    logger.info({ service: 'BrevoEmailService' }, 'Circuit breaker reset — REST API re-enabled');
   }
 
   /**
@@ -254,7 +262,7 @@ export class BrevoEmailService {
       html: params.htmlContent,
     });
 
-    console.log(`[BrevoEmailService] SMTP sent: ${info.messageId}`);
+    logger.info({ service: 'BrevoEmailService', messageId: info.messageId }, 'SMTP sent');
     return { messageId: info.messageId || `smtp-${Date.now()}` };
   }
 }

--- a/backend/src/services/CalendarService.ts
+++ b/backend/src/services/CalendarService.ts
@@ -17,6 +17,8 @@
  * await calendarService.notifyReservationConfirmed({ reservationId: '123', ... });
  */
 
+import { logger } from '../utils/logger';
+
 // ============================================
 // TYPES / TIPOS
 // ============================================
@@ -86,7 +88,10 @@ export class CalendarService {
    */
   async notifyReservationConfirmed(payload: CalendarEventPayload): Promise<void> {
     if (!this.webhookUrl) {
-      console.warn('[CalendarService] N8N_CALENDAR_WEBHOOK_URL not set, skipping calendar sync');
+      logger.warn(
+        { service: 'CalendarService' },
+        'N8N_CALENDAR_WEBHOOK_URL not set, skipping calendar sync'
+      );
       return;
     }
 
@@ -101,14 +106,17 @@ export class CalendarService {
       });
 
       if (!response.ok) {
-        console.error(`[CalendarService] n8n webhook returned ${response.status}`);
+        logger.error(
+          { service: 'CalendarService', statusCode: response.status },
+          'n8n webhook returned non-OK status'
+        );
       }
     } catch (error) {
       // Non-blocking — log error but don't throw
       // (calendar sync failure should not break booking flow)
       // No bloqueante — registrar error pero no lanzar
       // (el fallo de sincronización no debe romper el flujo de reserva)
-      console.error('[CalendarService] Failed to notify n8n webhook:', error);
+      logger.error({ service: 'CalendarService', err: error }, 'Failed to notify n8n webhook');
     }
   }
 }

--- a/backend/src/services/CartRecoveryEmailService.ts
+++ b/backend/src/services/CartRecoveryEmailService.ts
@@ -18,6 +18,7 @@
 import { Cart, CartItem, CartRecoveryToken, Product, User } from '../models';
 import { emailService } from './EmailService';
 import { config } from '../config/env';
+import { logger } from '../utils/logger';
 
 /**
  * CartRecoveryEmailService - Composes and sends abandoned cart recovery emails
@@ -109,7 +110,10 @@ export class CartRecoveryEmailService {
       { where: { cartId, usedAt: null } }
     );
 
-    console.log(`[CartRecoveryEmail] Sent recovery email to ${user.email} for cart ${cartId}`);
+    logger.info(
+      { service: 'CartRecoveryEmailService', email: user.email, cartId },
+      'Sent recovery email'
+    );
   }
 
   /**

--- a/backend/src/services/CommissionService.ts
+++ b/backend/src/services/CommissionService.ts
@@ -25,6 +25,7 @@ import { User, Commission, Purchase, CommissionConfig } from '../models';
 import { COMMISSION_RATES } from '../types';
 import { walletService } from './WalletService';
 import { emailService } from './EmailService';
+import { logger } from '../utils/logger';
 
 export class CommissionService {
   /**
@@ -92,7 +93,9 @@ export class CommissionService {
           amount: Number(directCommission.amount),
           currency: purchase.currency,
         })
-        .catch((err) => console.error('Commission email failed:', err));
+        .catch((err) =>
+          logger.error({ service: 'CommissionService', err }, 'Commission email failed')
+        );
     }
 
     const commissionTypeMap: Record<number, 'level_1' | 'level_2' | 'level_3' | 'level_4'> = {
@@ -260,7 +263,10 @@ export class CommissionService {
         const commission = await this.approveCommission(id);
         approved.push(commission);
       } catch (error) {
-        console.error(`Error approving commission ${id}:`, error);
+        logger.error(
+          { service: 'CommissionService', err: error, commissionId: id },
+          'Error approving commission'
+        );
       }
     }
 
@@ -392,8 +398,9 @@ export class CommissionService {
     // Verify: vendorAmount + platformNet + sum(mlm) === price
     const verification = this.roundDecimal(vendorAmount + platformNet + totalMlm, 2);
     if (verification !== this.roundDecimal(price, 2)) {
-      console.warn(
-        `[CommissionService] Commission math verification failed: ${verification} !== ${this.roundDecimal(price, 2)}`
+      logger.warn(
+        { service: 'CommissionService', verification, expected: this.roundDecimal(price, 2) },
+        'Commission math verification failed'
       );
     }
 

--- a/backend/src/services/CryptoPriceService.ts
+++ b/backend/src/services/CryptoPriceService.ts
@@ -7,6 +7,7 @@
  */
 
 import axios from 'axios';
+import { logger } from '../utils/logger';
 
 // CoinGecko API URL
 const COINGECKO_API = 'https://api.coingecko.com/api/v3';
@@ -81,7 +82,7 @@ export async function getCryptoPrices(): Promise<CryptoPrices> {
 
     return prices;
   } catch (error) {
-    console.error('Error fetching crypto prices:', error);
+    logger.error({ service: 'CryptoPriceService', err: error }, 'Error fetching crypto prices');
 
     // Return cached data if available, otherwise fallback
     if (priceCache.data) {

--- a/backend/src/services/CurrencyService.ts
+++ b/backend/src/services/CurrencyService.ts
@@ -6,6 +6,8 @@
  * @author MLM Development Team
  */
 
+import { logger } from '../utils/logger';
+
 const FRANKFURTER_API = 'https://api.frankfurter.dev';
 
 /**
@@ -56,7 +58,7 @@ async function fetchExchangeRates(): Promise<Record<string, number>> {
       ...data.rates,
     };
   } catch (error) {
-    console.error('CurrencyService: Failed to fetch exchange rates:', error);
+    logger.error({ err: error, service: 'CurrencyService' }, 'Failed to fetch exchange rates');
     throw error;
   }
 }
@@ -107,7 +109,7 @@ export async function convertToUSD(amount: number, fromCurrency: string): Promis
     if (from === CURRENCY.EUR) {
       const usdRate = rates[CURRENCY.USD];
       if (!usdRate) {
-        console.warn('CurrencyService: USD rate not found, using 1:1 fallback');
+        logger.warn({ service: 'CurrencyService' }, 'USD rate not found, using 1:1 fallback');
         return amount;
       }
       return amount * usdRate;
@@ -120,7 +122,10 @@ export async function convertToUSD(amount: number, fromCurrency: string): Promis
     const eurToUsd = rates[CURRENCY.USD];
 
     if (!sourceToEur || !eurToUsd) {
-      console.warn(`CurrencyService: Missing rate for ${from} or USD, using 1:1 fallback`);
+      logger.warn(
+        { service: 'CurrencyService', fromCurrency: from },
+        'Missing rate, using 1:1 fallback'
+      );
       return amount;
     }
 
@@ -131,7 +136,7 @@ export async function convertToUSD(amount: number, fromCurrency: string): Promis
 
     return Math.round(amountInUSD * 100) / 100;
   } catch (error) {
-    console.error('CurrencyService: Conversion failed, using fallback:', error);
+    logger.error({ err: error, service: 'CurrencyService' }, 'Conversion failed, using fallback');
     // Fallback: return 1:1 if API fails
     return amount;
   }
@@ -166,7 +171,10 @@ export async function convertCurrency(
     const toRate = rates[to];
 
     if (!fromRate || !toRate) {
-      console.warn(`CurrencyService: Missing rate for ${from} or ${to}, using 1:1 fallback`);
+      logger.warn(
+        { service: 'CurrencyService', fromCurrency: from, toCurrency: to },
+        'Missing rate, using 1:1 fallback'
+      );
       return amount;
     }
 
@@ -176,7 +184,7 @@ export async function convertCurrency(
 
     return Math.round(converted * 100) / 100;
   } catch (error) {
-    console.error('CurrencyService: Conversion failed, using fallback:', error);
+    logger.error({ err: error, service: 'CurrencyService' }, 'Conversion failed, using fallback');
     return amount;
   }
 }

--- a/backend/src/services/EmailQueueService.ts
+++ b/backend/src/services/EmailQueueService.ts
@@ -22,6 +22,7 @@ import { Op } from 'sequelize';
 import { EmailQueue, EmailCampaign, EmailCampaignLog } from '../models';
 import { brevoEmailService } from './BrevoEmailService';
 import { EMAIL_QUEUE_STATUS, EMAIL_CAMPAIGN_STATUS } from '../types';
+import { logger } from '../utils/logger';
 
 // ============================================
 // CONSTANTS — Constantes
@@ -207,9 +208,9 @@ export class EmailQueueService {
     try {
       await EmailCampaign.increment(field, { where: { id: campaignId } });
     } catch (error) {
-      console.error(
-        `[EmailQueueService] Error incrementing ${field} for campaign ${campaignId}:`,
-        error
+      logger.error(
+        { err: error, service: 'EmailQueueService', campaignId, field },
+        'Error incrementing campaign stat'
       );
     }
   }
@@ -235,9 +236,9 @@ export class EmailQueueService {
 
         await EmailCampaign.update({ deferredCount }, { where: { id: campaignId } });
       } catch (error) {
-        console.error(
-          `[EmailQueueService] Error updating deferred count for campaign ${campaignId}:`,
-          error
+        logger.error(
+          { err: error, service: 'EmailQueueService', campaignId },
+          'Error updating deferred count for campaign'
         );
       }
     }
@@ -283,9 +284,9 @@ export class EmailQueueService {
           }
         }
       } catch (error) {
-        console.error(
-          `[EmailQueueService] Error checking completion for campaign ${campaignId}:`,
-          error
+        logger.error(
+          { err: error, service: 'EmailQueueService', campaignId },
+          'Error checking completion for campaign'
         );
       }
     }
@@ -315,7 +316,7 @@ export class EmailQueueService {
         details,
       });
     } catch (error) {
-      console.error(`[EmailQueueService] Error logging event '${eventType}':`, error);
+      logger.error({ err: error, service: 'EmailQueueService', eventType }, 'Error logging event');
     }
   }
 }

--- a/backend/src/services/EmailService.ts
+++ b/backend/src/services/EmailService.ts
@@ -15,6 +15,7 @@
  */
 import nodemailer from 'nodemailer';
 import { config } from '../config/env';
+import { logger } from '../utils/logger';
 
 /**
  * EmailService - Brevo SMTP email delivery
@@ -54,7 +55,7 @@ export class EmailService {
       });
       return true;
     } catch (error) {
-      console.error('Email send failed (Brevo SMTP):', error);
+      logger.error({ service: 'EmailService', err: error }, 'Email send failed (Brevo SMTP)');
       return false;
     }
   }

--- a/backend/src/services/GiftCardService.ts
+++ b/backend/src/services/GiftCardService.ts
@@ -23,6 +23,7 @@ import crypto from 'crypto';
 import { sequelize } from '../config/database';
 import { GiftCard, QrMapping, GiftCardTransaction, User } from '../models';
 import { qrService } from './QRService';
+import { logger } from '../utils/logger';
 import {
   GIFT_CARD_STATUS,
   GIFT_CARD_TRANSACTION_TYPE,
@@ -85,7 +86,10 @@ export class GiftCardService {
         qrCodeData = await qrService.generateGiftCardQR(shortCode);
       } catch {
         // QR generation failure — continue with null (placeholder)
-        console.error('QR generation failed, continuing without QR code data');
+        logger.error(
+          { service: 'GiftCardService' },
+          'QR generation failed, continuing without QR code data'
+        );
       }
 
       // Create gift card

--- a/backend/src/services/NotificationService.ts
+++ b/backend/src/services/NotificationService.ts
@@ -13,6 +13,7 @@
 import cron from 'node-cron';
 import { User, Commission } from '../models';
 import { emailService } from './EmailService';
+import { logger } from '../utils/logger';
 
 /**
  * Weekly digest cron schedule - Every Sunday at 9:00 AM UTC
@@ -62,7 +63,7 @@ export class NotificationService {
    * Enviar resumen semanal a todos los usuarios con weeklyDigest habilitado
    */
   async sendWeeklyDigestEmails(): Promise<void> {
-    console.log('[NotificationService] Starting weekly digest job...');
+    logger.info({ service: 'NotificationService' }, 'Starting weekly digest job');
 
     try {
       // Get all users with weekly digest enabled
@@ -73,7 +74,10 @@ export class NotificationService {
         },
       });
 
-      console.log(`[NotificationService] Sending weekly digest to ${users.length} users`);
+      logger.info(
+        { service: 'NotificationService', userCount: users.length },
+        'Sending weekly digest to users'
+      );
 
       let sentCount = 0;
       let failedCount = 0;
@@ -98,19 +102,20 @@ export class NotificationService {
 
           sentCount++;
         } catch (error) {
-          console.error(
-            `[NotificationService] Failed to send weekly digest to ${user.email}:`,
-            error
+          logger.error(
+            { err: error, service: 'NotificationService', email: user.email },
+            'Failed to send weekly digest'
           );
           failedCount++;
         }
       }
 
-      console.log(
-        `[NotificationService] Weekly digest job completed. Sent: ${sentCount}, Failed: ${failedCount}`
+      logger.info(
+        { service: 'NotificationService', sentCount, failedCount },
+        'Weekly digest job completed'
       );
     } catch (error) {
-      console.error('[NotificationService] Weekly digest job failed:', error);
+      logger.error({ err: error, service: 'NotificationService' }, 'Weekly digest job failed');
     }
   }
 
@@ -120,17 +125,20 @@ export class NotificationService {
    */
   startWeeklyDigest(): void {
     if (this.weeklyDigestJob) {
-      console.log('[NotificationService] Weekly digest job already running');
+      logger.warn({ service: 'NotificationService' }, 'Weekly digest job already running');
       return;
     }
 
-    console.log(`[NotificationService] Starting weekly digest cron: ${WEEKLY_DIGEST_CRON}`);
+    logger.info(
+      { service: 'NotificationService', cron: WEEKLY_DIGEST_CRON },
+      'Starting weekly digest cron'
+    );
 
     this.weeklyDigestJob = cron.schedule(WEEKLY_DIGEST_CRON, async () => {
       await this.sendWeeklyDigestEmails();
     });
 
-    console.log('[NotificationService] Weekly digest job started');
+    logger.info({ service: 'NotificationService' }, 'Weekly digest job started');
   }
 
   /**
@@ -141,7 +149,7 @@ export class NotificationService {
     if (this.weeklyDigestJob) {
       this.weeklyDigestJob.stop();
       this.weeklyDigestJob = null;
-      console.log('[NotificationService] Weekly digest job stopped');
+      logger.info({ service: 'NotificationService' }, 'Weekly digest job stopped');
     }
   }
 }

--- a/backend/src/services/OrderService.ts
+++ b/backend/src/services/OrderService.ts
@@ -20,6 +20,7 @@ import { AchievementService } from './AchievementService';
 import { LeaderboardService } from './LeaderboardService';
 import { body } from 'express-validator';
 import type { ProductType, ShippingStatus } from '../types';
+import { logger } from '../utils/logger';
 
 const achievementService = new AchievementService();
 const leaderboardService = new LeaderboardService();
@@ -243,7 +244,10 @@ export class OrderService {
           }
         } catch (commissionError) {
           // Log and throw AppError so that transaction is rolled back and error is propagated
-          console.error('Commission calculation failed:', commissionError);
+          logger.error(
+            { service: 'OrderService', err: commissionError },
+            'Commission calculation failed'
+          );
           throw new AppError(
             500,
             'COMMISSION_ERROR',
@@ -258,7 +262,12 @@ export class OrderService {
       // Fire-and-forget achievement check after successful order creation
       achievementService
         .checkAndUnlock(userId, 'sale_completed')
-        .catch((err) => console.error('[Achievements]', err));
+        .catch((err) =>
+          logger.error(
+            { service: 'OrderService', err },
+            'Achievement check failed after order creation'
+          )
+        );
 
       // Reload order with associations
       return (await Order.findByPk(order.id, {
@@ -423,7 +432,12 @@ export class OrderService {
       // Fire-and-forget achievement check — never blocks main flow
       achievementService
         .checkAndUnlock(order.userId, 'sale_completed')
-        .catch((err) => console.error('[Achievements]', err));
+        .catch((err) =>
+          logger.error(
+            { service: 'OrderService', err },
+            'Achievement check failed after status update'
+          )
+        );
     }
 
     return order;

--- a/backend/src/services/PushService.ts
+++ b/backend/src/services/PushService.ts
@@ -22,6 +22,7 @@
 import webpush from 'web-push';
 import { PushSubscription } from '../models';
 import { getWebPush, validateVapid } from '../utils/vapid';
+import { logger } from '../utils/logger';
 
 export interface PushNotificationPayload {
   title: string;
@@ -65,7 +66,7 @@ export class PushService {
     });
 
     if (subscriptions.length === 0) {
-      console.log(`[PushService] No subscriptions found for user ${userId}`);
+      logger.info({ service: 'PushService', userId }, 'No subscriptions found for user');
       return 0;
     }
 
@@ -94,27 +95,35 @@ export class PushService {
       } catch (error) {
         // Handle specific web-push errors
         if (error instanceof webpush.WebPushError) {
-          console.error(
-            `[PushService] Failed to send to endpoint: ${subscription.endpoint.slice(0, 50)}...`
+          logger.error(
+            { service: 'PushService', endpoint: subscription.endpoint.slice(0, 50) },
+            'Failed to send to endpoint'
           );
 
           // 410 Gone - Subscription is no longer valid, delete it
           if (error.statusCode === 410) {
-            console.log(`[PushService] Subscription expired, deleting: ${subscription.id}`);
+            logger.info(
+              { service: 'PushService', subscriptionId: subscription.id },
+              'Subscription expired, deleting'
+            );
             await subscription.destroy();
           }
           // 401 or 403 - VAPID keys might be invalid
           else if (error.statusCode === 401 || error.statusCode === 403) {
-            console.error('[PushService] VAPID authentication failed, check keys');
+            logger.error({ service: 'PushService' }, 'VAPID authentication failed, check keys');
           }
         } else {
-          console.error('[PushService] Unknown error sending notification:', error);
+          logger.error(
+            { err: error, service: 'PushService' },
+            'Unknown error sending notification'
+          );
         }
       }
     }
 
-    console.log(
-      `[PushService] Sent ${successCount}/${subscriptions.length} notifications to user ${userId}`
+    logger.info(
+      { service: 'PushService', successCount, totalCount: subscriptions.length, userId },
+      'Sent notifications to user'
     );
     return successCount;
   }
@@ -144,13 +153,14 @@ export class PushService {
           totalFailed++;
         }
       } catch (error) {
-        console.error(`[PushService] Error broadcasting to user ${userId}:`, error);
+        logger.error({ err: error, service: 'PushService', userId }, 'Error broadcasting to user');
         totalFailed++;
       }
     }
 
-    console.log(
-      `[PushService] Broadcast completed: ${totalSuccessful} sent, ${totalFailed} failed`
+    logger.info(
+      { service: 'PushService', successful: totalSuccessful, failed: totalFailed },
+      'Broadcast completed'
     );
 
     return {
@@ -194,8 +204,14 @@ export class PushService {
     if (existing) {
       // Update existing subscription with new user
       if (existing.userId !== userId) {
-        console.log(
-          `[PushService] Updating subscription ownership: ${existing.id} (user: ${existing.userId} -> ${userId})`
+        logger.info(
+          {
+            service: 'PushService',
+            subscriptionId: existing.id,
+            previousUserId: existing.userId,
+            newUserId: userId,
+          },
+          'Updating subscription ownership'
         );
         await existing.update({ userId, browser });
       }
@@ -210,7 +226,10 @@ export class PushService {
       browser,
     });
 
-    console.log(`[PushService] New subscription created: ${newSubscription.id}`);
+    logger.info(
+      { service: 'PushService', subscriptionId: newSubscription.id },
+      'New subscription created'
+    );
     return newSubscription;
   }
 
@@ -227,12 +246,18 @@ export class PushService {
     });
 
     if (!subscription) {
-      console.log(`[PushService] Subscription not found: ${endpoint.slice(0, 50)}...`);
+      logger.info(
+        { service: 'PushService', endpoint: endpoint.slice(0, 50) },
+        'Subscription not found'
+      );
       return false;
     }
 
     await subscription.destroy();
-    console.log(`[PushService] Subscription removed: ${subscription.id}`);
+    logger.info(
+      { service: 'PushService', subscriptionId: subscription.id },
+      'Subscription removed'
+    );
     return true;
   }
 

--- a/backend/src/services/ReservationService.ts
+++ b/backend/src/services/ReservationService.ts
@@ -18,6 +18,7 @@ import { WhereOptions } from 'sequelize';
 import { Reservation, Property, TourPackage, TourAvailability, User } from '../models';
 import type { ReservationAttributes, ReservationCreationAttributes } from '../models/Reservation';
 import { CalendarService } from './CalendarService';
+import { logger } from '../utils/logger';
 
 // ============================================
 // TYPES
@@ -306,7 +307,7 @@ export class ReservationService {
       vendorId: reservation.vendorId ?? null,
     };
     calendarService.notifyReservationConfirmed(payload).catch((err: unknown) => {
-      console.error('[ReservationService] Calendar sync error:', err);
+      logger.error({ service: 'ReservationService', err }, 'Calendar sync error');
     });
 
     return reservation;

--- a/backend/src/services/SMSService.ts
+++ b/backend/src/services/SMSService.ts
@@ -5,6 +5,7 @@
  */
 import axios from 'axios';
 import { config } from '../config/env';
+import { logger } from '../utils/logger';
 
 /**
  * SMSService - Brevo SMS delivery
@@ -56,7 +57,10 @@ export class SMSService {
       // (storage logic would be in NotificationService or AuthController)
       return { success: true };
     } catch (error: any) {
-      console.error('SMS send failed (Brevo API):', error.response?.data || error.message);
+      logger.error(
+        { service: 'SMSService', err: error, responseData: error.response?.data },
+        'SMS send failed (Brevo API)'
+      );
       return {
         success: false,
         error: error.response?.data?.message || 'Unknown error sending SMS',

--- a/backend/src/services/SchedulerService.ts
+++ b/backend/src/services/SchedulerService.ts
@@ -32,6 +32,7 @@ import { EmailCampaign } from '../models';
 import { Op } from 'sequelize';
 import { EMAIL_CAMPAIGN_STATUS } from '../types';
 import { config } from '../config/env';
+import { logger } from '../utils/logger';
 
 /**
  * Abandoned cart detection cron: every 15 minutes
@@ -66,31 +67,43 @@ export class SchedulerService {
    */
   start(): void {
     if (this.isRunning) {
-      console.log('⚠️  Scheduler already running');
+      logger.warn({ service: 'SchedulerService' }, 'Scheduler already running');
       return;
     }
 
     // Daily payout job at midnight UTC
     this.job = cron.schedule(config.wallet.cronTime, async () => {
-      console.log('📋 Running daily payout job...');
+      logger.info({ service: 'SchedulerService' }, 'Running daily payout job');
       try {
         const processed = await walletService.processDailyPayouts();
-        console.log(`✅ Processed ${processed.length} withdrawal requests`);
+        logger.info(
+          { service: 'SchedulerService', count: processed.length },
+          'Processed withdrawal requests'
+        );
       } catch (error) {
-        console.error('❌ Error processing daily payouts:', error);
+        logger.error({ err: error, service: 'SchedulerService' }, 'Error processing daily payouts');
       }
     });
 
     // Abandoned cart detection job every 15 minutes
     this.abandonedCartJob = cron.schedule(ABANDONED_CART_CRON, async () => {
-      console.log('🛒 Running abandoned cart detection job...');
+      logger.info({ service: 'SchedulerService' }, 'Running abandoned cart detection job');
       try {
         const result = await this.runAbandonedCartJob();
-        console.log(
-          `✅ Abandoned cart job: ${result.processed} processed, ${result.emailsSent} emails sent, ${result.errors} errors`
+        logger.info(
+          {
+            service: 'SchedulerService',
+            processed: result.processed,
+            emailsSent: result.emailsSent,
+            errors: result.errors,
+          },
+          'Abandoned cart job completed'
         );
       } catch (error) {
-        console.error('❌ Error running abandoned cart job:', error);
+        logger.error(
+          { err: error, service: 'SchedulerService' },
+          'Error running abandoned cart job'
+        );
       }
     });
 
@@ -102,7 +115,10 @@ export class SchedulerService {
       try {
         await this.emailCampaignSchedulerJob();
       } catch (error) {
-        console.error('❌ Error running email campaign scheduler job:', error);
+        logger.error(
+          { err: error, service: 'SchedulerService' },
+          'Error running email campaign scheduler job'
+        );
       }
     });
 
@@ -111,16 +127,24 @@ export class SchedulerService {
       try {
         await this.emailQueueProcessorJob();
       } catch (error) {
-        console.error('❌ Error running email queue processor job:', error);
+        logger.error(
+          { err: error, service: 'SchedulerService' },
+          'Error running email queue processor job'
+        );
       }
     });
 
-    console.log('📋 Scheduler initialized');
-    console.log(`   Daily payout: ${config.wallet.cronTime}`);
-    console.log(`   Abandoned cart detection: ${ABANDONED_CART_CRON}`);
-    console.log(`   Email campaign scheduler: ${EMAIL_CAMPAIGN_CRON}`);
-    console.log(`   Email queue processor: ${EMAIL_QUEUE_CRON}`);
-    console.log(`   Weekly digest: Every Sunday at 9:00 AM UTC`);
+    logger.info(
+      {
+        service: 'SchedulerService',
+        dailyPayout: config.wallet.cronTime,
+        abandonedCart: ABANDONED_CART_CRON,
+        emailCampaign: EMAIL_CAMPAIGN_CRON,
+        emailQueue: EMAIL_QUEUE_CRON,
+        weeklyDigest: 'Every Sunday at 9:00 AM UTC',
+      },
+      'Scheduler initialized'
+    );
 
     this.isRunning = true;
   }
@@ -149,7 +173,7 @@ export class SchedulerService {
     // Stop weekly digest job
     notificationService.stopWeeklyDigest();
     this.isRunning = false;
-    console.log('🛑 Scheduler stopped');
+    logger.info({ service: 'SchedulerService' }, 'Scheduler stopped');
   }
 
   /**
@@ -159,13 +183,16 @@ export class SchedulerService {
    * @returns Number of processed withdrawals / Número de retiros procesados
    */
   async triggerPayout(): Promise<number> {
-    console.log('📋 Manually triggered daily payout processing...');
+    logger.info({ service: 'SchedulerService' }, 'Manually triggered daily payout processing');
     try {
       const processed = await walletService.processDailyPayouts();
-      console.log(`✅ Processed ${processed.length} withdrawal requests`);
+      logger.info(
+        { service: 'SchedulerService', count: processed.length },
+        'Processed withdrawal requests'
+      );
       return processed.length;
     } catch (error) {
-      console.error('❌ Error processing daily payouts:', error);
+      logger.error({ err: error, service: 'SchedulerService' }, 'Error processing daily payouts');
       throw error;
     }
   }
@@ -196,7 +223,10 @@ export class SchedulerService {
         return stats;
       }
 
-      console.log(`[AbandonedCartJob] Found ${abandonedCarts.length} abandoned carts`);
+      logger.info(
+        { service: 'AbandonedCartJob', count: abandonedCarts.length },
+        'Found abandoned carts'
+      );
 
       // 2. Process each cart individually (graceful degradation)
       for (const cart of abandonedCarts) {
@@ -213,18 +243,24 @@ export class SchedulerService {
             await cartRecoveryEmailService.sendRecoveryEmail(cart.id, token.tokenPlain);
             stats.emailsSent++;
           } catch (emailError) {
-            console.error(`[AbandonedCartJob] Email failed for cart ${cart.id}:`, emailError);
+            logger.error(
+              { err: emailError, service: 'AbandonedCartJob', cartId: cart.id },
+              'Email failed for cart'
+            );
             stats.errors++;
             // Cart already marked abandoned — email can be retried manually or on next cycle
             // if the cart is re-activated by user and abandoned again
           }
         } catch (cartError) {
-          console.error(`[AbandonedCartJob] Error processing cart ${cart.id}:`, cartError);
+          logger.error(
+            { err: cartError, service: 'AbandonedCartJob', cartId: cart.id },
+            'Error processing cart'
+          );
           stats.errors++;
         }
       }
     } catch (error) {
-      console.error('[AbandonedCartJob] Fatal error:', error);
+      logger.error({ err: error, service: 'AbandonedCartJob' }, 'Fatal error');
       throw error;
     }
 
@@ -242,7 +278,7 @@ export class SchedulerService {
     emailsSent: number;
     errors: number;
   }> {
-    console.log('🛒 Manually triggered abandoned cart detection...');
+    logger.info({ service: 'SchedulerService' }, 'Manually triggered abandoned cart detection');
     return this.runAbandonedCartJob();
   }
 
@@ -281,8 +317,9 @@ export class SchedulerService {
       return 0;
     }
 
-    console.log(
-      `[EmailCampaignScheduler] Found ${scheduledCampaigns.length} scheduled campaigns to send`
+    logger.info(
+      { service: 'EmailCampaignScheduler', count: scheduledCampaigns.length },
+      'Found scheduled campaigns to send'
     );
 
     let triggered = 0;
@@ -290,11 +327,19 @@ export class SchedulerService {
       try {
         await emailCampaignService.sendCampaign(campaign.id);
         triggered++;
-        console.log(
-          `[EmailCampaignScheduler] Triggered campaign ${campaign.id} (${campaign.name})`
+        logger.info(
+          {
+            service: 'EmailCampaignScheduler',
+            campaignId: campaign.id,
+            campaignName: campaign.name,
+          },
+          'Triggered campaign'
         );
       } catch (error) {
-        console.error(`[EmailCampaignScheduler] Error triggering campaign ${campaign.id}:`, error);
+        logger.error(
+          { err: error, service: 'EmailCampaignScheduler', campaignId: campaign.id },
+          'Error triggering campaign'
+        );
         // Graceful degradation: continue with next campaign
       }
     }

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -12,6 +12,7 @@ import { TreeService } from './TreeService';
 import { AppError } from '../middleware/error.middleware';
 import { leaderboardService } from './LeaderboardService';
 import { achievementService } from './AchievementService';
+import { logger } from '../utils/logger';
 
 const treeService = new TreeService();
 
@@ -104,7 +105,9 @@ export class UserService {
     if (sponsorId) {
       achievementService
         .checkAndUnlock(sponsorId, 'referral_added')
-        .catch((err: unknown) => console.error('[Achievements]', err));
+        .catch((err: unknown) =>
+          logger.error({ service: 'UserService', err }, 'Achievement check failed for sponsor')
+        );
     }
 
     return user;

--- a/backend/src/services/WalletService.ts
+++ b/backend/src/services/WalletService.ts
@@ -23,6 +23,7 @@ import { Wallet, WalletTransaction, WithdrawalRequest } from '../models';
 import { config } from '../config/env';
 import { WALLET_TRANSACTION_TYPE, WITHDRAWAL_STATUS } from '../types';
 import { Op } from 'sequelize';
+import { logger } from '../utils/logger';
 
 // Simple exchange rates to USD (in production, use an external API)
 const EXCHANGE_RATES: Record<string, number> = {
@@ -365,7 +366,10 @@ export class WalletService {
         await withdrawal.save();
         processed.push(withdrawal);
       } catch (error) {
-        console.error(`Error processing withdrawal ${withdrawal.id}:`, error);
+        logger.error(
+          { service: 'WalletService', err: error, withdrawalId: withdrawal.id },
+          'Error processing withdrawal'
+        );
         withdrawal.status = WITHDRAWAL_STATUS.FAILED;
         await withdrawal.save();
       }

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,0 +1,30 @@
+import pino from 'pino';
+
+const isProduction = process.env.NODE_ENV === 'production';
+const isTest = process.env.NODE_ENV === 'test';
+
+/**
+ * Centralized Pino logger singleton for the entire backend.
+ * Logger centralizado Pino (singleton) para todo el backend.
+ *
+ * - Production: JSON structured logs (Grafana / Loki / CloudWatch ready)
+ * - Development: pino-pretty colorized output
+ * - Test: silent (level 'silent') to avoid noise in test output
+ *
+ * @example
+ * ```ts
+ * import { logger } from '../utils/logger';
+ *
+ * logger.info({ userId: 123 }, 'User logged in');
+ * logger.error({ err }, 'Payment failed');
+ * logger.warn('Deprecated endpoint called');
+ * logger.debug({ payload }, 'Processing webhook');
+ * ```
+ */
+const logger = pino({
+  level: isTest ? 'silent' : isProduction ? 'info' : 'debug',
+  ...(isProduction || isTest ? {} : { transport: { target: 'pino-pretty' } }),
+});
+
+export { logger };
+export default logger;


### PR DESCRIPTION
## Summary

Replaces all `console.*` calls in backend production code with a centralized **Pino logger** singleton, enabling structured JSON logging in production and colorized output in development.

Closes #128

## Changes

### New file
- **`src/utils/logger.ts`** — Centralized Pino logger singleton
  - Production: JSON structured logs (Grafana/Loki/CloudWatch ready)
  - Development: `pino-pretty` colorized output
  - Test: `silent` level (zero noise in test output)

### Migration scope (~290 `console.*` calls across 40+ files)

| Domain | Files | Calls replaced |
|--------|-------|---------------|
| Services | 18 files | ~85 calls |
| Controllers | 16 files | ~90 calls |
| Middleware | 5 files | ~20 calls |
| Config | 2 files | ~8 calls |
| Server + routes + models | 3 files | ~21 calls |
| **Test files (mock updates)** | 4 files | Spies updated |

### Key patterns applied
- **Error objects** always in Pino's first arg: `logger.error({ err }, 'message')` — proper stack trace serialization
- **Template literal variables** extracted into structured context: `logger.info({ userId, amount }, 'Payment processed')`
- **Bracketed prefixes** (`[DEBUG]`, `[BotLeads]`, etc.) replaced with structured `{ component }` or appropriate log level
- **Emoji prefixes** (✅❌⚠️) removed — `pino-pretty` handles formatting in dev
- `logger.fatal()` used for unrecoverable server errors (previously `console.error`)

### Excluded from migration (intentional)
- `seed.ts` / `seed-demo.ts` — CLI tools, `console.*` is appropriate
- `database/migrations/` — One-off migration scripts

## Testing
- ✅ **540/541 tests passing** (1 skipped — pre-existing)
- ✅ **Zero new TSC errors** (955 total = pre-existing ESM baseline)
- ✅ **Zero `console.*` calls** remaining in production code
- ✅ 4 test files updated to mock `logger` instead of `console` spies