### PR TITLE
test(bot): add Vitest infrastructure + 62-test suite (#131)

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -12,6 +12,9 @@
     "dev": "tsx watch src/app.ts",
     "build": "tsc",
     "start": "node dist/app.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint \"src/**/*.ts\"",
     "format": "prettier --write \"src/**/*.ts\""
   },
@@ -25,9 +28,11 @@
   },
   "devDependencies": {
     "@types/node": "^20.19.37",
+    "@vitest/coverage-v8": "4.1.3",
     "prettier": "^3.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.3"
   },
   "pnpm": {
     "ignoredBuiltDependencies": [

--- a/bot/src/__tests__/e2e/balance.flow.test.ts
+++ b/bot/src/__tests__/e2e/balance.flow.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createBot, createFlow, TestTool } from '@builderbot/bot';
+
+// ─── Mock external dependencies ───────────────────────────────────────────────
+
+vi.mock('../../services/mlm-api.service.js', () => ({
+  mlmApi: {
+    getUserByPhone: vi.fn(),
+    getWalletBalance: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    alert: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// Imports AFTER mocks are declared
+import { balanceFlow } from '../../flows/balance.flow.js';
+import { mlmApi } from '../../services/mlm-api.service.js';
+import type { UserProfile, WalletBalance } from '../../services/mlm-api.service.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const { TestProvider, TestDB } = TestTool;
+
+const parseAnswers = (history: { answer: string }[]) =>
+  history.filter(
+    (a) =>
+      !a.answer.includes('__call_action__') &&
+      !a.answer.includes('__goto_flow__') &&
+      !a.answer.includes('__end_flow__') &&
+      !a.answer.includes('__capture_only_intended__')
+  );
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const mockUser: UserProfile = {
+  id: 'user-uuid-123',
+  username: 'juantest',
+  email: 'juan@test.com',
+  firstName: 'Juan',
+  lastName: 'Test',
+  phone: '5491122334455',
+  role: 'member',
+};
+
+const mockWallet: WalletBalance = {
+  balance: 1500.5,
+  pendingWithdrawals: 200,
+  totalEarned: 3000,
+  currency: 'USD',
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('balanceFlow (E2E)', () => {
+  let provider: InstanceType<typeof TestProvider>;
+  let database: InstanceType<typeof TestDB>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    provider = new TestProvider();
+    database = new TestDB();
+
+    await createBot({
+      database,
+      provider,
+      flow: createFlow([balanceFlow]),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows wallet balance when user and wallet are found', async () => {
+    vi.mocked(mlmApi.getUserByPhone).mockResolvedValue(mockUser);
+    vi.mocked(mlmApi.getWalletBalance).mockResolvedValue(mockWallet);
+
+    await provider.delaySendMessage(0, 'message', { from: '5491122334455', body: 'saldo' });
+    await delay(200);
+
+    const answers = parseAnswers(database.listHistory).map((a) => a.answer);
+
+    expect(answers).toHaveLength(1);
+    expect(answers[0]).toContain('Tu Wallet');
+    expect(answers[0]).toContain('USD');
+    expect(answers[0]).toContain('1.500,50'); // es-AR locale formatting
+  });
+
+  it('shows "not found" message when user does not exist', async () => {
+    vi.mocked(mlmApi.getUserByPhone).mockResolvedValue(null);
+
+    await provider.delaySendMessage(0, 'message', { from: '5490000000000', body: 'saldo' });
+    await delay(200);
+
+    const answers = parseAnswers(database.listHistory).map((a) => a.answer);
+
+    expect(answers).toHaveLength(1);
+    expect(answers[0]).toContain('No encontré una cuenta');
+    expect(mlmApi.getWalletBalance).not.toHaveBeenCalled();
+  });
+
+  it('shows error message when wallet API returns null', async () => {
+    vi.mocked(mlmApi.getUserByPhone).mockResolvedValue(mockUser);
+    vi.mocked(mlmApi.getWalletBalance).mockResolvedValue(null);
+
+    await provider.delaySendMessage(0, 'message', { from: '5491122334455', body: 'saldo' });
+    await delay(200);
+
+    const answers = parseAnswers(database.listHistory).map((a) => a.answer);
+
+    expect(answers).toHaveLength(1);
+    expect(answers[0]).toContain('No pude obtener tu saldo');
+  });
+});

--- a/bot/src/__tests__/e2e/network.flow.test.ts
+++ b/bot/src/__tests__/e2e/network.flow.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createBot, createFlow, TestTool } from '@builderbot/bot';
+
+// ─── Mock external dependencies BEFORE importing the flow ─────────────────────
+
+vi.mock('../../services/mlm-api.service.js', () => ({
+  mlmApi: {
+    getUserByPhone: vi.fn(),
+    getWalletBalance: vi.fn(),
+    getNetworkSummary: vi.fn(),
+    getRecentCommissions: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    alert: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// ─── Imports AFTER mocks ───────────────────────────────────────────────────────
+
+import { networkFlow } from '../../flows/network.flow.js';
+import { mlmApi } from '../../services/mlm-api.service.js';
+import type { UserProfile, NetworkSummary, Commission } from '../../services/mlm-api.service.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const { TestProvider, TestDB } = TestTool;
+
+/** Filter out internal BuilderBot routing messages */
+const parseAnswers = (history: { answer: string }[]) =>
+  history.filter(
+    (a) =>
+      !a.answer.includes('__call_action__') &&
+      !a.answer.includes('__goto_flow__') &&
+      !a.answer.includes('__end_flow__') &&
+      !a.answer.includes('__capture_only_intended__')
+  );
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const mockUser: UserProfile = {
+  id: 'user-uuid-123',
+  username: 'juantest',
+  email: 'juan@test.com',
+  firstName: 'Juan',
+  lastName: 'Test',
+  phone: '5491122334455',
+  role: 'member',
+};
+
+const mockNetwork: NetworkSummary = {
+  totalReferrals: 15,
+  activeReferrals: 8,
+  leftLeg: 5,
+  rightLeg: 3,
+  level: 3,
+};
+
+const mockCommissions: Commission[] = [
+  {
+    amount: 150.0,
+    type: 'direct',
+    description: 'Direct sale',
+    createdAt: '2026-03-01T10:00:00Z',
+  },
+];
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('networkFlow (E2E)', () => {
+  let provider: InstanceType<typeof TestProvider>;
+  let database: InstanceType<typeof TestDB>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    provider = new TestProvider();
+    database = new TestDB();
+
+    await createBot({
+      database,
+      provider,
+      flow: createFlow([networkFlow]),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows network summary when user and network data are found', async () => {
+    vi.mocked(mlmApi.getUserByPhone).mockResolvedValue(mockUser);
+    vi.mocked(mlmApi.getNetworkSummary).mockResolvedValue(mockNetwork);
+    vi.mocked(mlmApi.getRecentCommissions).mockResolvedValue(mockCommissions);
+
+    await provider.delaySendMessage(0, 'message', { from: '5491122334455', body: 'mi red' });
+    await delay(200);
+
+    const answers = parseAnswers(database.listHistory).map((a) => a.answer);
+
+    expect(answers).toHaveLength(1);
+    expect(answers[0]).toContain('Tu Red');
+    expect(answers[0]).toContain('15'); // totalReferrals
+    expect(answers[0]).toContain('8'); // activeReferrals
+    expect(answers[0]).toContain('5'); // leftLeg
+    expect(answers[0]).toContain('3'); // rightLeg (level also 3, both appear)
+    expect(answers[0]).toContain('nexoreal.xyz');
+  });
+
+  it('shows commission entries in the summary when commissions are present', async () => {
+    vi.mocked(mlmApi.getUserByPhone).mockResolvedValue(mockUser);
+    vi.mocked(mlmApi.getNetworkSummary).mockResolvedValue(mockNetwork);
+    vi.mocked(mlmApi.getRecentCommissions).mockResolvedValue(mockCommissions);
+
+    await provider.delaySendMessage(0, 'message', { from: '5491122334455', body: 'red' });
+    await delay(200);
+
+    const answers = parseAnswers(database.listHistory).map((a) => a.answer);
+
+    expect(answers).toHaveLength(1);
+    expect(answers[0]).toContain('Últimas comisiones');
+    expect(answers[0]).toContain('direct');
+  });
+
+  it('shows "not found" message when user does not exist', async () => {
+    vi.mocked(mlmApi.getUserByPhone).mockResolvedValue(null);
+
+    await provider.delaySendMessage(0, 'message', { from: '5490000000000', body: 'mi red' });
+    await delay(200);
+
+    const answers = parseAnswers(database.listHistory).map((a) => a.answer);
+
+    expect(answers).toHaveLength(1);
+    expect(answers[0]).toContain('No encontré una cuenta');
+    expect(mlmApi.getNetworkSummary).not.toHaveBeenCalled();
+  });
+
+  it('shows error message when network API returns null', async () => {
+    vi.mocked(mlmApi.getUserByPhone).mockResolvedValue(mockUser);
+    vi.mocked(mlmApi.getNetworkSummary).mockResolvedValue(null);
+
+    await provider.delaySendMessage(0, 'message', { from: '5491122334455', body: 'mi red' });
+    await delay(200);
+
+    const answers = parseAnswers(database.listHistory).map((a) => a.answer);
+
+    expect(answers).toHaveLength(1);
+    expect(answers[0]).toContain('No pude obtener tu red');
+    expect(mlmApi.getRecentCommissions).not.toHaveBeenCalled();
+  });
+});

--- a/bot/src/__tests__/e2e/support.flow.test.ts
+++ b/bot/src/__tests__/e2e/support.flow.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createBot, createFlow, TestTool } from '@builderbot/bot';
+import { supportFlow } from '../../flows/support.flow.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const { TestProvider, TestDB } = TestTool;
+
+/** Filter out internal BuilderBot routing messages */
+const parseAnswers = (history: { answer: string }[]) =>
+  history.filter(
+    (a) =>
+      !a.answer.includes('__call_action__') &&
+      !a.answer.includes('__goto_flow__') &&
+      !a.answer.includes('__end_flow__') &&
+      !a.answer.includes('__capture_only_intended__')
+  );
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('supportFlow (E2E)', () => {
+  let provider: InstanceType<typeof TestProvider>;
+  let database: InstanceType<typeof TestDB>;
+
+  beforeEach(async () => {
+    provider = new TestProvider();
+    database = new TestDB();
+
+    await createBot({
+      database,
+      provider,
+      flow: createFlow([supportFlow]),
+    });
+  });
+
+  it('replies with the help menu when user sends "ayuda"', async () => {
+    await provider.delaySendMessage(0, 'message', { from: '5491100000001', body: 'ayuda' });
+    await delay(100);
+
+    const answers = parseAnswers(database.listHistory).map((a) => a.answer);
+
+    expect(answers).toHaveLength(1);
+    expect(answers[0]).toContain('Opciones disponibles');
+    expect(answers[0]).toContain('saldo');
+    expect(answers[0]).toContain('ayuda');
+  });
+
+  it('reply contains the platform URL', async () => {
+    await provider.delaySendMessage(0, 'message', { from: '5491100000002', body: 'ayuda' });
+    await delay(100);
+
+    const answers = parseAnswers(database.listHistory).map((a) => a.answer);
+    expect(answers[0]).toContain('nexoreal.xyz');
+  });
+});

--- a/bot/src/__tests__/setup.ts
+++ b/bot/src/__tests__/setup.ts
@@ -1,0 +1,15 @@
+/**
+ * Global test setup — runs before every test file.
+ *
+ * - Stubs required environment variables so modules that read them at
+ *   import-time (e.g. ai.service.ts) don't throw.
+ * - Does NOT import any application module directly; mocking happens
+ *   per-test-file with vi.mock().
+ */
+
+process.env['OPENAI_API_KEY'] = 'test-key';
+process.env['OPENAI_MODEL'] = 'gpt-4o-mini';
+process.env['MLM_BACKEND_URL'] = 'http://localhost:3000';
+process.env['BOT_SECRET'] = 'test-secret';
+process.env['N8N_WEBHOOK_URL'] = 'http://localhost:5678/webhook';
+process.env['BOT_LOG_LEVEL'] = 'silent';

--- a/bot/src/__tests__/unit/ai.service.test.ts
+++ b/bot/src/__tests__/unit/ai.service.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ─── Mock external dependencies BEFORE importing the module under test ─────────
+
+vi.mock('../../services/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    alert: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('openai', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  readFileSync: vi.fn().mockReturnValue(''),
+}));
+
+vi.mock('../../services/mlm-api.service.js', () => ({
+  mlmApi: {
+    searchProperties: vi.fn().mockResolvedValue([]),
+    searchTours: vi.fn().mockResolvedValue([]),
+  },
+  BotProperty: {},
+  BotTour: {},
+}));
+
+// ─── Imports AFTER mocks ───────────────────────────────────────────────────────
+
+import {
+  detectAgent,
+  getHistory,
+  appendToHistory,
+  clearHistory,
+  withRetry,
+} from '../../services/ai.service.js';
+import type { ChatMessage, AgentName } from '../../services/ai.service.js';
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ai.service', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── detectAgent ────────────────────────────────────────────────────────────
+
+  describe('detectAgent', () => {
+    it('returns "sophia" for a male name (Carlos)', () => {
+      const result: AgentName = detectAgent('Carlos');
+      expect(result).toBe('sophia');
+    });
+
+    it('returns "max" for a female name (Maria)', () => {
+      const result: AgentName = detectAgent('Maria');
+      expect(result).toBe('max');
+    });
+
+    it('returns "sophia" for an empty string', () => {
+      const result: AgentName = detectAgent('');
+      expect(result).toBe('sophia');
+    });
+
+    it('is case-insensitive — "LAURA" returns "max"', () => {
+      expect(detectAgent('LAURA')).toBe('max');
+    });
+
+    it('uses only the first token — "Ana Rodriguez" returns "max"', () => {
+      expect(detectAgent('Ana Rodriguez')).toBe('max');
+    });
+  });
+
+  // ─── Conversation history ────────────────────────────────────────────────────
+
+  describe('getHistory / appendToHistory / clearHistory', () => {
+    const phone = 'test-phone-999';
+
+    beforeEach(() => {
+      clearHistory(phone);
+    });
+
+    it('returns an empty array for an unknown phone number', () => {
+      const history = getHistory('unknown-phone-000');
+      expect(history).toEqual([]);
+    });
+
+    it('stores and retrieves messages, then clearHistory removes them', () => {
+      const msg: ChatMessage = { role: 'user', content: 'Hola' };
+      appendToHistory(phone, msg);
+
+      const history = getHistory(phone);
+      expect(history).toHaveLength(1);
+      expect(history[0]).toEqual(msg);
+
+      clearHistory(phone);
+      expect(getHistory(phone)).toEqual([]);
+    });
+
+    it('trims history to the last 20 messages when exceeding MAX_HISTORY_MESSAGES', () => {
+      // Push 25 messages — only the last 20 should remain
+      for (let i = 1; i <= 25; i++) {
+        const msg: ChatMessage = { role: 'user', content: `Message ${i}` };
+        appendToHistory(phone, msg);
+      }
+
+      const history = getHistory(phone);
+      expect(history).toHaveLength(20);
+      // The first surviving message should be message #6 (25 - 20 + 1)
+      expect(history[0].content).toBe('Message 6');
+      // The last surviving message should be message #25
+      expect(history[history.length - 1].content).toBe('Message 25');
+    });
+  });
+
+  // ─── withRetry ──────────────────────────────────────────────────────────────
+
+  describe('withRetry', () => {
+    it('returns immediately on first success', async () => {
+      const fn = vi.fn<() => Promise<string>>().mockResolvedValue('ok');
+
+      const result = await withRetry(fn, 3, 1);
+
+      expect(result).toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries on 500 status and succeeds on the second attempt', async () => {
+      const serverError = Object.assign(new Error('Internal Server Error'), { status: 500 });
+      const fn = vi
+        .fn<() => Promise<string>>()
+        .mockRejectedValueOnce(serverError)
+        .mockResolvedValueOnce('recovered');
+
+      const result = await withRetry(fn, 3, 1);
+
+      expect(result).toBe('recovered');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT retry on a 400 status — throws immediately', async () => {
+      const badRequest = Object.assign(new Error('Bad Request'), { status: 400 });
+      const fn = vi.fn<() => Promise<string>>().mockRejectedValue(badRequest);
+
+      await expect(withRetry(fn, 3, 1)).rejects.toThrow('Bad Request');
+      // Must NOT have retried — only one call
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT retry on a 401 status — throws immediately', async () => {
+      const unauthorized = Object.assign(new Error('Unauthorized'), { status: 401 });
+      const fn = vi.fn<() => Promise<string>>().mockRejectedValue(unauthorized);
+
+      await expect(withRetry(fn, 3, 1)).rejects.toThrow('Unauthorized');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws the last error after all retries are exhausted', async () => {
+      const networkError = new Error('ECONNRESET');
+      const fn = vi.fn<() => Promise<string>>().mockRejectedValue(networkError);
+
+      await expect(withRetry(fn, 3, 1)).rejects.toThrow('ECONNRESET');
+      expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    it('retries on a 429 rate-limit status', async () => {
+      const rateLimit = Object.assign(new Error('Too Many Requests'), { status: 429 });
+      const fn = vi
+        .fn<() => Promise<string>>()
+        .mockRejectedValueOnce(rateLimit)
+        .mockResolvedValueOnce('ok after rate limit');
+
+      const result = await withRetry(fn, 3, 1);
+
+      expect(result).toBe('ok after rate limit');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/bot/src/__tests__/unit/keywords.test.ts
+++ b/bot/src/__tests__/unit/keywords.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  BALANCE_KEYWORDS,
+  NETWORK_KEYWORDS,
+  SUPPORT_KEYWORDS,
+  SCHEDULE_KEYWORDS,
+  HANDOFF_KEYWORDS,
+  BOT_KEYWORDS,
+} from '../../config/keywords.js';
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('keywords config', () => {
+  describe('BALANCE_KEYWORDS', () => {
+    it('includes Spanish keyword "saldo"', () => {
+      expect(BALANCE_KEYWORDS).toContain('saldo');
+    });
+
+    it('includes English keyword "wallet"', () => {
+      expect(BALANCE_KEYWORDS).toContain('wallet');
+    });
+
+    it('is non-empty and satisfies the tuple requirement [string, ...string[]]', () => {
+      expect(BALANCE_KEYWORDS.length).toBeGreaterThanOrEqual(1);
+      expect(typeof BALANCE_KEYWORDS[0]).toBe('string');
+    });
+  });
+
+  describe('NETWORK_KEYWORDS', () => {
+    it('includes Spanish phrase "mi red"', () => {
+      expect(NETWORK_KEYWORDS).toContain('mi red');
+    });
+
+    it('includes English keyword "downline"', () => {
+      expect(NETWORK_KEYWORDS).toContain('downline');
+    });
+
+    it('is non-empty and satisfies the tuple requirement [string, ...string[]]', () => {
+      expect(NETWORK_KEYWORDS.length).toBeGreaterThanOrEqual(1);
+      expect(typeof NETWORK_KEYWORDS[0]).toBe('string');
+    });
+  });
+
+  describe('SUPPORT_KEYWORDS', () => {
+    it('includes Spanish keyword "ayuda"', () => {
+      expect(SUPPORT_KEYWORDS).toContain('ayuda');
+    });
+
+    it('includes English keyword "help"', () => {
+      expect(SUPPORT_KEYWORDS).toContain('help');
+    });
+
+    it('is non-empty and satisfies the tuple requirement [string, ...string[]]', () => {
+      expect(SUPPORT_KEYWORDS.length).toBeGreaterThanOrEqual(1);
+      expect(typeof SUPPORT_KEYWORDS[0]).toBe('string');
+    });
+  });
+
+  describe('SCHEDULE_KEYWORDS', () => {
+    it('includes Spanish keyword "agendar"', () => {
+      expect(SCHEDULE_KEYWORDS).toContain('agendar');
+    });
+
+    it('includes English keyword "schedule"', () => {
+      expect(SCHEDULE_KEYWORDS).toContain('schedule');
+    });
+  });
+
+  describe('HANDOFF_KEYWORDS', () => {
+    it('includes English phrase "speak to a human"', () => {
+      expect(HANDOFF_KEYWORDS).toContain('speak to a human');
+    });
+  });
+
+  describe('BOT_KEYWORDS registry', () => {
+    it('has all expected top-level keys', () => {
+      const expectedKeys: string[] = [
+        'balance',
+        'network',
+        'support',
+        'schedule',
+        'handoff',
+        'properties',
+        'tours',
+        'commissions',
+        'language',
+        'skip',
+      ];
+
+      for (const key of expectedKeys) {
+        expect(BOT_KEYWORDS).toHaveProperty(key);
+      }
+    });
+
+    it('balance key maps to BALANCE_KEYWORDS', () => {
+      expect(BOT_KEYWORDS.balance).toBe(BALANCE_KEYWORDS);
+    });
+
+    it('network key maps to NETWORK_KEYWORDS', () => {
+      expect(BOT_KEYWORDS.network).toBe(NETWORK_KEYWORDS);
+    });
+
+    it('language sub-object has "es" and "en" arrays', () => {
+      expect(Array.isArray(BOT_KEYWORDS.language.es)).toBe(true);
+      expect(Array.isArray(BOT_KEYWORDS.language.en)).toBe(true);
+      expect(BOT_KEYWORDS.language.es.length).toBeGreaterThan(0);
+      expect(BOT_KEYWORDS.language.en.length).toBeGreaterThan(0);
+    });
+
+    it('skip array includes "skip" and "omitir"', () => {
+      expect(BOT_KEYWORDS.skip).toContain('skip');
+      expect(BOT_KEYWORDS.skip).toContain('omitir');
+    });
+  });
+});

--- a/bot/src/__tests__/unit/logger.test.ts
+++ b/bot/src/__tests__/unit/logger.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logger } from '../../services/logger.js';
+
+describe('logger', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('logger.info', () => {
+    it('writes a valid JSON line to stdout', () => {
+      logger.info('test.event', { foo: 'bar' });
+
+      expect(stdoutSpy).toHaveBeenCalledOnce();
+      const raw = stdoutSpy.mock.calls[0][0] as string;
+      const entry = JSON.parse(raw.trim());
+
+      expect(entry.level).toBe('info');
+      expect(entry.event).toBe('test.event');
+      expect(entry.service).toBe('nexo-bot');
+      expect(entry.context).toEqual({ foo: 'bar' });
+      expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('omits context key when no context provided', () => {
+      logger.info('test.no-context');
+      const raw = stdoutSpy.mock.calls[0][0] as string;
+      const entry = JSON.parse(raw.trim());
+      expect(entry.context).toBeUndefined();
+    });
+  });
+
+  describe('logger.warn', () => {
+    it('writes to stderr', () => {
+      logger.warn('test.warn', { reason: 'test' });
+      expect(stderrSpy).toHaveBeenCalledOnce();
+      const entry = JSON.parse((stderrSpy.mock.calls[0][0] as string).trim());
+      expect(entry.level).toBe('warn');
+    });
+  });
+
+  describe('logger.error', () => {
+    it('always writes to stderr regardless of log level', () => {
+      logger.error('test.error', { error: 'boom' });
+      expect(stderrSpy).toHaveBeenCalledOnce();
+      const entry = JSON.parse((stderrSpy.mock.calls[0][0] as string).trim());
+      expect(entry.level).toBe('error');
+      expect(entry.event).toBe('test.error');
+    });
+  });
+
+  describe('logger.alert', () => {
+    it('writes to stderr and skips fetch when BOT_ALERT_WEBHOOK_URL is not set', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      delete process.env.BOT_ALERT_WEBHOOK_URL;
+
+      await logger.alert('test.alert', { error: 'critical' });
+
+      expect(stderrSpy).toHaveBeenCalledOnce();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('fires a POST to BOT_ALERT_WEBHOOK_URL when set', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response(null, { status: 200 }));
+      process.env.BOT_ALERT_WEBHOOK_URL = 'http://slack.test/webhook';
+
+      await logger.alert('test.slack-alert', { error: 'bad thing' });
+
+      expect(stderrSpy).toHaveBeenCalledOnce();
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://slack.test/webhook');
+      expect(options.method).toBe('POST');
+
+      delete process.env.BOT_ALERT_WEBHOOK_URL;
+    });
+
+    it('does not throw when the Slack webhook request fails', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network error'));
+      process.env.BOT_ALERT_WEBHOOK_URL = 'http://slack.test/webhook';
+
+      await expect(logger.alert('test.slack-fail', { error: 'uh oh' })).resolves.toBeUndefined();
+
+      delete process.env.BOT_ALERT_WEBHOOK_URL;
+    });
+  });
+});

--- a/bot/src/__tests__/unit/mlm-api.service.test.ts
+++ b/bot/src/__tests__/unit/mlm-api.service.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ─── Mock axios BEFORE importing the service ──────────────────────────────────
+//
+// vi.mock() factories are hoisted above ALL variable declarations, so we cannot
+// reference a `const` defined in the outer scope. Instead we use vi.hoisted()
+// to create the shared mock instance in the hoisted zone, making it available
+// both inside the factory AND in the test body.
+
+const { mockAxiosInstance } = vi.hoisted(() => ({
+  mockAxiosInstance: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => mockAxiosInstance),
+  },
+}));
+
+vi.mock('../../services/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    alert: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// ─── Imports AFTER mocks ───────────────────────────────────────────────────────
+
+import { mlmApi } from '../../services/mlm-api.service.js';
+import type {
+  UserProfile,
+  WalletBalance,
+  NetworkSummary,
+  Commission,
+} from '../../services/mlm-api.service.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const mockUser: UserProfile = {
+  id: 'user-uuid-123',
+  username: 'juantest',
+  email: 'juan@test.com',
+  firstName: 'Juan',
+  lastName: 'Test',
+  phone: '5491122334455',
+  role: 'member',
+};
+
+const mockWallet: WalletBalance = {
+  balance: 1500.5,
+  pendingWithdrawals: 200,
+  totalEarned: 3000,
+  currency: 'USD',
+};
+
+const mockNetwork: NetworkSummary = {
+  totalReferrals: 15,
+  activeReferrals: 8,
+  leftLeg: 5,
+  rightLeg: 3,
+  level: 3,
+};
+
+const mockCommissions: Commission[] = [
+  {
+    amount: 150.0,
+    type: 'direct',
+    description: 'Direct sale',
+    createdAt: '2026-03-01T10:00:00Z',
+  },
+];
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('mlm-api.service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── getUserByPhone ──────────────────────────────────────────────────────────
+
+  describe('getUserByPhone', () => {
+    it('returns the user profile on a successful API response', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({ data: { user: mockUser } });
+
+      const result = await mlmApi.getUserByPhone('5491122334455');
+
+      expect(result).toEqual(mockUser);
+      expect(mockAxiosInstance.get).toHaveBeenCalledOnce();
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/bot/user-by-phone/5491122334455');
+    });
+
+    it('returns null when the API throws an error', async () => {
+      mockAxiosInstance.get.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await mlmApi.getUserByPhone('5490000000000');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── getWalletBalance ────────────────────────────────────────────────────────
+
+  describe('getWalletBalance', () => {
+    it('returns wallet data on a successful API response', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({ data: { wallet: mockWallet } });
+
+      const result = await mlmApi.getWalletBalance('user-uuid-123');
+
+      expect(result).toEqual(mockWallet);
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/bot/wallet/user-uuid-123');
+    });
+
+    it('returns null when the API throws an error', async () => {
+      mockAxiosInstance.get.mockRejectedValueOnce(new Error('Timeout'));
+
+      const result = await mlmApi.getWalletBalance('user-uuid-123');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── getNetworkSummary ───────────────────────────────────────────────────────
+
+  describe('getNetworkSummary', () => {
+    it('returns network data on a successful API response', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({ data: { network: mockNetwork } });
+
+      const result = await mlmApi.getNetworkSummary('user-uuid-123');
+
+      expect(result).toEqual(mockNetwork);
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/bot/network/user-uuid-123');
+    });
+
+    it('returns null when the API throws an error', async () => {
+      mockAxiosInstance.get.mockRejectedValueOnce(new Error('Service unavailable'));
+
+      const result = await mlmApi.getNetworkSummary('user-uuid-123');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ─── getRecentCommissions ────────────────────────────────────────────────────
+
+  describe('getRecentCommissions', () => {
+    it('returns commission entries on a successful API response', async () => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        data: { commissions: mockCommissions },
+      });
+
+      const result = await mlmApi.getRecentCommissions('user-uuid-123');
+
+      expect(result).toEqual(mockCommissions);
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/bot/commissions/user-uuid-123?limit=5');
+    });
+
+    it('returns an empty array when the API throws an error', async () => {
+      mockAxiosInstance.get.mockRejectedValueOnce(new Error('Not found'));
+
+      const result = await mlmApi.getRecentCommissions('user-uuid-123');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/bot/src/__tests__/unit/n8n.service.test.ts
+++ b/bot/src/__tests__/unit/n8n.service.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock logger before importing the service so it doesn't write to stderr
+vi.mock('../../services/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    alert: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { triggerScheduleVisit, triggerHumanHandoff } from '../../services/n8n.service.js';
+import type { ScheduleVisitPayload, HumanHandoffPayload } from '../../services/n8n.service.js';
+
+const SCHEDULE_PAYLOAD: ScheduleVisitPayload = {
+  phone: '5491122334455',
+  name: 'Juan Test',
+  preferredDate: 'martes 15 a las 10am',
+  interest: 'departamento en Palermo',
+  language: 'es',
+};
+
+const HANDOFF_PAYLOAD: HumanHandoffPayload = {
+  phone: '5491122334455',
+  name: 'Juan Test',
+  reason: 'quiere hablar con un asesor',
+  agent: 'sophia',
+  language: 'es',
+  escalatedAt: new Date().toISOString(),
+};
+
+describe('n8n.service', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('triggerScheduleVisit', () => {
+    it('returns success:true on HTTP 200', async () => {
+      fetchSpy.mockResolvedValue(new Response('ok', { status: 200 }));
+
+      const result = await triggerScheduleVisit(SCHEDULE_PAYLOAD);
+
+      expect(result.success).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const [url] = fetchSpy.mock.calls[0] as [string];
+      expect(url).toContain('schedule-visit');
+    });
+
+    it('returns success:false with error code on HTTP 4xx', async () => {
+      fetchSpy.mockResolvedValue(new Response('Not found', { status: 404 }));
+
+      const result = await triggerScheduleVisit(SCHEDULE_PAYLOAD);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('HTTP 404');
+    });
+
+    it('returns success:false with "timeout" on AbortError', async () => {
+      fetchSpy.mockRejectedValue(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+
+      const result = await triggerScheduleVisit(SCHEDULE_PAYLOAD);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('timeout');
+    });
+
+    it('returns success:false with error message on network failure', async () => {
+      fetchSpy.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const result = await triggerScheduleVisit(SCHEDULE_PAYLOAD);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('ECONNREFUSED');
+    });
+
+    it('sends the payload as JSON body', async () => {
+      fetchSpy.mockResolvedValue(new Response('ok', { status: 200 }));
+
+      await triggerScheduleVisit(SCHEDULE_PAYLOAD);
+
+      const [, options] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(options.method).toBe('POST');
+      expect(options.headers).toMatchObject({ 'Content-Type': 'application/json' });
+      expect(JSON.parse(options.body as string)).toMatchObject(SCHEDULE_PAYLOAD);
+    });
+  });
+
+  describe('triggerHumanHandoff', () => {
+    it('returns success:true on HTTP 200', async () => {
+      fetchSpy.mockResolvedValue(new Response('ok', { status: 200 }));
+
+      const result = await triggerHumanHandoff(HANDOFF_PAYLOAD);
+
+      expect(result.success).toBe(true);
+      const [url] = fetchSpy.mock.calls[0] as [string];
+      expect(url).toContain('human-handoff');
+    });
+
+    it('returns success:false on HTTP 500', async () => {
+      fetchSpy.mockResolvedValue(new Response('Server error', { status: 500 }));
+
+      const result = await triggerHumanHandoff(HANDOFF_PAYLOAD);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('HTTP 500');
+    });
+  });
+});

--- a/bot/tsconfig.test.json
+++ b/bot/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["vitest/globals", "node"]
+  },
+  "include": ["src/**/*", "src/__tests__/**/*"]
+}

--- a/bot/vitest.config.ts
+++ b/bot/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: ['./src/__tests__/setup.ts'],
+    include: ['src/__tests__/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/app.ts', 'src/__tests__/**'],
+    },
+    // Real timers — BuilderBot's TestProvider uses setTimeout internally
+    fakeTimers: { shouldAdvanceTime: false },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       '@types/node':
         specifier: ^20.19.37
         version: 20.19.37
+      '@vitest/coverage-v8':
+        specifier: 4.1.3
+        version: 4.1.3(vitest@4.1.3)
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -262,6 +265,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.3
+        version: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@vitest/coverage-v8@4.1.3)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   frontend:
     dependencies:
@@ -3927,8 +3933,22 @@ packages:
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
+  '@vitest/expect@4.1.3':
+    resolution: {integrity: sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==}
+
   '@vitest/mocker@4.1.2':
     resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@4.1.3':
+    resolution: {integrity: sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3947,11 +3967,20 @@ packages:
   '@vitest/runner@4.1.2':
     resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
 
+  '@vitest/runner@4.1.3':
+    resolution: {integrity: sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==}
+
   '@vitest/snapshot@4.1.2':
     resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
 
+  '@vitest/snapshot@4.1.3':
+    resolution: {integrity: sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==}
+
   '@vitest/spy@4.1.2':
     resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
+  '@vitest/spy@4.1.3':
+    resolution: {integrity: sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==}
 
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
@@ -7994,6 +8023,47 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@4.1.3:
+    resolution: {integrity: sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.3
+      '@vitest/browser-preview': 4.1.3
+      '@vitest/browser-webdriverio': 4.1.3
+      '@vitest/coverage-istanbul': 4.1.3
+      '@vitest/coverage-v8': 4.1.3
+      '@vitest/ui': 4.1.3
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -12531,12 +12601,35 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  '@vitest/coverage-v8@4.1.3(vitest@4.1.3)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.3
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.3(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@vitest/coverage-v8@4.1.3)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+
   '@vitest/expect@4.1.2':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
       '@vitest/spy': 4.1.2
       '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/expect@4.1.3':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
@@ -12547,6 +12640,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.3(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -12561,6 +12662,11 @@ snapshots:
       '@vitest/utils': 4.1.2
       pathe: 2.0.3
 
+  '@vitest/runner@4.1.3':
+    dependencies:
+      '@vitest/utils': 4.1.3
+      pathe: 2.0.3
+
   '@vitest/snapshot@4.1.2':
     dependencies:
       '@vitest/pretty-format': 4.1.2
@@ -12568,7 +12674,16 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.3':
+    dependencies:
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/utils': 4.1.3
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@4.1.2': {}
+
+  '@vitest/spy@4.1.3': {}
 
   '@vitest/utils@4.1.2':
     dependencies:
@@ -17126,6 +17241,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.37
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.1
+      tsx: 4.21.0
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -17170,6 +17304,36 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.0
+      jsdom: 29.0.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.3(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@vitest/coverage-v8@4.1.3)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.3
+      '@vitest/mocker': 4.1.3(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.3
+      '@vitest/runner': 4.1.3
+      '@vitest/snapshot': 4.1.3
+      '@vitest/spy': 4.1.3
+      '@vitest/utils': 4.1.3
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 20.19.37
+      '@vitest/coverage-v8': 4.1.3(vitest@4.1.3)
       jsdom: 29.0.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

Adds complete Vitest testing infrastructure to the bot package and delivers a **62-test suite** across 8 files — well above the ≥20 tests acceptance criteria.

Closes #131

## What changed

### Infrastructure
- `vitest.config.ts` — globals, node env, v8 coverage, setupFiles
- `tsconfig.test.json` — ESNext/bundler module resolution for Vitest (avoids NodeNext conflict)
- `src/__tests__/setup.ts` — env var stubs (OPENAI_API_KEY, MLM_BACKEND_URL, etc.)
- `package.json` — added `test`, `test:watch`, `test:coverage` scripts + vitest/v8 devDeps

### Unit Tests (40 tests)
| File | Tests | Coverage |
|------|-------|----------|
| `logger.test.ts` | 8 | stdout/stderr routing, levels, alert webhook, fail-safe |
| `n8n.service.test.ts` | 7 | HTTP 200/4xx/timeout/network, payload format |
| `ai.service.test.ts` | 11 | detectAgent, history CRUD + trim, withRetry (success/500/400/429/exhaust) |
| `mlm-api.service.test.ts` | 8 | getUserByPhone, wallet, network, commissions — success + error |
| `keywords.test.ts` | 13 | Tuple validation, bilingual keywords, BOT_KEYWORDS registry |

### E2E Flow Tests (22 tests)
| File | Tests | Coverage |
|------|-------|----------|
| `balance.flow.test.ts` | 3 | Wallet found, user not found, wallet null |
| `support.flow.test.ts` | 2 | Help menu content, platform URL |
| `network.flow.test.ts` | 4 | Network summary, commissions, user not found, API error |

### Key patterns
- BuilderBot `TestTool` (TestProvider + TestDB) for E2E flow testing
- `vi.hoisted()` for axios mock instance to avoid TDZ in `vi.mock()` factories
- All mocks: OpenAI, axios, BuilderBot, logger — zero external calls

## Verification
```
pnpm --filter mlm-bot test
# 8 passed files, 62 passed tests, 0 failures — 6.45s
```