### PR TITLE
refactor(env): introduce PLATFORM_DOMAIN, remove hardcoded nexoreal.xyz (#129)

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -31,6 +31,24 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 /**
+ * Platform domain used across all config defaults (emails, URLs, VAPID).
+ * Set PLATFORM_DOMAIN env var in production to override.
+ *
+ * Dominio de la plataforma usado en todos los valores por defecto de config.
+ * Establecer la variable PLATFORM_DOMAIN en producción para sobreescribir.
+ */
+const platformDomain: string = process.env.PLATFORM_DOMAIN || 'nexoreal.xyz';
+
+/**
+ * Exported for use in seed scripts and modules that cannot import config
+ * due to circular dependencies or initialization order.
+ *
+ * Exportado para uso en scripts de seed y módulos que no pueden importar config
+ * por dependencias circulares u orden de inicialización.
+ */
+export { platformDomain };
+
+/**
  * Main configuration object / Objeto de configuración principal
  * @constant {Object}
  *
@@ -48,6 +66,16 @@ export const config = {
   nodeEnv: process.env.NODE_ENV || 'development',
   /** Server port / Puerto del servidor */
   port: parseInt(process.env.PORT || '3000', 10),
+
+  /**
+   * Platform identity / Identidad de la plataforma
+   * Single source of truth for the platform domain used in emails, URLs, and VAPID.
+   * Fuente única de verdad para el dominio de la plataforma usado en emails, URLs y VAPID.
+   */
+  platform: {
+    /** Platform domain (set via PLATFORM_DOMAIN env var) / Dominio de la plataforma */
+    domain: platformDomain,
+  },
 
   /** Database configuration / Configuración de base de datos */
   db: {
@@ -118,7 +146,7 @@ export const config = {
     /** Brevo API key for transactional emails / Clave API de Brevo para correos transaccionales */
     apiKey: process.env.BREVO_API_KEY || '',
     /** Sender email address / Correo del remitente */
-    senderEmail: process.env.BREVO_SENDER_EMAIL || 'noreply@nexoreal.xyz', // TODO: domain pending
+    senderEmail: process.env.BREVO_SENDER_EMAIL || `noreply@${platformDomain}`,
     /** Sender display name / Nombre del remitente */
     senderName: process.env.BREVO_SENDER_NAME || 'Nexo Real',
     /** SMS sender ID / ID del remitente SMS */
@@ -142,7 +170,7 @@ export const config = {
     /** VAPID private key / Clave privada VAPID */
     privateKey: process.env.VAPID_PRIVATE_KEY || '',
     /** VAPID subject (mailto or URL) / Asunto VAPID (mailto o URL) */
-    subject: process.env.VAPID_SUBJECT || 'mailto:admin@nexoreal.xyz', // TODO: domain pending
+    subject: process.env.VAPID_SUBJECT || `mailto:admin@${platformDomain}`,
   },
 
   /** PayPal configuration / Configuración de PayPal */
@@ -192,5 +220,15 @@ if (!config.jwt.secret) {
 if (!config.twoFactor.secretKey) {
   throw new Error(
     'FATAL: TWO_FACTOR_SECRET_KEY environment variable is required. Server cannot start without it.'
+  );
+}
+
+/**
+ * Warn if PLATFORM_DOMAIN is not explicitly set (uses default).
+ * Advertir si PLATFORM_DOMAIN no está configurado explícitamente (usa default).
+ */
+if (!process.env.PLATFORM_DOMAIN) {
+  console.warn(
+    `⚠️  PLATFORM_DOMAIN is not set — defaulting to '${config.platform.domain}'. Set it in production.`
   );
 }

--- a/backend/src/config/r2.ts
+++ b/backend/src/config/r2.ts
@@ -13,6 +13,7 @@
  * import { r2Client, R2_BUCKET } from './config/r2';
  */
 import { S3Client } from '@aws-sdk/client-s3';
+import { config } from './env';
 
 /**
  * S3-compatible client configured to use Cloudflare R2
@@ -35,4 +36,4 @@ export const R2_BUCKET = process.env.R2_BUCKET ?? 'nexoreal-media';
 /**
  * Public base URL for serving R2 assets / URL base pública para servir activos de R2
  */
-export const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL ?? 'https://media.nexoreal.xyz';
+export const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL ?? `https://media.${config.platform.domain}`;

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -1,4 +1,5 @@
 import swaggerJsdoc from 'swagger-jsdoc';
+import { config } from './env';
 
 /**
  * Swagger/OpenAPI Configuration for Nexo Real API
@@ -60,7 +61,7 @@ Esta API usa JWT Bearer tokens. Incluye el token en el header:
       `,
       contact: {
         name: 'Nexo Real Support',
-        email: 'support@nexoreal.xyz', // TODO: domain pending
+        email: `support@${config.platform.domain}`,
       },
     },
     servers: [

--- a/backend/src/config/vapid.ts
+++ b/backend/src/config/vapid.ts
@@ -27,6 +27,7 @@
  * const publicKey = vapidConfig.publicKey;
  */
 import webpush from 'web-push';
+import { config } from './env';
 
 /**
  * VAPID keys structure
@@ -49,14 +50,14 @@ export interface VapidKeys {
  * // Add to .env:
  * // VAPID_PUBLIC_KEY=<publicKey>
  * // VAPID_PRIVATE_KEY=<privateKey>
- * // VAPID_SUBJECT=mailto:admin@nexoreal.xyz
+ * // VAPID_SUBJECT=mailto:admin@<PLATFORM_DOMAIN>
  *
  * // Español: Generar claves y guardar en .env
  * const keys = generateKeys();
  * // Agregar a .env:
  * // VAPID_PUBLIC_KEY=<publicKey>
  * // VAPID_PRIVATE_KEY=<privateKey>
- * // VAPID_SUBJECT=mailto:admin@nexoreal.xyz
+ * // VAPID_SUBJECT=mailto:admin@<PLATFORM_DOMAIN>
  */
 export function generateKeys(): VapidKeys {
   const keys = webpush.generateVAPIDKeys();
@@ -87,7 +88,7 @@ export const vapidConfig = {
   /** Private key for server-side push / Clave privada para push del servidor */
   privateKey: process.env.VAPID_PRIVATE_KEY || '',
   /** Subject for VAPID (mailto or URL) / Asunto para VAPID (mailto o URL) */
-  subject: process.env.VAPID_SUBJECT || 'mailto:admin@nexoreal.xyz', // TODO: domain pending
+  subject: process.env.VAPID_SUBJECT || `mailto:admin@${config.platform.domain}`,
 };
 
 /**

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -114,7 +114,7 @@ export const register: RequestHandler = asyncHandler(
     const token = generateToken(user);
 
     // Send welcome email / Enviar email de bienvenida
-    const referralLink = `${config.app.frontendUrl || 'https://nexoreal.xyz'}/register?ref=${user.referralCode}`; // TODO: domain pending
+    const referralLink = `${config.app.frontendUrl || `https://${config.platform.domain}`}/register?ref=${user.referralCode}`;
     const firstName = user.email.split('@')[0];
 
     // Fire and forget - don't block registration response

--- a/backend/src/controllers/invoices/InvoicePdfController.ts
+++ b/backend/src/controllers/invoices/InvoicePdfController.ts
@@ -16,6 +16,7 @@ import { Response } from 'express';
 import type { AuthenticatedRequest } from '../../middleware/auth.middleware';
 import { asyncHandler } from '../../middleware/asyncHandler';
 import { invoiceStore, InvoiceStatus } from './store';
+import { config } from '../../config/env';
 
 /**
  * UUID validation regex
@@ -31,7 +32,7 @@ const COMPANY_INFO = {
   name: 'Nexo Real',
   address: '123 Business Street, City, Country',
   phone: '+1 (555) 123-4567',
-  email: 'billing@nexoreal.xyz', // TODO: domain pending
+  email: `billing@${config.platform.domain}`,
   taxId: 'TAX-12345678',
 };
 

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -27,6 +27,7 @@ import { connectDatabase, syncDatabase } from './config/database';
 import { initModels, User, UserClosure, CommissionConfig, Product } from './models';
 import { hashPassword } from './services/AuthService';
 import { seedDemoProperties, seedDemoTours, seedDemoTourAvailabilities } from './seed-demo';
+import { platformDomain } from './config/env';
 
 // ─── Tipos auxiliares ─────────────────────────────────────────────────────────
 
@@ -385,7 +386,7 @@ async function seedUsers(): Promise<void> {
   // Nivel 0 — raíz del sistema / System root
   const superAdmin = await createUser(
     SEED_IDS.SUPER_ADMIN,
-    'superadmin@nexoreal.xyz',
+    `superadmin@${platformDomain}`,
     'Nexo2024!',
     'NXR-SA-001',
     'super_admin',
@@ -397,7 +398,7 @@ async function seedUsers(): Promise<void> {
   // Nivel 1 — admin general / General admin
   const admin = await createUser(
     SEED_IDS.ADMIN,
-    'admin@nexoreal.xyz',
+    `admin@${platformDomain}`,
     'Nexo2024!',
     'NXR-AD-002',
     'admin',
@@ -409,7 +410,7 @@ async function seedUsers(): Promise<void> {
   // Nivel 2 — roles operativos bajo admin / Operational roles under admin
   const finance = await createUser(
     SEED_IDS.FINANCE,
-    'finanzas@nexoreal.xyz',
+    `finanzas@${platformDomain}`,
     'Nexo2024!',
     'NXR-FN-003',
     'finance',
@@ -420,7 +421,7 @@ async function seedUsers(): Promise<void> {
 
   const sales = await createUser(
     SEED_IDS.SALES,
-    'ventas@nexoreal.xyz',
+    `ventas@${platformDomain}`,
     'Nexo2024!',
     'NXR-SL-004',
     'sales',
@@ -431,7 +432,7 @@ async function seedUsers(): Promise<void> {
 
   const vendor1 = await createUser(
     SEED_IDS.VENDOR_1,
-    'camilo.restrepo@nexoreal.xyz',
+    `camilo.restrepo@${platformDomain}`,
     'Nexo2024!',
     'NXR-VD-007',
     'vendor',
@@ -443,7 +444,7 @@ async function seedUsers(): Promise<void> {
   // Nivel 3 — asesores comerciales bajo ventas / Sales advisors under sales
   const advisor1 = await createUser(
     SEED_IDS.ADVISOR_1,
-    'valentina.ospina@nexoreal.xyz',
+    `valentina.ospina@${platformDomain}`,
     'Nexo2024!',
     'NXR-AV-005',
     'advisor',
@@ -454,7 +455,7 @@ async function seedUsers(): Promise<void> {
 
   const advisor2 = await createUser(
     SEED_IDS.ADVISOR_2,
-    'santiago.gomez@nexoreal.xyz',
+    `santiago.gomez@${platformDomain}`,
     'Nexo2024!',
     'NXR-AV-006',
     'advisor',
@@ -465,7 +466,7 @@ async function seedUsers(): Promise<void> {
 
   const vendor2 = await createUser(
     SEED_IDS.VENDOR_2,
-    'isabella.vargas@nexoreal.xyz',
+    `isabella.vargas@${platformDomain}`,
     'Nexo2024!',
     'NXR-VD-008',
     'vendor',
@@ -477,7 +478,7 @@ async function seedUsers(): Promise<void> {
   // Nivel 4 — usuarios finales bajo asesores / End users under advisors
   await createUser(
     SEED_IDS.USER_1,
-    'andres.martinez@nexoreal.xyz',
+    `andres.martinez@${platformDomain}`,
     'usuario123',
     'NXR-US-009',
     'user',
@@ -488,7 +489,7 @@ async function seedUsers(): Promise<void> {
 
   await createUser(
     SEED_IDS.USER_2,
-    'luisa.fernandez@nexoreal.xyz',
+    `luisa.fernandez@${platformDomain}`,
     'usuario123',
     'NXR-US-010',
     'user',
@@ -499,7 +500,7 @@ async function seedUsers(): Promise<void> {
 
   await createUser(
     SEED_IDS.USER_3,
-    'miguel.torres@nexoreal.xyz',
+    `miguel.torres@${platformDomain}`,
     'usuario123',
     'NXR-US-011',
     'user',
@@ -511,7 +512,7 @@ async function seedUsers(): Promise<void> {
   // Guest — sin sponsor (invitado registrado via link) / Guest — no sponsor (registered via link)
   await createUser(
     SEED_IDS.GUEST,
-    'invitado@nexoreal.xyz',
+    `invitado@${platformDomain}`,
     'invitado123',
     'NXR-GT-012',
     'guest',
@@ -525,18 +526,18 @@ async function seedUsers(): Promise<void> {
 
   console.log('\n✅ Árbol Unilevel seeded');
   console.log('\n📋 Estructura del árbol / Tree Structure:');
-  console.log('   super_admin (superadmin@nexoreal.xyz)');
-  console.log('   └── admin (admin@nexoreal.xyz)');
-  console.log('       ├── finance (finanzas@nexoreal.xyz)');
-  console.log('       ├── sales (ventas@nexoreal.xyz)');
-  console.log('       │   ├── advisor_1 (valentina.ospina@nexoreal.xyz)');
-  console.log('       │   │   ├── user_1 (andres.martinez@nexoreal.xyz)');
-  console.log('       │   │   └── user_2 (luisa.fernandez@nexoreal.xyz)');
-  console.log('       │   └── advisor_2 (santiago.gomez@nexoreal.xyz)');
-  console.log('       │       └── user_3 (miguel.torres@nexoreal.xyz)');
-  console.log('       └── vendor_1 (camilo.restrepo@nexoreal.xyz)');
-  console.log('           └── vendor_2 (isabella.vargas@nexoreal.xyz)');
-  console.log('   + guest (invitado@nexoreal.xyz) — sin red');
+  console.log(`   super_admin (superadmin@${platformDomain})`);
+  console.log(`   └── admin (admin@${platformDomain})`);
+  console.log(`       ├── finance (finanzas@${platformDomain})`);
+  console.log(`       ├── sales (ventas@${platformDomain})`);
+  console.log(`       │   ├── advisor_1 (valentina.ospina@${platformDomain})`);
+  console.log(`       │   │   ├── user_1 (andres.martinez@${platformDomain})`);
+  console.log(`       │   │   └── user_2 (luisa.fernandez@${platformDomain})`);
+  console.log(`       │   └── advisor_2 (santiago.gomez@${platformDomain})`);
+  console.log(`       │       └── user_3 (miguel.torres@${platformDomain})`);
+  console.log(`       └── vendor_1 (camilo.restrepo@${platformDomain})`);
+  console.log(`           └── vendor_2 (isabella.vargas@${platformDomain})`);
+  console.log(`   + guest (invitado@${platformDomain}) — sin red`);
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
@@ -573,10 +574,10 @@ async function seed(): Promise<void> {
     console.log('╠═══════════════════════════════════════════════════════════╣');
     console.log('║  Credenciales de prueba / Test credentials:               ║');
     console.log('║                                                           ║');
-    console.log('║  superadmin@nexoreal.xyz  /  Nexo2024!  (super_admin)     ║');
-    console.log('║  admin@nexoreal.xyz       /  Nexo2024!  (admin)           ║');
-    console.log('║  finanzas@nexoreal.xyz    /  Nexo2024!  (finance)         ║');
-    console.log('║  ventas@nexoreal.xyz      /  Nexo2024!  (sales)           ║');
+    console.log(`║  superadmin@${platformDomain.padEnd(16)} /  Nexo2024!  (super_admin)     ║`);
+    console.log(`║  admin@${platformDomain.padEnd(21)} /  Nexo2024!  (admin)           ║`);
+    console.log(`║  finanzas@${platformDomain.padEnd(18)} /  Nexo2024!  (finance)         ║`);
+    console.log(`║  ventas@${platformDomain.padEnd(20)} /  Nexo2024!  (sales)           ║`);
     console.log('║  valentina.ospina@...     /  Nexo2024!  (advisor)         ║');
     console.log('║  santiago.gomez@...       /  Nexo2024!  (advisor)         ║');
     console.log('║  camilo.restrepo@...      /  Nexo2024!  (vendor)          ║');
@@ -584,7 +585,7 @@ async function seed(): Promise<void> {
     console.log('║  andres.martinez@...      /  usuario123 (user)            ║');
     console.log('║  luisa.fernandez@...      /  usuario123 (user)            ║');
     console.log('║  miguel.torres@...        /  usuario123 (user)            ║');
-    console.log('║  invitado@nexoreal.xyz    /  invitado123 (guest)          ║');
+    console.log(`║  invitado@${platformDomain.padEnd(18)} /  invitado123 (guest)          ║`);
     console.log('║                                                           ║');
     console.log('║  📊 Demo data:                                            ║');
     console.log('║  20 propiedades (CO + MX) • 12 tours • 36 disponibilidades║');

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,7 +3,7 @@ import './instrument';
 
 import app from './app';
 import { connectDatabase, syncDatabase } from './config/database';
-import { config } from './config/env';
+import { config, platformDomain } from './config/env';
 import { logger } from './utils/logger';
 import { initModels, User, Product, CommissionConfig, UserClosure } from './models';
 import { achievementService } from './services/AchievementService';
@@ -250,7 +250,7 @@ async function autoSeed(): Promise<void> {
 
     const superAdmin = await createUserWithClosure(
       '00000000-0000-0000-0000-000000000001',
-      'superadmin@nexoreal.xyz',
+      `superadmin@${platformDomain}`,
       'NXR-SA-001',
       'super_admin',
       null,
@@ -259,7 +259,7 @@ async function autoSeed(): Promise<void> {
 
     const admin = await createUserWithClosure(
       '00000000-0000-0000-0000-000000000002',
-      'admin@nexoreal.xyz',
+      `admin@${platformDomain}`,
       'NXR-AD-002',
       'admin',
       superAdmin.id,
@@ -268,7 +268,7 @@ async function autoSeed(): Promise<void> {
 
     const advisor = await createUserWithClosure(
       '00000000-0000-0000-0000-000000000003',
-      'valentina.ospina@nexoreal.xyz',
+      `valentina.ospina@${platformDomain}`,
       'NXR-AV-003',
       'advisor',
       admin.id,
@@ -277,7 +277,7 @@ async function autoSeed(): Promise<void> {
 
     await createUserWithClosure(
       '00000000-0000-0000-0000-000000000004',
-      'andres.martinez@nexoreal.xyz',
+      `andres.martinez@${platformDomain}`,
       'NXR-US-004',
       'user',
       advisor.id,
@@ -286,7 +286,7 @@ async function autoSeed(): Promise<void> {
 
     await createUserWithClosure(
       '00000000-0000-0000-0000-000000000005',
-      'invitado@nexoreal.xyz',
+      `invitado@${platformDomain}`,
       'NXR-GT-005',
       'guest',
       null,
@@ -294,11 +294,11 @@ async function autoSeed(): Promise<void> {
     );
 
     logger.info('Nexo Real — Test Credentials:');
-    logger.info('  superadmin@nexoreal.xyz  /  Nexo2024!  (super_admin)');
-    logger.info('  admin@nexoreal.xyz       /  Nexo2024!  (admin)');
+    logger.info(`  superadmin@${platformDomain}  /  Nexo2024!  (super_admin)`);
+    logger.info(`  admin@${platformDomain}       /  Nexo2024!  (admin)`);
     logger.info('  valentina.ospina@...     /  Nexo2024!  (advisor)');
     logger.info('  andres.martinez@...      /  Nexo2024!  (user)');
-    logger.info('  invitado@nexoreal.xyz    /  Nexo2024!  (guest)');
+    logger.info(`  invitado@${platformDomain}    /  Nexo2024!  (guest)`);
   } catch (error) {
     logger.error({ err: error }, 'Auto-seed failed');
   }

--- a/backend/src/services/R2Service.ts
+++ b/backend/src/services/R2Service.ts
@@ -84,7 +84,7 @@ export class R2Service {
    *   entityId: 'prop-uuid',
    *   filename: 'facade.jpg',
    * });
-   * // returns 'https://media.nexoreal.xyz/properties/prop-uuid/550e8400.webp'
+   * // returns 'https://media.<PLATFORM_DOMAIN>/properties/prop-uuid/550e8400.webp'
    */
   async uploadImage(params: UploadImageParams): Promise<string> {
     const { buffer, entityType, entityId } = params;
@@ -123,7 +123,7 @@ export class R2Service {
    * @returns Promise that resolves when deletion is complete / Promesa que resuelve cuando la eliminación completa
    *
    * @example
-   * await r2Service.deleteImage('https://media.nexoreal.xyz/properties/uuid/550e8400.webp');
+   * await r2Service.deleteImage('https://media.<PLATFORM_DOMAIN>/properties/uuid/550e8400.webp');
    */
   async deleteImage(imageUrl: string): Promise<void> {
     // Extract key by removing the base URL prefix
@@ -154,7 +154,7 @@ export class R2Service {
    *   entityType: 'properties',
    *   entityId: 'prop-uuid',
    * });
-   * // returns ['https://media.nexoreal.xyz/properties/uuid/a.webp', ...]
+   * // returns ['https://media.<PLATFORM_DOMAIN>/properties/uuid/a.webp', ...]
    */
   async uploadImages(params: UploadImagesParams): Promise<string[]> {
     const { files, entityType, entityId } = params;


### PR DESCRIPTION
## Summary

Introduces a `PLATFORM_DOMAIN` environment variable to eliminate all hardcoded `nexoreal.xyz` references from backend production code. Defaults to `nexoreal.xyz` for backward compatibility.

Closes #129

## Changes

| File | What changed |
|------|-------------|
| `config/env.ts` | Added `platformDomain` const + `platform.domain` in config + startup warning if env var not set |
| `config/vapid.ts` | Import config, use `config.platform.domain` in VAPID subject fallback |
| `config/swagger.ts` | Import config, use `config.platform.domain` for contact email |
| `config/r2.ts` | Use `platformDomain` for R2_PUBLIC_URL fallback |
| `AuthController.ts` | Use `config.platform.domain` for referral link fallback |
| `InvoicePdfController.ts` | Import config, use `config.platform.domain` for billing email |
| `seed.ts` | All seed emails use template literals with `platformDomain` |
| `server.ts` | Seed user creation + log output use `platformDomain` |
| `R2Service.ts` | Updated JSDoc examples to reference PLATFORM_DOMAIN |

## Verification

- `grep -rn "nexoreal.xyz" backend/src/ --include="*.ts" | grep -v __tests__` → only 1 result: the default value in `env.ts:40` ✅
- Backend tests: **540 passed, 0 failed** ✅
- Backward compatible: defaults to `nexoreal.xyz` when env var not set ✅

## Testing

```bash
cd backend && pnpm test   # 540 passed, 1 skipped
```