### PR TITLE
fix(backend): complete payment webhooks with persistent idempotency (#151)

### DIFF
--- a/backend/src/__tests__/MercadoPagoWebhook.test.ts
+++ b/backend/src/__tests__/MercadoPagoWebhook.test.ts
@@ -85,6 +85,17 @@ jest.mock('../models/index.js', () => ({
   },
 }));
 
+// ─── Mock WebhookEvent model (persistent idempotency) ────────────────────────
+const mockWebhookEventFindOne = jest.fn();
+const mockWebhookEventCreate = jest.fn();
+
+jest.mock('../models/WebhookEvent.js', () => ({
+  WebhookEvent: {
+    findOne: (...args: unknown[]) => mockWebhookEventFindOne(...args),
+    create: (...args: unknown[]) => mockWebhookEventCreate(...args),
+  },
+}));
+
 // ─── Mock CommissionService ───────────────────────────────────────────────────
 const mockCalculateCommissions = jest.fn().mockResolvedValue([]);
 
@@ -279,8 +290,18 @@ describe('MercadoPago — webhook handler', () => {
     // Default: signature verification passes
     mockVerifyWebhookSignature.mockReturnValue(true);
 
-    // Default: no existing order (idempotency not triggered)
+    // Default: no existing order (secondary reference check)
     (Order.findOne as jest.Mock).mockResolvedValue(null);
+
+    // Default: no existing WebhookEvent (idempotency not triggered)
+    mockWebhookEventFindOne.mockResolvedValue(null);
+
+    // Default: WebhookEvent.create succeeds
+    mockWebhookEventCreate.mockResolvedValue({
+      id: 'we-uuid',
+      eventId: PAYMENT_ID,
+      provider: 'mercadopago',
+    });
 
     // Default: product exists
     (Product.findOne as jest.Mock).mockResolvedValue(mockProduct);
@@ -356,19 +377,22 @@ describe('MercadoPago — webhook handler', () => {
   });
 
   /**
-   * Test 5: idempotency — if Order.findOne returns an existing order → skips creation
+   * Test 5: idempotency — if WebhookEvent.findOne returns an existing record → skips creation
    */
-  it('should skip Purchase/Order creation if order already exists (idempotency)', async () => {
+  it('should skip Purchase/Order creation if WebhookEvent already exists (idempotency)', async () => {
     mockGetPayment.mockResolvedValue(mockApprovedPayment);
-    (Order.findOne as jest.Mock).mockResolvedValue({
-      id: 'existing-order',
-      notes: `mercadopago:${PAYMENT_ID}`,
+    mockWebhookEventFindOne.mockResolvedValue({
+      id: 'we-existing',
+      eventId: String(PAYMENT_ID),
+      provider: 'mercadopago',
     });
 
     const { req, res } = buildReqRes({
       query: { topic: 'payment' },
       body: { id: PAYMENT_ID, topic: 'payment' },
-      headers: { 'x-signature': 'ts=123456,v1=abc' },
+      headers: {
+        'x-signature': `ts=123456,v1=abc`,
+      },
     });
 
     await (PaymentMercadoPagoController.webhook as (...args: unknown[]) => Promise<void>)(req, res);

--- a/backend/src/__tests__/PayPalService.test.ts
+++ b/backend/src/__tests__/PayPalService.test.ts
@@ -1,9 +1,9 @@
 /**
  * @fileoverview Unit tests for PayPalService
- * @description Tests covering previously uncovered methods:
+ * @description Tests covering:
  *              - verifyWebhookSignature(): SUCCESS, FAILURE, dev-mode bypass (no webhookId)
- *              - isIdempotent(): found (true), not found (false)
- *              - markAsProcessed(): adds event to processed set
+ *              - isEventProcessed(): found (true), not found (false) via WebhookEvent table
+ *              - markEventProcessed(): inserts into WebhookEvent table, propagates errors
  *              - createOrder(): order creation flow
  *              - captureOrder(): capture flow, SSRF validation
  * @module __tests__/PayPalService
@@ -50,6 +50,17 @@ jest.mock('../config/database', () => ({
     authenticate: jest.fn().mockResolvedValue(undefined),
   },
   resetSequelize: jest.fn(),
+}));
+
+// ── Mock WebhookEvent model (used by isEventProcessed / markEventProcessed) ──
+const mockWebhookEventFindOne = jest.fn();
+const mockWebhookEventCreate = jest.fn();
+
+jest.mock('../models/WebhookEvent', () => ({
+  WebhookEvent: {
+    findOne: (...args: unknown[]) => mockWebhookEventFindOne(...args),
+    create: (...args: unknown[]) => mockWebhookEventCreate(...args),
+  },
 }));
 
 // ── Import after mocks ────────────────────────────────────────────────────────
@@ -187,66 +198,84 @@ describe('PayPalService', () => {
     });
   });
 
-  // ── isIdempotent ───────────────────────────────────────────────────────────
+  // ── isEventProcessed (persistent via WebhookEvent table) ────────────────────
 
-  describe('isIdempotent()', () => {
-    it('should return false for an event that has not been processed', () => {
+  describe('isEventProcessed()', () => {
+    it('should return false when WebhookEvent.findOne returns null (not processed)', async () => {
+      // Arrange
+      mockWebhookEventFindOne.mockResolvedValue(null);
+
       // Act
-      const result = paypalService.isIdempotent('event-never-seen-xyz');
+      const result = await paypalService.isEventProcessed('event-never-seen', 'paypal');
 
       // Assert
       expect(result).toBe(false);
+      expect(mockWebhookEventFindOne).toHaveBeenCalledWith({
+        where: { eventId: 'event-never-seen', provider: 'paypal' },
+      });
     });
 
-    it('should return true for an event that has been processed', () => {
-      // Arrange — mark it first
-      const eventId = `idempotent-test-${Date.now()}-${Math.random()}`;
-      paypalService.markAsProcessed(eventId);
+    it('should return true when WebhookEvent.findOne returns a record (already processed)', async () => {
+      // Arrange
+      mockWebhookEventFindOne.mockResolvedValue({
+        id: 'uuid-1',
+        eventId: 'evt-abc',
+        provider: 'paypal',
+      });
 
       // Act
-      const result = paypalService.isIdempotent(eventId);
+      const result = await paypalService.isEventProcessed('evt-abc', 'paypal');
 
       // Assert
       expect(result).toBe(true);
     });
 
-    it('should not affect other events when one is marked', () => {
+    it('should query with the correct provider for mercadopago', async () => {
       // Arrange
-      const ts = Date.now();
-      const eventA = `event-a-${ts}`;
-      const eventB = `event-b-${ts}`;
-      paypalService.markAsProcessed(eventA);
+      mockWebhookEventFindOne.mockResolvedValue(null);
 
-      // Act & Assert
-      expect(paypalService.isIdempotent(eventA)).toBe(true);
-      expect(paypalService.isIdempotent(eventB)).toBe(false);
+      // Act
+      await paypalService.isEventProcessed('mp-event-123', 'mercadopago');
+
+      // Assert
+      expect(mockWebhookEventFindOne).toHaveBeenCalledWith({
+        where: { eventId: 'mp-event-123', provider: 'mercadopago' },
+      });
     });
   });
 
-  // ── markAsProcessed ────────────────────────────────────────────────────────
+  // ── markEventProcessed (persistent via WebhookEvent table) ─────────────────
 
-  describe('markAsProcessed()', () => {
-    it('should mark event so subsequent isIdempotent returns true', () => {
+  describe('markEventProcessed()', () => {
+    it('should insert a record into WebhookEvent with eventId, provider, and eventType', async () => {
       // Arrange
-      const eventId = `mark-test-${Date.now()}-${Math.random()}`;
-      expect(paypalService.isIdempotent(eventId)).toBe(false);
+      mockWebhookEventCreate.mockResolvedValue({
+        id: 'uuid-new',
+        eventId: 'evt-new',
+        provider: 'paypal',
+        eventType: 'PAYMENT.CAPTURE.COMPLETED',
+      });
 
       // Act
-      paypalService.markAsProcessed(eventId);
+      await paypalService.markEventProcessed('evt-new', 'paypal', 'PAYMENT.CAPTURE.COMPLETED');
 
       // Assert
-      expect(paypalService.isIdempotent(eventId)).toBe(true);
+      expect(mockWebhookEventCreate).toHaveBeenCalledWith({
+        eventId: 'evt-new',
+        provider: 'paypal',
+        eventType: 'PAYMENT.CAPTURE.COMPLETED',
+        processedAt: expect.any(Date),
+      });
     });
 
-    it('should be idempotent itself — marking same event twice does not throw', () => {
+    it('should propagate database errors to the caller', async () => {
       // Arrange
-      const eventId = `dup-mark-${Date.now()}-${Math.random()}`;
+      mockWebhookEventCreate.mockRejectedValue(new Error('Unique constraint violation'));
 
-      // Act & Assert — no throw expected
-      expect(() => {
-        paypalService.markAsProcessed(eventId);
-        paypalService.markAsProcessed(eventId);
-      }).not.toThrow();
+      // Act & Assert
+      await expect(
+        paypalService.markEventProcessed('dup-evt', 'paypal', 'PAYMENT.CAPTURE.COMPLETED')
+      ).rejects.toThrow('Unique constraint violation');
     });
   });
 
@@ -520,34 +549,6 @@ describe('PayPalService', () => {
 
       // Act & Assert
       await expect(paypalService.getOrder('VALID-ORDER-ID')).rejects.toThrow('Order not found');
-    });
-  });
-
-  // ── markAsProcessed (eviction at 10k) ─────────────────────────────────────
-
-  describe('markAsProcessed() — set size limit', () => {
-    it('should evict the oldest entry when the set exceeds 10,000 events', () => {
-      // Arrange — fill set to exactly 10,000 unique events
-      const prefix = `bulk-event-${Date.now()}-`;
-      // We only need to add enough to trigger eviction (the set already has some entries)
-      // So we fill until size > 10,000
-      const currentSize = (paypalService as any).processedEvents.size;
-      const toAdd = 10_001 - currentSize;
-
-      // Add entries up to the limit first
-      for (let i = 0; i < toAdd - 1; i++) {
-        (paypalService as any).processedEvents.add(`${prefix}${i}`);
-      }
-      const firstEntry = `${prefix}0`;
-
-      // Sanity check — first entry is in set
-      expect((paypalService as any).processedEvents.has(firstEntry)).toBe(true);
-
-      // Act — adding one more should trigger eviction
-      paypalService.markAsProcessed(`${prefix}${toAdd}`);
-
-      // Assert — set size should still be ≤ 10,001 (one was evicted)
-      expect((paypalService as any).processedEvents.size).toBeLessThanOrEqual(10_001);
     });
   });
 });

--- a/backend/src/__tests__/unit/PayPalService.test.ts
+++ b/backend/src/__tests__/unit/PayPalService.test.ts
@@ -26,6 +26,13 @@ jest.mock('../../config/env', () => ({
 
 jest.mock('axios');
 
+jest.mock('../../models/WebhookEvent', () => ({
+  WebhookEvent: {
+    findOne: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
 import axios from 'axios';
 import { AppError } from '../../middleware/error.middleware';
 

--- a/backend/src/__tests__/unit/PaymentMercadoPagoController.test.ts
+++ b/backend/src/__tests__/unit/PaymentMercadoPagoController.test.ts
@@ -28,6 +28,10 @@ jest.mock('../../models/index', () => ({
   Product: { findByPk: jest.fn(), findOne: jest.fn() },
 }));
 
+jest.mock('../../models/WebhookEvent', () => ({
+  WebhookEvent: { findOne: jest.fn(), create: jest.fn() },
+}));
+
 jest.mock('../../config/env', () => ({
   config: {
     app: { url: 'http://localhost:3000', frontendUrl: 'http://localhost:4200' },

--- a/backend/src/__tests__/unit/PaymentPayPalController.test.ts
+++ b/backend/src/__tests__/unit/PaymentPayPalController.test.ts
@@ -12,13 +12,25 @@ jest.mock('../../services/PayPalService', () => ({
     captureOrder: jest.fn(),
     getOrder: jest.fn(),
     verifyWebhookSignature: jest.fn(),
-    isIdempotent: jest.fn(),
-    markAsProcessed: jest.fn(),
+    isEventProcessed: jest.fn(),
+    markEventProcessed: jest.fn(),
   },
 }));
 
 jest.mock('../../utils/logger', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../../services/CommissionService', () => ({
+  CommissionService: jest.fn().mockImplementation(() => ({
+    calculateCommissions: jest.fn(),
+  })),
+}));
+
+jest.mock('../../models/index', () => ({
+  Purchase: { create: jest.fn() },
+  Order: { create: jest.fn(), findOne: jest.fn(), findByPk: jest.fn() },
+  Product: { findByPk: jest.fn(), findOne: jest.fn() },
 }));
 
 // ── Imports ───────────────────────────────────────────────────────────────────
@@ -27,6 +39,12 @@ import { PaymentPayPalController } from '../../controllers/PaymentPayPalControll
 import { paypalService } from '../../services/PayPalService';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Flush microtask queue — required for asyncHandler wrapper.
+ * Vacía la cola de microtareas — requerido por el wrapper asyncHandler.
+ */
+const flushPromises = (): Promise<void> => new Promise((r) => setImmediate(r));
 
 function createMockReq(overrides: Record<string, unknown> = {}) {
   return {
@@ -263,34 +281,45 @@ describe('PaymentPayPalController', () => {
 
     it('returns 200 and marks processed on valid signature', async () => {
       (paypalService.verifyWebhookSignature as jest.Mock).mockResolvedValue(true);
-      (paypalService.isIdempotent as jest.Mock).mockReturnValue(false);
+      (paypalService.isEventProcessed as jest.Mock).mockResolvedValue(false);
+      (paypalService.markEventProcessed as jest.Mock).mockResolvedValue(undefined);
 
       const req = createMockReq({
-        body: { event_type: 'PAYMENT.CAPTURE.COMPLETED', resource: { id: 'res-002' } },
+        body: { id: 'evt-002', event_type: 'CHECKOUT.ORDER.APPROVED', resource: { id: 'res-002' } },
         headers: {},
       });
       const res = createMockRes();
       const next = jest.fn();
 
       await PaymentPayPalController.webhook(req, res, next);
+      await flushPromises();
 
-      expect(paypalService.markAsProcessed).toHaveBeenCalledWith('res-002');
+      expect(paypalService.markEventProcessed).toHaveBeenCalledWith(
+        'evt-002',
+        'paypal',
+        'CHECKOUT.ORDER.APPROVED'
+      );
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({ received: true });
     });
 
     it('returns 200 with duplicate flag on idempotent event', async () => {
       (paypalService.verifyWebhookSignature as jest.Mock).mockResolvedValue(true);
-      (paypalService.isIdempotent as jest.Mock).mockReturnValue(true);
+      (paypalService.isEventProcessed as jest.Mock).mockResolvedValue(true);
 
       const req = createMockReq({
-        body: { event_type: 'PAYMENT.CAPTURE.COMPLETED', resource: { id: 'res-dup' } },
+        body: {
+          id: 'evt-dup',
+          event_type: 'PAYMENT.CAPTURE.COMPLETED',
+          resource: { id: 'res-dup' },
+        },
         headers: {},
       });
       const res = createMockRes();
       const next = jest.fn();
 
       await PaymentPayPalController.webhook(req, res, next);
+      await flushPromises();
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({ received: true, duplicate: true });

--- a/backend/src/controllers/PaymentMercadoPagoController.ts
+++ b/backend/src/controllers/PaymentMercadoPagoController.ts
@@ -11,6 +11,7 @@ import { ResponseUtil } from '../utils/response.util.js';
 import { config } from '../config/env.js';
 import { logger } from '../utils/logger';
 import { Purchase, Order, Product } from '../models/index.js';
+import { WebhookEvent } from '../models/WebhookEvent.js';
 import { CommissionService } from '../services/CommissionService.js';
 import type { AuthenticatedRequest } from '../middleware/auth.middleware.js';
 
@@ -240,14 +241,14 @@ export class PaymentMercadoPagoController {
                   break;
                 }
 
-                // ── Step 2: Idempotency check — skip if Order already exists for this MP payment ──
-                const existingOrder = await Order.findOne({
-                  where: { notes: `mercadopago:${payment.id}` },
+                // ── Step 2: Idempotency check — skip if WebhookEvent already exists for this MP payment ──
+                const existingEvent = await WebhookEvent.findOne({
+                  where: { eventId: String(payment.id), provider: 'mercadopago' },
                 });
-                if (existingOrder) {
+                if (existingEvent) {
                   logger.info(
                     { component: 'MercadoPago Webhook', paymentId: payment.id },
-                    'Order already exists for payment — skipping'
+                    'WebhookEvent already exists for payment — skipping'
                   );
                   break;
                 }
@@ -322,6 +323,14 @@ export class PaymentMercadoPagoController {
                   );
                   // Non-fatal — MP still gets 200
                 }
+
+                // ── Step 7: Mark event as processed in WebhookEvent table (persistent idempotency) ──
+                await WebhookEvent.create({
+                  eventId: String(payment.id),
+                  provider: 'mercadopago',
+                  eventType: 'payment.approved',
+                  processedAt: new Date(),
+                });
               } catch (orderError) {
                 logger.error(
                   { err: orderError, component: 'MercadoPago Webhook' },

--- a/backend/src/controllers/PaymentPayPalController.ts
+++ b/backend/src/controllers/PaymentPayPalController.ts
@@ -9,6 +9,8 @@ import { asyncHandler } from '../middleware/asyncHandler.js';
 import { paypalService } from '../services/PayPalService.js';
 import { ResponseUtil } from '../utils/response.util.js';
 import { logger } from '../utils/logger';
+import { Purchase, Order, Product } from '../models/index.js';
+import { CommissionService } from '../services/CommissionService.js';
 import type { AuthenticatedRequest } from '../middleware/auth.middleware.js';
 
 /**
@@ -104,7 +106,14 @@ export class PaymentPayPalController {
 
   /**
    * POST /api/payment/paypal/webhook
-   * Handle PayPal webhook events
+   * Handle PayPal webhook events.
+   * Processes PAYMENT.CAPTURE.COMPLETED (creates Purchase + Order + commissions)
+   * and PAYMENT.CAPTURE.REFUNDED (marks Order failed + Purchase refunded).
+   *
+   * Maneja eventos de webhook de PayPal.
+   * Procesa PAYMENT.CAPTURE.COMPLETED (crea Purchase + Order + comisiones)
+   * y PAYMENT.CAPTURE.REFUNDED (marca Order como fallida + Purchase reembolsada).
+   *
    * @see https://developer.paypal.com/docs/api-basics/notifications/webhooks/
    */
   static webhook = asyncHandler(async (req: Request, res: Response) => {
@@ -129,46 +138,230 @@ export class PaymentPayPalController {
     }
 
     const event = req.body;
+    const eventId: string | undefined = event.id;
 
-    // Check idempotency
-    if (paypalService.isIdempotent(event.resource?.id)) {
-      logger.info(
-        { component: 'PayPal Webhook', resourceId: event.resource?.id },
-        'Duplicate event, skipping'
-      );
+    // ── Global idempotency check (persistent via WebhookEvent table) ──
+    if (eventId && (await paypalService.isEventProcessed(eventId, 'paypal'))) {
+      logger.info({ component: 'PayPal Webhook', eventId }, 'Duplicate event, skipping');
       return res.status(200).json({ received: true, duplicate: true });
     }
 
     logger.info(
-      { component: 'PayPal Webhook', eventType: event.event_type, resourceId: event.resource?.id },
+      { component: 'PayPal Webhook', eventType: event.event_type, eventId },
       'Webhook event received'
     );
 
     switch (event.event_type) {
       case 'CHECKOUT.ORDER.APPROVED':
-        // Order was approved by user
-        logger.info({ component: 'PayPal', resourceId: event.resource?.id }, 'Order approved');
+        // Order was approved by user — no action needed
+        logger.info({ component: 'PayPal', eventId }, 'Order approved');
         break;
 
-      case 'PAYMENT.CAPTURE.COMPLETED':
-        // Payment successfully captured
-        logger.info({ component: 'PayPal', resourceId: event.resource?.id }, 'Payment completed');
-        // TODO: Trigger commission calculation
-        break;
+      case 'PAYMENT.CAPTURE.COMPLETED': {
+        /**
+         * Payment successfully captured — create Purchase + Order + commissions.
+         * Follows the same pattern as the MercadoPago webhook for consistency.
+         *
+         * Pago capturado exitosamente — crea Purchase + Order + comisiones.
+         * Sigue el mismo patrón del webhook de MercadoPago por consistencia.
+         */
+        try {
+          const resource = event.resource;
+          const captureId: string = resource?.id ?? '';
+          const amount: number = parseFloat(resource?.amount?.value ?? '0');
+          const currency: string = resource?.amount?.currency_code ?? 'USD';
 
-      case 'PAYMENT.CAPTURE.REFUNDED':
-        // Payment was refunded
-        logger.info({ component: 'PayPal', resourceId: event.resource?.id }, 'Payment refunded');
-        // TODO: Reverse commissions if applicable
+          // Extract userId from custom_id (set during createOrder as JSON)
+          let userId: string | undefined;
+          let internalOrderId: string | undefined;
+          const customId: string | undefined =
+            resource?.custom_id ?? event.resource?.supplementary_data?.related_ids?.order_id;
+
+          if (customId) {
+            try {
+              const parsed: { userId?: string; internalOrderId?: string } = JSON.parse(
+                customId
+              ) as { userId?: string; internalOrderId?: string };
+              userId = parsed.userId;
+              internalOrderId = parsed.internalOrderId;
+            } catch {
+              // custom_id may be a plain string (userId) — use it directly
+              userId = customId;
+            }
+          }
+
+          if (!userId) {
+            logger.error(
+              { component: 'PayPal Webhook', eventId, captureId },
+              'No userId found in PayPal webhook payload (custom_id)'
+            );
+            break;
+          }
+
+          // ── Additional idempotency: check if Order already exists for this capture ──
+          const existingOrder = await Order.findOne({
+            where: { notes: `paypal:${captureId}` },
+          });
+          if (existingOrder) {
+            logger.info(
+              { component: 'PayPal Webhook', captureId },
+              'Order already exists for capture — skipping'
+            );
+            break;
+          }
+
+          // ── Resolve productId from internalOrderId or fallback to first active product ──
+          let productId: string = '';
+          if (internalOrderId) {
+            const existingInternalOrder = await Order.findByPk(internalOrderId);
+            if (existingInternalOrder) {
+              productId = existingInternalOrder.productId;
+            }
+          }
+          if (!productId) {
+            const fallbackProduct = await Product.findOne({ where: { isActive: true } });
+            productId = fallbackProduct?.id ?? '';
+          }
+
+          if (!productId) {
+            logger.error(
+              { component: 'PayPal Webhook', eventId },
+              'Could not resolve productId for payment'
+            );
+            break;
+          }
+
+          // ── Create Purchase record ──
+          const purchase = await Purchase.create({
+            userId,
+            productId,
+            businessType: 'producto',
+            amount,
+            currency,
+            description: `PayPal payment ${captureId}`,
+            status: 'completed',
+          });
+
+          // ── Create Order record ──
+          const orderNumber =
+            'ORD-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9).toUpperCase();
+
+          await Order.create({
+            orderNumber,
+            userId,
+            productId,
+            purchaseId: purchase.id,
+            totalAmount: amount,
+            currency,
+            status: 'completed',
+            paymentMethod: 'paypal',
+            notes: `paypal:${captureId}`,
+          });
+
+          logger.info(
+            { component: 'PayPal Webhook', captureId },
+            'Purchase & Order created for payment'
+          );
+
+          // ── Trigger commission calculation (fire-and-forget, don't break 200) ──
+          try {
+            const commissionService = new CommissionService();
+            await commissionService.calculateCommissions(purchase.id);
+            logger.info(
+              { component: 'PayPal Webhook', purchaseId: purchase.id },
+              'Commissions calculated for purchase'
+            );
+          } catch (commissionError) {
+            logger.error(
+              { err: commissionError, component: 'PayPal Webhook' },
+              'Commission calculation failed'
+            );
+            // Non-fatal — PayPal still gets 200
+          }
+        } catch (orderError) {
+          logger.error(
+            { err: orderError, component: 'PayPal Webhook' },
+            'Error creating Purchase/Order'
+          );
+          // Non-fatal — PayPal must receive 200 regardless
+        }
         break;
+      }
+
+      case 'PAYMENT.CAPTURE.REFUNDED': {
+        /**
+         * Payment was refunded — update Order to 'failed' + Purchase to 'refunded'.
+         * NO commission reversal (this is a business decision).
+         *
+         * Pago reembolsado — actualiza Order a 'failed' + Purchase a 'refunded'.
+         * NO se revierten comisiones (decisión de negocio).
+         */
+        try {
+          const resource = event.resource;
+          const refundId: string = resource?.id ?? '';
+
+          // The refund resource links back to the original capture via links
+          // Find the original capture ID from the refund payload
+          const captureLink = resource?.links?.find(
+            (link: { rel: string; href: string }) => link.rel === 'up'
+          );
+          const captureId: string | undefined = captureLink?.href?.split('/').pop();
+
+          if (!captureId) {
+            logger.error(
+              { component: 'PayPal Webhook', refundId },
+              'Could not extract original capture ID from refund event'
+            );
+            break;
+          }
+
+          // Find the original Order by notes pattern
+          const originalOrder = await Order.findOne({
+            where: { notes: `paypal:${captureId}` },
+          });
+
+          if (!originalOrder) {
+            logger.warn(
+              { component: 'PayPal Webhook', captureId },
+              'Original order not found for refund — may not have been processed by us'
+            );
+            break;
+          }
+
+          // Update Order status to 'failed' (no 'refunded' in Order ENUM)
+          originalOrder.status = 'failed';
+          await originalOrder.save();
+
+          // Update related Purchase status to 'refunded'
+          if (originalOrder.purchaseId) {
+            const purchase = await Purchase.findByPk(originalOrder.purchaseId);
+            if (purchase) {
+              purchase.status = 'refunded';
+              await purchase.save();
+            }
+          }
+
+          logger.info(
+            { component: 'PayPal Webhook', captureId, refundId, orderId: originalOrder.id },
+            'Order marked as failed and Purchase as refunded'
+          );
+        } catch (refundError) {
+          logger.error(
+            { err: refundError, component: 'PayPal Webhook' },
+            'Error processing refund'
+          );
+          // Non-fatal — PayPal must receive 200 regardless
+        }
+        break;
+      }
 
       default:
         logger.info({ component: 'PayPal', eventType: event.event_type }, 'Unhandled event');
     }
 
-    // Mark as processed for idempotency
-    if (event.resource?.id) {
-      paypalService.markAsProcessed(event.resource.id);
+    // Mark as processed for idempotency (persistent)
+    if (eventId) {
+      await paypalService.markEventProcessed(eventId, 'paypal', event.event_type ?? 'unknown');
     }
 
     return res.status(200).json({ received: true });

--- a/backend/src/services/PayPalService.ts
+++ b/backend/src/services/PayPalService.ts
@@ -7,6 +7,8 @@
 import axios from 'axios';
 import { config } from '../config/env.js';
 import { AppError } from '../middleware/error.middleware.js';
+import { WebhookEvent } from '../models/WebhookEvent.js';
+import type { WebhookProvider } from '../models/WebhookEvent.js';
 
 const PAYPAL_API_BASE =
   config.paypal.mode === 'sandbox'
@@ -281,52 +283,56 @@ class PayPalService {
     }
   }
 
-  // ── Idempotency guard ────────────────────────────────────────────────────────
+  // ── Idempotency guard (persistent via WebhookEvent table) ─────────────────
 
   /**
-   * Set of already-processed PayPal webhook event IDs.
-   * Capped at MAX_PROCESSED_EVENTS to prevent unbounded memory growth.
+   * Check whether a webhook event has already been processed.
+   * Uses the WebhookEvent table for persistent, crash-safe idempotency
+   * (replaces the previous in-memory Set).
    *
-   * Conjunto de IDs de eventos de webhook ya procesados.
-   * Limitado a MAX_PROCESSED_EVENTS para evitar crecimiento ilimitado de memoria.
-   */
-  private readonly processedEvents: Set<string> = new Set();
-  private static readonly MAX_PROCESSED_EVENTS = 10_000;
-
-  /**
-   * Check whether a PayPal webhook event has already been processed.
-   * Used to implement idempotent webhook handling.
+   * Verifica si un evento de webhook ya fue procesado.
+   * Usa la tabla WebhookEvent para idempotencia persistente (reemplaza
+   * el Set en memoria anterior).
    *
-   * Verifica si un evento de webhook de PayPal ya fue procesado.
-   *
-   * @param eventId - PayPal event ID (e.g. from event.id)
+   * @param eventId  - Provider-assigned event ID (e.g. PayPal event.id)
+   * @param provider - Payment provider name
    * @returns true if the event was already processed
+   *
+   * ES: Retorna true si el evento ya fue procesado anteriormente.
+   * EN: Returns true if the event was already processed.
    */
-  isIdempotent(eventId: string): boolean {
-    return this.processedEvents.has(eventId);
+  async isEventProcessed(eventId: string, provider: WebhookProvider): Promise<boolean> {
+    const existing = await WebhookEvent.findOne({
+      where: { eventId, provider },
+    });
+    return existing !== null;
   }
 
   /**
-   * Mark a PayPal webhook event as processed.
-   * Evicts the oldest entry if the set exceeds MAX_PROCESSED_EVENTS.
+   * Mark a webhook event as processed by inserting it into the WebhookEvent table.
+   * The composite unique index (event_id, provider) prevents double-inserts.
    *
-   * Marca un evento de webhook de PayPal como procesado.
-   * Elimina la entrada más antigua si el set supera MAX_PROCESSED_EVENTS.
+   * Marca un evento de webhook como procesado insertándolo en la tabla WebhookEvent.
+   * El índice único compuesto (event_id, provider) previene doble inserción.
    *
-   * @param eventId - PayPal event ID to mark as processed
+   * @param eventId   - Provider-assigned event ID
+   * @param provider  - Payment provider name
+   * @param eventType - Event type string (e.g. "PAYMENT.CAPTURE.COMPLETED")
+   *
+   * ES: Inserta el evento en la tabla de idempotencia.
+   * EN: Inserts the event into the idempotency table.
    */
-  markAsProcessed(eventId: string): void {
-    if (this.processedEvents.has(eventId)) return;
-
-    // Evict oldest entry if at capacity
-    if (this.processedEvents.size >= PayPalService.MAX_PROCESSED_EVENTS) {
-      const oldest = this.processedEvents.values().next().value;
-      if (oldest !== undefined) {
-        this.processedEvents.delete(oldest);
-      }
-    }
-
-    this.processedEvents.add(eventId);
+  async markEventProcessed(
+    eventId: string,
+    provider: WebhookProvider,
+    eventType: string
+  ): Promise<void> {
+    await WebhookEvent.create({
+      eventId,
+      provider,
+      eventType,
+      processedAt: new Date(),
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

- Complete PayPal `PAYMENT.CAPTURE.COMPLETED` webhook: creates Purchase + Order + triggers commission calculation via `CommissionService`
- Implement PayPal `PAYMENT.CAPTURE.REFUNDED` handler: marks Order as `failed` + Purchase as `refunded` (no commission reversal per business decision)
- Migrate PayPal idempotency from in-memory `Set<string>` (capped at 10k, lost on restart) to persistent `WebhookEvent` table with composite unique constraint `(event_id, provider)`
- Migrate MercadoPago idempotency from `Order.notes` hack (`mercadopago:{paymentId}`) to same `WebhookEvent` table
- Update all payment webhook tests for both providers (666 tests passing, 0 failures)

## Changes

| File | What changed |
|------|-------------|
| `services/PayPalService.ts` | Replaced in-memory Set with `isEventProcessed()` / `markEventProcessed()` using WebhookEvent model |
| `controllers/PaymentPayPalController.ts` | Completed CAPTURE.COMPLETED (Purchase+Order+commissions) and CAPTURE.REFUNDED handlers |
| `controllers/PaymentMercadoPagoController.ts` | Migrated idempotency from Order.notes to WebhookEvent table |
| `__tests__/PayPalService.test.ts` | Updated tests for new async idempotency methods |
| `__tests__/MercadoPagoWebhook.test.ts` | Updated idempotency tests to use WebhookEvent mock |
| `__tests__/unit/PayPalService.test.ts` | Added WebhookEvent mock for transitive dependency |
| `__tests__/unit/PaymentPayPalController.test.ts` | Added CommissionService + model mocks, flushPromises for async webhook |
| `__tests__/unit/PaymentMercadoPagoController.test.ts` | Added WebhookEvent mock |

## Pending (not in this PR)

- [ ] MercadoPago refund/cancelled notification handling (MP was already 90% complete, refund handler only added for PayPal)
- [ ] Sandbox integration testing (deferred to dedicated testing session)

## Testing

```
Test Suites: 49 passed, 49 total
Tests:       1 skipped, 666 passed, 667 total
```

Closes #151