### PR TITLE
fix(payment): route PayPal checkout through backend API for proper user tracking (#152)

### DIFF
--- a/backend/src/__tests__/unit/PaymentPayPalController.test.ts
+++ b/backend/src/__tests__/unit/PaymentPayPalController.test.ts
@@ -168,15 +168,42 @@ describe('PaymentPayPalController', () => {
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
     });
 
-    it('returns 400 when internalOrderId is missing', async () => {
-      // Valid PayPal order ID: 17 uppercase alphanumeric chars
+    it('succeeds when internalOrderId is missing (optional field)', async () => {
+      const mockCaptured = {
+        id: 'ABCDEFGHIJ1234567',
+        status: 'COMPLETED',
+        purchase_units: [
+          {
+            payments: {
+              captures: [{ id: 'cap-002', amount: { value: '50.00', currency_code: 'USD' } }],
+            },
+          },
+        ],
+      };
+      (paypalService.captureOrder as jest.Mock).mockResolvedValue(mockCaptured);
+
+      // Valid PayPal order ID: 17 uppercase alphanumeric chars, no internalOrderId
       const req = createMockReq({ body: { orderId: 'ABCDEFGHIJ1234567' } });
       const res = createMockRes();
       const next = jest.fn();
 
       await PaymentPayPalController.captureOrder(req, res, next);
 
-      expect(res.status).toHaveBeenCalledWith(400);
+      expect(paypalService.captureOrder).toHaveBeenCalledWith({
+        orderId: 'ABCDEFGHIJ1234567',
+        internalOrderId: '',
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            orderId: 'ABCDEFGHIJ1234567',
+            status: 'COMPLETED',
+            captureId: 'cap-002',
+          }),
+        })
+      );
     });
 
     it('captures order and returns 200 on success', async () => {

--- a/backend/src/controllers/PaymentPayPalController.ts
+++ b/backend/src/controllers/PaymentPayPalController.ts
@@ -75,17 +75,9 @@ export class PaymentPayPalController {
         .json(ResponseUtil.error('INVALID_ORDER_ID', 'Invalid PayPal order ID format', 400));
     }
 
-    if (!internalOrderId) {
-      return res
-        .status(400)
-        .json(
-          ResponseUtil.error('MISSING_INTERNAL_ORDER_ID', 'Internal order ID is required', 400)
-        );
-    }
-
     const capturedOrder = await paypalService.captureOrder({
       orderId,
-      internalOrderId,
+      internalOrderId: internalOrderId || '',
     });
 
     // Extract capture details

--- a/backend/src/services/PayPalService.ts
+++ b/backend/src/services/PayPalService.ts
@@ -60,7 +60,14 @@ interface CreateOrderRequest {
 
 interface CaptureOrderRequest {
   orderId: string; // PayPal order ID
-  internalOrderId: string; // Our internal order ID
+  /**
+   * Our internal order ID — optional since PayPal SDK flow
+   * captures before a local Order exists (webhook creates it).
+   *
+   * Nuestro order ID interno — opcional ya que el flujo del SDK de PayPal
+   * captura antes de que exista una Order local (el webhook la crea).
+   */
+  internalOrderId?: string;
 }
 
 class PayPalService {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -253,6 +253,24 @@ function App() {
               }
             />
 
+            {/* PayPal return URL routes — shown after PayPal redirect */}
+            <Route
+              path="/checkout/success"
+              element={
+                <Suspense fallback={<PageLoader />}>
+                  <OrderProcessing />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/checkout/cancel"
+              element={
+                <Suspense fallback={<PageLoader />}>
+                  <OrderProcessing />
+                </Suspense>
+              }
+            />
+
             {/* Wallet Digital Route */}
             <Route
               path="/wallet"

--- a/frontend/src/components/CheckoutForm.tsx
+++ b/frontend/src/components/CheckoutForm.tsx
@@ -17,6 +17,15 @@ const PAYPAL_CLIENT_ID = import.meta.env.VITE_PAYPAL_CLIENT_ID || '';
 const MP_SANDBOX = import.meta.env.VITE_MP_SANDBOX === 'true' || import.meta.env.DEV;
 
 /**
+ * Data returned after a successful PayPal capture
+ * Datos devueltos después de una captura exitosa de PayPal
+ */
+interface PayPalSuccessData {
+  orderId: string;
+  internalOrderId?: string;
+}
+
+/**
  * CheckoutForm props
  */
 interface CheckoutFormProps {
@@ -26,7 +35,7 @@ interface CheckoutFormProps {
   className?: string;
   total?: number;
   currency?: string;
-  onPayPalSuccess?: (paymentMethod: PaymentMethod) => void;
+  onPayPalSuccess?: (data: PayPalSuccessData) => void;
   /** Product data needed to build MP preference items */
   productId?: string;
   productName?: string;
@@ -40,7 +49,7 @@ interface PayPalButtonProps {
   agreedToTerms: boolean;
   currency: string;
   total: number;
-  onPayPalSuccess?: (paymentMethod: PaymentMethod) => void;
+  onPayPalSuccess?: (data: PayPalSuccessData) => void;
   onError?: (error: string) => void;
 }
 
@@ -77,30 +86,30 @@ const PayPalButton = React.memo(function PayPalButton({
       <PayPalButtons
         style={{ layout: 'vertical', color: 'blue', shape: 'rect' }}
         disabled={isProcessing || !agreedToTerms}
-        createOrder={(_data, actions) => {
-          return actions.order.create({
-            intent: 'CAPTURE',
-            purchase_units: [
-              {
-                amount: {
-                  currency_code: currency,
-                  value: total.toFixed(2),
-                },
-                description: t('checkout.paypalDescription'),
-              },
-            ],
+        createOrder={async () => {
+          // Route through our backend so custom_id (userId) is set on the PayPal order.
+          // Without this, the webhook cannot identify the user.
+          // Se enruta por nuestro backend para que custom_id (userId) se establezca en la orden de PayPal.
+          const response = await paymentService.createPayPalOrder({
+            amount: total,
+            currency,
+            description: t('checkout.paypalDescription'),
           });
+          return response.data.orderId;
         }}
         onApprove={async (data, _actions) => {
           try {
-            // IMPORTANT: capture must go through our backend for validation.
+            // Capture must go through our backend for validation.
             // Never trust a client-side capture result — the backend verifies
             // the payment status with PayPal before updating the order.
             const result = await paymentService.completeWithPayPal({
               orderId: data.orderID,
             });
             if (result.success) {
-              onPayPalSuccess?.('paypal');
+              onPayPalSuccess?.({
+                orderId: result.data.orderId,
+                internalOrderId: result.data.internalOrderId,
+              });
             } else {
               onError?.(t('checkout.paypalCaptureError'));
             }

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -191,7 +191,16 @@ export default function Checkout() {
               error={submitError}
               total={product.price}
               currency={product.currency}
-              onPayPalSuccess={handleConfirmPurchase}
+              onPayPalSuccess={(data) => {
+                // Navigate directly to the OrderProcessing page — the webhook
+                // handles Purchase + Order creation, so no confirmation modal needed.
+                // Se navega directo a la página de procesamiento — el webhook
+                // maneja la creación de Purchase + Order, no se necesita modal.
+                navigate(
+                  '/checkout/success?status=approved&payment_method=paypal&paypal_order_id=' +
+                    data.orderId
+                );
+              }}
               productId={product.id}
               productName={product.name}
             />

--- a/frontend/src/pages/OrderProcessing.tsx
+++ b/frontend/src/pages/OrderProcessing.tsx
@@ -121,9 +121,17 @@ export default function OrderProcessing() {
   /**
    * Infer status from current pathname for named routes:
    * /orders/success → approved, /orders/pending → pending
+   * /checkout/success → approved (PayPal return URL)
+   * /checkout/cancel → rejected (PayPal cancel URL)
+   *
+   * Infiere el estado desde el pathname actual para rutas nombradas:
+   * /checkout/success → approved (URL de retorno de PayPal)
+   * /checkout/cancel → rejected (URL de cancelación de PayPal)
    */
   function inferStatusFromPath(): string | null {
     const path = window.location.pathname;
+    if (path.includes('/checkout/success')) return 'approved';
+    if (path.includes('/checkout/cancel')) return 'rejected';
     if (path.includes('/orders/success')) return 'approved';
     if (path.includes('/orders/pending')) return 'pending';
     return null;


### PR DESCRIPTION
## Summary

Fixes the PayPal checkout flow so that orders are created through our backend API (with `custom_id` containing `userId`), enabling the webhook to properly identify users and create Purchase + Order records.

Closes #152

## Changes

### Frontend
- **`CheckoutForm.tsx`**: `createOrder` now calls `paymentService.createPayPalOrder()` (backend) instead of `actions.order.create()` (SDK direct). New `PayPalSuccessData` interface replaces plain `PaymentMethod` string in `onPayPalSuccess` callback.
- **`Checkout.tsx`**: PayPal success navigates directly to `/checkout/success` with query params instead of showing the redundant confirmation modal (modal still works for simulated payments only).
- **`App.tsx`**: Added `/checkout/success` and `/checkout/cancel` routes mapped to `OrderProcessing` component.
- **`OrderProcessing.tsx`**: `inferStatusFromPath()` now handles `/checkout/success` → approved and `/checkout/cancel` → rejected.

### Backend
- **`PaymentPayPalController.ts`**: Removed required validation for `internalOrderId` in capture endpoint (webhook now handles Purchase + Order creation).
- **`PayPalService.ts`**: Made `internalOrderId` optional in `CaptureOrderRequest` interface.

## Flow After Fix

1. User clicks PayPal button → SDK calls our backend `POST /api/payment/paypal/create` (sets `custom_id` with `userId`)
2. User approves on PayPal → SDK `onApprove` calls backend `POST /api/payment/paypal/capture`
3. Frontend navigates to `/checkout/success?status=approved`
4. PayPal webhook fires async → creates Purchase + Order + triggers commissions (using `custom_id` to identify user)

## Verification

- ✅ `pnpm tsc -b` — zero type errors (frontend)
- ✅ `pnpm test` — all tests passing (backend)