### PR TITLE
feat(admin): add navigation links to admin CRUD pages (#155)

### DIFF
--- a/frontend/src/components/layout/MobileMenu.tsx
+++ b/frontend/src/components/layout/MobileMenu.tsx
@@ -1,5 +1,9 @@
 /**
- * MobileMenu - Menú móvil para navegación responsive
+ * MobileMenu - Menú móvil para navegación responsive.
+ * Los links de admin se muestran en una sección separada con label.
+ *
+ * MobileMenu - Mobile menu for responsive navigation.
+ * Admin links are shown in a separate labeled section.
  *
  * @module components/layout/MobileMenu
  */
@@ -17,10 +21,13 @@ import {
   DollarSign,
   LogOut,
   Wallet,
+  Building2,
+  MapPin,
+  CalendarDays,
 } from 'lucide-react';
 import { featureFlags } from '../../utils/featureFlags';
 
-// Navigation items
+/** Regular navigation items / Ítems de navegación regulares */
 const NAV_ITEMS = [
   { path: '/dashboard', labelKey: 'nav.dashboard', icon: LayoutDashboard },
   { path: '/tree', labelKey: 'nav.tree', icon: TreeDeciduous },
@@ -30,9 +37,13 @@ const NAV_ITEMS = [
   { path: '/profile', labelKey: 'nav.profile', icon: User },
 ];
 
+/** Admin-only navigation items / Ítems exclusivos para administradores */
 const ADMIN_ITEMS = [
-  { path: '/admin', labelKey: 'nav.admin', icon: Shield },
+  { path: '/admin', labelKey: 'nav.adminUsers', icon: Users },
   { path: '/admin/commissions', labelKey: 'nav.commissionConfig', icon: DollarSign },
+  { path: '/admin/properties', labelKey: 'nav.adminProperties', icon: Building2 },
+  { path: '/admin/tours', labelKey: 'nav.adminTours', icon: MapPin },
+  { path: '/admin/reservations', labelKey: 'nav.adminReservations', icon: CalendarDays },
 ];
 
 interface MobileMenuProps {
@@ -45,10 +56,13 @@ export function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
   const { user, logout } = useAuth();
   const { t } = useTranslation();
 
-  const isAdmin = (user as any)?.role === 'admin';
-  const allNavItems = (isAdmin ? [...NAV_ITEMS, ...ADMIN_ITEMS] : NAV_ITEMS).filter(
+  const isAdmin = (user as { role?: string })?.role === 'admin';
+
+  /** Regular nav items with wallet feature flag filter */
+  const filteredNavItems = NAV_ITEMS.filter(
     (item) => item.path !== '/wallet' || featureFlags.cryptoWallet
   );
+
   const currentLang = getCurrentLanguage();
 
   const handleLanguageChange = (code: 'en' | 'es') => {
@@ -61,7 +75,8 @@ export function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
   return (
     <div className="md:hidden border-t border-slate-200 bg-white">
       <div className="px-4 py-3 space-y-1">
-        {allNavItems.map((item) => {
+        {/* Regular navigation items */}
+        {filteredNavItems.map((item) => {
           const Icon = item.icon;
           const isActive = location.pathname === item.path;
           return (
@@ -83,6 +98,38 @@ export function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
             </Link>
           );
         })}
+
+        {/* Admin section — only for admin users */}
+        {isAdmin && (
+          <div className="pt-3 mt-3 border-t border-slate-200">
+            <p className="px-4 py-2 text-xs font-semibold text-slate-500 uppercase tracking-wider flex items-center gap-2">
+              <Shield className="w-3.5 h-3.5" />
+              {t('nav.administration')}
+            </p>
+            {ADMIN_ITEMS.map((item) => {
+              const Icon = item.icon;
+              const isActive = location.pathname === item.path;
+              return (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  onClick={onClose}
+                  className={`
+                    flex items-center gap-3 px-4 py-3 rounded-lg text-base font-medium transition-colors
+                    ${
+                      isActive
+                        ? 'bg-emerald-50 text-emerald-700'
+                        : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900'
+                    }
+                  `}
+                >
+                  <Icon className="w-5 h-5" />
+                  {t(item.labelKey)}
+                </Link>
+              );
+            })}
+          </div>
+        )}
 
         {/* Language selector (mobile) */}
         <div className="pt-3 mt-3 border-t border-slate-200">
@@ -114,7 +161,9 @@ export function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
             </div>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-slate-900 truncate">{user?.email}</p>
-              <p className="text-xs text-slate-500 capitalize">{(user as any)?.role || 'user'}</p>
+              <p className="text-xs text-slate-500 capitalize">
+                {(user as { role?: string })?.role || 'user'}
+              </p>
             </div>
           </div>
           <button

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -1,9 +1,11 @@
 /**
  * Navbar - Barra de navegación principal de Nexo Real con glass morphism.
  * Muestra ítems diferenciados para usuarios autenticados vs. visitantes.
+ * Los links de admin se agrupan en un dropdown (desktop) o sección colapsada (mobile).
  *
  * Navbar - Main Nexo Real navigation bar with glass morphism.
  * Shows different items for authenticated users vs. public visitors.
+ * Admin links are grouped into a dropdown (desktop) or collapsible section (mobile).
  *
  * @module components/layout/Navbar
  */
@@ -25,12 +27,22 @@ import {
   Building2,
   MapPin,
   CalendarCheck,
+  CalendarDays,
   Trophy,
   Medal,
+  ChevronDown,
 } from 'lucide-react';
 import { LanguageSelector } from './LanguageSelector';
 import { UserMenu } from './UserMenu';
 import { featureFlags } from '../../utils/featureFlags';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuLabel,
+} from '../ui/dropdown-menu';
 
 /** Navigation items shown to authenticated users / Ítems de navegación para usuarios autenticados */
 const NAV_ITEMS = [
@@ -44,10 +56,13 @@ const NAV_ITEMS = [
   { path: '/profile', labelKey: 'nav.profile', icon: User },
 ];
 
-/** Admin-only navigation items / Ítems exclusivos para administradores */
-const ADMIN_ITEMS = [
-  { path: '/admin', labelKey: 'nav.admin', icon: Shield },
+/** Admin dropdown items / Ítems del dropdown de administración */
+const ADMIN_DROPDOWN_ITEMS = [
+  { path: '/admin', labelKey: 'nav.adminUsers', icon: Users },
   { path: '/admin/commissions', labelKey: 'nav.commissionConfig', icon: DollarSign },
+  { path: '/admin/properties', labelKey: 'nav.adminProperties', icon: Building2 },
+  { path: '/admin/tours', labelKey: 'nav.adminTours', icon: MapPin },
+  { path: '/admin/reservations', labelKey: 'nav.adminReservations', icon: CalendarDays },
 ];
 
 /** Public navigation items (not logged in) / Ítems públicos (visitantes no autenticados) */
@@ -77,9 +92,14 @@ export function Navbar({ onMobileMenuToggle, mobileMenuOpen }: NavbarProps) {
   const { t } = useTranslation();
 
   const isAdmin = (user as { role?: string })?.role === 'admin';
-  const allNavItems = (isAdmin ? [...NAV_ITEMS, ...ADMIN_ITEMS] : NAV_ITEMS).filter(
+
+  /** Regular nav items with wallet feature flag filter */
+  const filteredNavItems = NAV_ITEMS.filter(
     (item) => item.path !== '/wallet' || featureFlags.cryptoWallet
   );
+
+  /** Whether any admin route is currently active */
+  const isAdminRouteActive = location.pathname.startsWith('/admin');
 
   return (
     <nav className="sticky top-0 z-50 bg-slate-900/80 backdrop-blur-xl border-b border-slate-700/50">
@@ -103,9 +123,10 @@ export function Navbar({ onMobileMenuToggle, mobileMenuOpen }: NavbarProps) {
 
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center gap-1">
-            {user
-              ? // Logged in: show full navigation items
-                allNavItems.map((item) => {
+            {user ? (
+              // Logged in: show regular nav items + admin dropdown
+              <>
+                {filteredNavItems.map((item) => {
                   const Icon = item.icon;
                   const isActive = location.pathname === item.path;
                   return (
@@ -113,40 +134,13 @@ export function Navbar({ onMobileMenuToggle, mobileMenuOpen }: NavbarProps) {
                       key={item.path}
                       to={item.path}
                       className={`
-                      relative flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-300
-                      ${
-                        isActive
-                          ? 'text-white'
-                          : 'text-slate-400 hover:text-white hover:bg-slate-800/50'
-                      }
-                    `}
-                    >
-                      {isActive && (
-                        <div className="absolute inset-0 bg-gradient-to-r from-emerald-500/20 to-teal-500/20 rounded-xl border border-emerald-500/30" />
-                      )}
-                      <Icon
-                        className={`w-4 h-4 relative z-10 ${isActive ? 'text-emerald-400' : ''}`}
-                      />
-                      <span className="relative z-10">{t(item.labelKey)}</span>
-                    </Link>
-                  );
-                })
-              : // Not logged in: show public property/tour links
-                PUBLIC_NAV_ITEMS.map((item) => {
-                  const Icon = item.icon;
-                  const isActive = location.pathname.startsWith(item.path);
-                  return (
-                    <Link
-                      key={item.path}
-                      to={item.path}
-                      className={`
-                      relative flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-300
-                      ${
-                        isActive
-                          ? 'text-white'
-                          : 'text-slate-400 hover:text-white hover:bg-slate-800/50'
-                      }
-                    `}
+                        relative flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-300
+                        ${
+                          isActive
+                            ? 'text-white'
+                            : 'text-slate-400 hover:text-white hover:bg-slate-800/50'
+                        }
+                      `}
                     >
                       {isActive && (
                         <div className="absolute inset-0 bg-gradient-to-r from-emerald-500/20 to-teal-500/20 rounded-xl border border-emerald-500/30" />
@@ -158,6 +152,95 @@ export function Navbar({ onMobileMenuToggle, mobileMenuOpen }: NavbarProps) {
                     </Link>
                   );
                 })}
+
+                {/* Admin dropdown — only for admin users */}
+                {isAdmin && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        className={`
+                            relative flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-300 outline-none
+                            ${
+                              isAdminRouteActive
+                                ? 'text-white'
+                                : 'text-slate-400 hover:text-white hover:bg-slate-800/50'
+                            }
+                          `}
+                      >
+                        {isAdminRouteActive && (
+                          <div className="absolute inset-0 bg-gradient-to-r from-emerald-500/20 to-teal-500/20 rounded-xl border border-emerald-500/30" />
+                        )}
+                        <Shield
+                          className={`w-4 h-4 relative z-10 ${isAdminRouteActive ? 'text-emerald-400' : ''}`}
+                        />
+                        <span className="relative z-10">{t('nav.admin')}</span>
+                        <ChevronDown className="w-3 h-3 relative z-10" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align="start"
+                      className="bg-slate-800/95 backdrop-blur-xl border-slate-700/50 min-w-[200px]"
+                    >
+                      <DropdownMenuLabel className="text-slate-400 text-xs uppercase tracking-wider">
+                        {t('nav.administration')}
+                      </DropdownMenuLabel>
+                      <DropdownMenuSeparator className="bg-slate-700/50" />
+                      {ADMIN_DROPDOWN_ITEMS.map((item) => {
+                        const Icon = item.icon;
+                        const isActive = location.pathname === item.path;
+                        return (
+                          <DropdownMenuItem
+                            key={item.path}
+                            asChild
+                            className={`
+                                cursor-pointer rounded-md
+                                ${
+                                  isActive
+                                    ? 'text-emerald-400'
+                                    : 'text-slate-300 hover:text-white hover:bg-slate-700/50 focus:bg-slate-700/50 focus:text-white'
+                                }
+                              `}
+                          >
+                            <Link to={item.path} className="flex items-center gap-2">
+                              <Icon className="w-4 h-4" />
+                              {t(item.labelKey)}
+                            </Link>
+                          </DropdownMenuItem>
+                        );
+                      })}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+              </>
+            ) : (
+              // Not logged in: show public property/tour links
+              PUBLIC_NAV_ITEMS.map((item) => {
+                const Icon = item.icon;
+                const isActive = location.pathname.startsWith(item.path);
+                return (
+                  <Link
+                    key={item.path}
+                    to={item.path}
+                    className={`
+                      relative flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-300
+                      ${
+                        isActive
+                          ? 'text-white'
+                          : 'text-slate-400 hover:text-white hover:bg-slate-800/50'
+                      }
+                    `}
+                  >
+                    {isActive && (
+                      <div className="absolute inset-0 bg-gradient-to-r from-emerald-500/20 to-teal-500/20 rounded-xl border border-emerald-500/30" />
+                    )}
+                    <Icon
+                      className={`w-4 h-4 relative z-10 ${isActive ? 'text-emerald-400' : ''}`}
+                    />
+                    <span className="relative z-10">{t(item.labelKey)}</span>
+                  </Link>
+                );
+              })
+            )}
           </div>
 
           {/* Right section */}
@@ -204,8 +287,10 @@ export function Navbar({ onMobileMenuToggle, mobileMenuOpen }: NavbarProps) {
         <div className="md:hidden bg-slate-900/95 backdrop-blur-xl border-t border-slate-700/50">
           <div className="px-4 py-6 space-y-4">
             {/* Mobile navigation items */}
-            {user
-              ? allNavItems.map((item) => {
+            {user ? (
+              <>
+                {/* Regular nav items */}
+                {filteredNavItems.map((item) => {
                   const Icon = item.icon;
                   const isActive = location.pathname === item.path;
                   return (
@@ -214,41 +299,76 @@ export function Navbar({ onMobileMenuToggle, mobileMenuOpen }: NavbarProps) {
                       to={item.path}
                       onClick={onMobileMenuToggle}
                       className={`
-                      flex items-center gap-3 px-4 py-3 rounded-xl text-base font-medium transition-all duration-300
-                      ${
-                        isActive
-                          ? 'bg-gradient-to-r from-emerald-500/20 to-teal-500/20 text-white border border-emerald-500/30'
-                          : 'text-slate-400 hover:text-white hover:bg-slate-800/50'
-                      }
-                    `}
-                    >
-                      <Icon className={`w-5 h-5 ${isActive ? 'text-emerald-400' : ''}`} />
-                      {t(item.labelKey)}
-                    </Link>
-                  );
-                })
-              : PUBLIC_NAV_ITEMS.map((item) => {
-                  const Icon = item.icon;
-                  const isActive = location.pathname.startsWith(item.path);
-                  return (
-                    <Link
-                      key={item.path}
-                      to={item.path}
-                      onClick={onMobileMenuToggle}
-                      className={`
-                      flex items-center gap-3 px-4 py-3 rounded-xl text-base font-medium transition-all duration-300
-                      ${
-                        isActive
-                          ? 'bg-gradient-to-r from-emerald-500/20 to-teal-500/20 text-white border border-emerald-500/30'
-                          : 'text-slate-400 hover:text-white hover:bg-slate-800/50'
-                      }
-                    `}
+                        flex items-center gap-3 px-4 py-3 rounded-xl text-base font-medium transition-all duration-300
+                        ${
+                          isActive
+                            ? 'bg-gradient-to-r from-emerald-500/20 to-teal-500/20 text-white border border-emerald-500/30'
+                            : 'text-slate-400 hover:text-white hover:bg-slate-800/50'
+                        }
+                      `}
                     >
                       <Icon className={`w-5 h-5 ${isActive ? 'text-emerald-400' : ''}`} />
                       {t(item.labelKey)}
                     </Link>
                   );
                 })}
+
+                {/* Admin section — only for admin users */}
+                {isAdmin && (
+                  <div className="pt-3 border-t border-slate-700/50">
+                    <p className="px-4 py-2 text-xs font-semibold text-slate-500 uppercase tracking-wider flex items-center gap-2">
+                      <Shield className="w-3.5 h-3.5" />
+                      {t('nav.administration')}
+                    </p>
+                    {ADMIN_DROPDOWN_ITEMS.map((item) => {
+                      const Icon = item.icon;
+                      const isActive = location.pathname === item.path;
+                      return (
+                        <Link
+                          key={item.path}
+                          to={item.path}
+                          onClick={onMobileMenuToggle}
+                          className={`
+                              flex items-center gap-3 px-4 py-3 rounded-xl text-base font-medium transition-all duration-300
+                              ${
+                                isActive
+                                  ? 'bg-gradient-to-r from-emerald-500/20 to-teal-500/20 text-white border border-emerald-500/30'
+                                  : 'text-slate-400 hover:text-white hover:bg-slate-800/50'
+                              }
+                            `}
+                        >
+                          <Icon className={`w-5 h-5 ${isActive ? 'text-emerald-400' : ''}`} />
+                          {t(item.labelKey)}
+                        </Link>
+                      );
+                    })}
+                  </div>
+                )}
+              </>
+            ) : (
+              PUBLIC_NAV_ITEMS.map((item) => {
+                const Icon = item.icon;
+                const isActive = location.pathname.startsWith(item.path);
+                return (
+                  <Link
+                    key={item.path}
+                    to={item.path}
+                    onClick={onMobileMenuToggle}
+                    className={`
+                      flex items-center gap-3 px-4 py-3 rounded-xl text-base font-medium transition-all duration-300
+                      ${
+                        isActive
+                          ? 'bg-gradient-to-r from-emerald-500/20 to-teal-500/20 text-white border border-emerald-500/30'
+                          : 'text-slate-400 hover:text-white hover:bg-slate-800/50'
+                      }
+                    `}
+                  >
+                    <Icon className={`w-5 h-5 ${isActive ? 'text-emerald-400' : ''}`} />
+                    {t(item.labelKey)}
+                  </Link>
+                );
+              })
+            )}
 
             {/* Mobile auth buttons */}
             <div className="pt-4 border-t border-slate-700/50">

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -116,6 +116,11 @@
     "profile": "Profile",
     "admin": "Admin",
     "commissionConfig": "Commissions",
+    "adminUsers": "Users",
+    "adminProperties": "Properties",
+    "adminTours": "Tours",
+    "adminReservations": "Reservations",
+    "administration": "Administration",
     "logout": "Logout",
     "myProfile": "My Profile",
     "twoFactor": "Two-Factor Authentication",
@@ -266,7 +271,12 @@
     "activate": "Activate",
     "deactivate": "Deactivate",
     "promote": "Promote to Admin",
-    "role": "Role"
+    "role": "Role",
+    "quickAccess": "Quick Access",
+    "manageProperties": "Manage real estate properties",
+    "manageTours": "Manage tour packages",
+    "manageReservations": "Manage client reservations",
+    "manageCommissions": "Configure network commissions"
   },
   "landingPages": {
     "title": "Landing Pages",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -112,6 +112,11 @@
     "profile": "Perfil",
     "admin": "Admin",
     "commissionConfig": "Comisiones",
+    "adminUsers": "Usuarios",
+    "adminProperties": "Propiedades",
+    "adminTours": "Tours",
+    "adminReservations": "Reservas",
+    "administration": "Administración",
     "logout": "Cerrar Sesión",
     "myProfile": "Mi Perfil",
     "twoFactor": "Autenticación en 2 Pasos",
@@ -262,7 +267,12 @@
     "activate": "Activar",
     "deactivate": "Desactivar",
     "promote": "Hacer Admin",
-    "role": "Rol"
+    "role": "Rol",
+    "quickAccess": "Acceso Rápido",
+    "manageProperties": "Gestionar propiedades inmobiliarias",
+    "manageTours": "Gestionar paquetes turísticos",
+    "manageReservations": "Gestionar reservas de clientes",
+    "manageCommissions": "Configurar comisiones de la red"
   },
   "landingPages": {
     "title": "Landing Pages",

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -1,7 +1,22 @@
+/**
+ * AdminDashboard - Panel principal de administración con acceso rápido a sub-páginas.
+ *
+ * AdminDashboard - Main admin panel with quick-access cards to sub-pages.
+ *
+ * @module pages/AdminDashboard
+ */
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, Crown, RefreshCw } from 'lucide-react';
+import {
+  ArrowLeft,
+  Crown,
+  RefreshCw,
+  Building2,
+  MapPin,
+  CalendarDays,
+  DollarSign,
+} from 'lucide-react';
 import { adminService } from '../services/api';
 import { StatsOverview, UserFilters, UsersTable } from '../components/admin';
 
@@ -15,6 +30,42 @@ interface UserData {
   referralCode: string;
   createdAt: string;
 }
+
+/** Quick-access cards for admin sub-pages / Tarjetas de acceso rápido a sub-páginas admin */
+const QUICK_ACCESS_CARDS = [
+  {
+    path: '/admin/properties',
+    titleKey: 'nav.adminProperties',
+    descriptionKey: 'admin.manageProperties',
+    icon: Building2,
+    gradient: 'from-blue-500 to-indigo-500',
+    shadow: 'shadow-blue-500/25',
+  },
+  {
+    path: '/admin/tours',
+    titleKey: 'nav.adminTours',
+    descriptionKey: 'admin.manageTours',
+    icon: MapPin,
+    gradient: 'from-emerald-500 to-teal-500',
+    shadow: 'shadow-emerald-500/25',
+  },
+  {
+    path: '/admin/reservations',
+    titleKey: 'nav.adminReservations',
+    descriptionKey: 'admin.manageReservations',
+    icon: CalendarDays,
+    gradient: 'from-purple-500 to-pink-500',
+    shadow: 'shadow-purple-500/25',
+  },
+  {
+    path: '/admin/commissions',
+    titleKey: 'nav.commissionConfig',
+    descriptionKey: 'admin.manageCommissions',
+    icon: DollarSign,
+    gradient: 'from-amber-500 to-orange-500',
+    shadow: 'shadow-amber-500/25',
+  },
+];
 
 export default function AdminDashboard() {
   const { t } = useTranslation();
@@ -92,6 +143,34 @@ export default function AdminDashboard() {
             <h1 className="text-2xl font-bold text-slate-900">{t('admin.title')}</h1>
             <p className="text-slate-500 text-sm">{t('admin.subtitle')}</p>
           </div>
+        </div>
+      </div>
+
+      {/* Quick Access Cards */}
+      <div>
+        <h2 className="text-lg font-semibold text-slate-900 mb-3">{t('admin.quickAccess')}</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {QUICK_ACCESS_CARDS.map((card) => {
+            const Icon = card.icon;
+            return (
+              <Link
+                key={card.path}
+                to={card.path}
+                className={`
+                  group relative overflow-hidden rounded-xl bg-white border border-slate-200 p-5
+                  hover:shadow-lg ${card.shadow} transition-all duration-300 hover:-translate-y-0.5
+                `}
+              >
+                <div
+                  className={`w-10 h-10 bg-gradient-to-br ${card.gradient} rounded-lg flex items-center justify-center mb-3 group-hover:scale-110 transition-transform duration-300`}
+                >
+                  <Icon className="w-5 h-5 text-white" />
+                </div>
+                <h3 className="text-sm font-semibold text-slate-900 mb-1">{t(card.titleKey)}</h3>
+                <p className="text-xs text-slate-500 leading-relaxed">{t(card.descriptionKey)}</p>
+              </Link>
+            );
+          })}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Resolves #155 — Admin CRUD pages (Properties, Tours, Reservations) already existed as full implementations but were unreachable because no navigation links pointed to them.

### Changes

- **Navbar (desktop)**: Replaced flat `ADMIN_ITEMS` with a Radix `DropdownMenu` containing 5 grouped admin links (Users, Commissions, Properties, Tours, Reservations) with dark glass morphism styling and active-route highlighting
- **MobileMenu**: Added a visually separated admin section with label (`Administración` / `Administration`) and all 5 admin links
- **AdminDashboard**: Added quick-access card grid with gradient icons linking to Properties, Tours, Reservations, and Commissions sub-pages
- **i18n**: Added translation keys for admin navigation in both `es.json` and `en.json`
- **Type safety**: Replaced `as any` casts with `as { role?: string }` in MobileMenu

### Why a dropdown?

The navbar already had 8 regular items + 2 admin items = 10 flat links. Adding 3 more would be 13 — impossible for usability. A single "Administración" dropdown groups all admin links cleanly.

### Verification

- ✅ `pnpm tsc -b` — zero errors
- ✅ `pnpm test` — 467/467 tests passed (35 files)
- No new dependencies added (uses existing `shadcn/dropdown-menu` + Radix)

### Screenshots

_Admin dropdown and quick-access cards — please verify visually on review._