### PR TITLE
feat(ui): UX polish for purchase and reservation flows (#159)

### DIFF
--- a/frontend/src/__tests__/components/CartRecoveryNotif.test.tsx
+++ b/frontend/src/__tests__/components/CartRecoveryNotif.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview CartRecoveryNotif Sonner migration tests / Tests de migración a Sonner
+ * @description Validates showCartRecoveryToast calls Sonner's toast() with correct args
+ *              Verifica que showCartRecoveryToast llama a toast() de Sonner correctamente
+ * @module __tests__/components/CartRecoveryNotif.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.hoisted runs BEFORE vi.mock hoisting — safe reference for factory
+const { mockToast } = vi.hoisted(() => ({
+  mockToast: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: mockToast,
+}));
+
+// Import AFTER mocking
+import { showCartRecoveryToast } from '../../components/Cart/CartRecoveryNotif';
+
+describe('CartRecoveryNotif — Sonner migration (T1.3)', () => {
+  beforeEach(() => {
+    mockToast.mockClear();
+  });
+
+  it('calls toast() with title, description, and resume action', () => {
+    const onResume = vi.fn();
+    const onDismiss = vi.fn();
+
+    showCartRecoveryToast({
+      itemCount: 3,
+      totalAmount: 150.5,
+      onResume,
+      onDismiss,
+    });
+
+    expect(mockToast).toHaveBeenCalledTimes(1);
+
+    const [title, options] = mockToast.mock.calls[0];
+    expect(typeof title).toBe('string');
+    expect(title.length).toBeGreaterThan(0);
+
+    // Must have a description containing item count
+    expect(options.description).toContain('3');
+
+    // Must have an action button
+    expect(options.action).toBeDefined();
+    expect(options.action.label).toBeDefined();
+    expect(typeof options.action.onClick).toBe('function');
+
+    // Clicking the action should call onResume
+    options.action.onClick();
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls toast() with singular "item" for count=1', () => {
+    const onResume = vi.fn();
+    const onDismiss = vi.fn();
+
+    showCartRecoveryToast({
+      itemCount: 1,
+      totalAmount: 49.99,
+      onResume,
+      onDismiss,
+    });
+
+    expect(mockToast).toHaveBeenCalledTimes(1);
+    const [, options] = mockToast.mock.calls[0];
+    expect(options.description).toContain('1');
+    // Should say "item" not "items" for singular
+    expect(options.description).toContain('item');
+    expect(options.description).not.toContain('items');
+  });
+
+  it('passes onDismiss callback to the toast', () => {
+    const onResume = vi.fn();
+    const onDismiss = vi.fn();
+
+    showCartRecoveryToast({
+      itemCount: 2,
+      totalAmount: 100,
+      onResume,
+      onDismiss,
+    });
+
+    const [, options] = mockToast.mock.calls[0];
+    expect(options.onDismiss).toBe(onDismiss);
+  });
+});

--- a/frontend/src/__tests__/components/EmptyState.test.tsx
+++ b/frontend/src/__tests__/components/EmptyState.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview EmptyState component tests / Tests del componente EmptyState
+ * @description Validates EmptyState renders shadcn Button (not raw <button>)
+ *              and correctly wires onAction callback
+ * @module __tests__/components/EmptyState.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EmptyState } from '../../components/EmptyState';
+
+describe('EmptyState — shadcn Button migration (T1.2)', () => {
+  it('renders shadcn Button (not raw <button>) when actionLabel + onAction provided', () => {
+    const onAction = vi.fn();
+    const { container } = render(
+      <EmptyState
+        type="default"
+        title="No hay datos"
+        actionLabel="Reintentar"
+        onAction={onAction}
+      />
+    );
+
+    // shadcn Button renders a <button> element internally,
+    // but it should NOT have the old inline color classes
+    const button = screen.getByRole('button', { name: 'Reintentar' });
+    expect(button).toBeInTheDocument();
+
+    // OLD inline classes should be GONE (bg-purple-600, hover:bg-purple-500)
+    expect(button.className).not.toContain('bg-purple-600');
+    expect(button.className).not.toContain('hover:bg-purple-500');
+
+    // The container should NOT have raw <button> elements
+    // with the old styling — the button should come from the Button component
+    // which adds the data-slot="button" attribute (shadcn convention) or
+    // at minimum uses buttonVariants classes
+    // Verify it's NOT a raw styled button by checking no focus:ring-purple classes
+    expect(button.className).not.toContain('focus:ring-purple-500');
+  });
+
+  it('calls onAction when the button is clicked', () => {
+    const onAction = vi.fn();
+    render(<EmptyState type="error" title="Error" actionLabel="Retry" onAction={onAction} />);
+
+    const button = screen.getByRole('button', { name: 'Retry' });
+    fireEvent.click(button);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT render a button when actionLabel or onAction is missing', () => {
+    render(<EmptyState type="default" title="No data" />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/EmptyState.test.tsx
+++ b/frontend/src/__tests__/components/EmptyState.test.tsx
@@ -1,18 +1,22 @@
 /**
  * @fileoverview EmptyState component tests / Tests del componente EmptyState
- * @description Validates EmptyState renders shadcn Button (not raw <button>)
- *              and correctly wires onAction callback
+ * @description Validates EmptyState renders shadcn Button (not raw <button>),
+ *              wires onAction callback, supports new types (cart, reservation, order),
+ *              and supports actionHref with Link navigation
  * @module __tests__/components/EmptyState.test
  */
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { EmptyState } from '../../components/EmptyState';
+
+/* ─────────────────── Phase 1 Tests (T1.2 — existing) ─────────────────── */
 
 describe('EmptyState — shadcn Button migration (T1.2)', () => {
   it('renders shadcn Button (not raw <button>) when actionLabel + onAction provided', () => {
     const onAction = vi.fn();
-    const { container } = render(
+    render(
       <EmptyState
         type="default"
         title="No hay datos"
@@ -21,20 +25,12 @@ describe('EmptyState — shadcn Button migration (T1.2)', () => {
       />
     );
 
-    // shadcn Button renders a <button> element internally,
-    // but it should NOT have the old inline color classes
     const button = screen.getByRole('button', { name: 'Reintentar' });
     expect(button).toBeInTheDocument();
 
-    // OLD inline classes should be GONE (bg-purple-600, hover:bg-purple-500)
+    // OLD inline classes should be GONE
     expect(button.className).not.toContain('bg-purple-600');
     expect(button.className).not.toContain('hover:bg-purple-500');
-
-    // The container should NOT have raw <button> elements
-    // with the old styling — the button should come from the Button component
-    // which adds the data-slot="button" attribute (shadcn convention) or
-    // at minimum uses buttonVariants classes
-    // Verify it's NOT a raw styled button by checking no focus:ring-purple classes
     expect(button.className).not.toContain('focus:ring-purple-500');
   });
 
@@ -50,6 +46,98 @@ describe('EmptyState — shadcn Button migration (T1.2)', () => {
   it('does NOT render a button when actionLabel or onAction is missing', () => {
     render(<EmptyState type="default" title="No data" />);
 
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});
+
+/* ─────────────────── Phase 2 Tests (T2.2 — new types) ─────────────────── */
+
+describe('EmptyState — new types: cart, reservation, order (T2.2)', () => {
+  it('renders cart type with shopping cart icon and i18n defaults', () => {
+    render(<EmptyState type="cart" />);
+
+    // Should render the i18n default title for cart
+    expect(screen.getByText('Tu carrito está vacío')).toBeInTheDocument();
+    expect(
+      screen.getByText('Explorá tours y propiedades disponibles para comenzar.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders reservation type with calendar icon and i18n defaults', () => {
+    render(<EmptyState type="reservation" />);
+
+    expect(screen.getByText('No tenés reservas todavía')).toBeInTheDocument();
+    expect(
+      screen.getByText('Explorá propiedades y tours disponibles para hacer tu primera reserva.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders order type with receipt icon and i18n defaults', () => {
+    render(<EmptyState type="order" />);
+
+    expect(screen.getByText('No tenés órdenes todavía')).toBeInTheDocument();
+    expect(
+      screen.getByText('Tus compras aparecerán aquí cuando realices tu primera orden.')
+    ).toBeInTheDocument();
+  });
+
+  it('allows custom title/description to override i18n defaults for new types', () => {
+    render(<EmptyState type="cart" title="Custom Title" description="Custom Desc" />);
+
+    expect(screen.getByText('Custom Title')).toBeInTheDocument();
+    expect(screen.getByText('Custom Desc')).toBeInTheDocument();
+    // The default cart title should NOT appear
+    expect(screen.queryByText('Tu carrito está vacío')).not.toBeInTheDocument();
+  });
+});
+
+/* ─────────────────── Phase 2 Tests (T2.2 — actionHref) ─────────────────── */
+
+describe('EmptyState — actionHref navigation (T2.2)', () => {
+  it('renders a link (not button callback) when actionHref is provided', () => {
+    render(
+      <MemoryRouter>
+        <EmptyState type="cart" actionLabel="Explorar tours" actionHref="/tours" />
+      </MemoryRouter>
+    );
+
+    // Should render a link element navigating to /tours
+    const link = screen.getByRole('link', { name: 'Explorar tours' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/tours');
+  });
+
+  it('renders onAction button (not link) when onAction is provided without actionHref', () => {
+    const onAction = vi.fn();
+    render(<EmptyState type="reservation" actionLabel="Buscar" onAction={onAction} />);
+
+    // Should be a button, NOT a link
+    expect(screen.getByRole('button', { name: 'Buscar' })).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('prefers actionHref over onAction when both are provided', () => {
+    const onAction = vi.fn();
+    render(
+      <MemoryRouter>
+        <EmptyState type="order" actionLabel="Ver tienda" actionHref="/tours" onAction={onAction} />
+      </MemoryRouter>
+    );
+
+    // actionHref takes precedence — renders a link, not a button
+    const link = screen.getByRole('link', { name: 'Ver tienda' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/tours');
+  });
+
+  it('does NOT render action when only actionHref is present without actionLabel', () => {
+    render(
+      <MemoryRouter>
+        <EmptyState type="cart" actionHref="/tours" />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/components/skeletons/ListingSkeleton.test.tsx
+++ b/frontend/src/__tests__/components/skeletons/ListingSkeleton.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview ListingSkeleton tests / Tests del esqueleto de listado
+ * @description Validates ListingSkeleton renders correct variant (tour | property)
+ *              with configurable count, in a responsive grid layout
+ * @module __tests__/components/skeletons/ListingSkeleton.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ListingSkeleton } from '../../../components/ui/skeletons';
+
+describe('ListingSkeleton (T2.4)', () => {
+  it('renders 4 tour card skeletons by default (count=4, variant=tour)', () => {
+    render(<ListingSkeleton variant="tour" />);
+
+    const articles = screen.getAllByRole('article');
+    expect(articles).toHaveLength(4);
+  });
+
+  it('renders the specified count of tour card skeletons', () => {
+    render(<ListingSkeleton variant="tour" count={6} />);
+
+    const articles = screen.getAllByRole('article');
+    expect(articles).toHaveLength(6);
+  });
+
+  it('renders property card skeletons when variant is "property"', () => {
+    render(<ListingSkeleton variant="property" count={3} />);
+
+    const articles = screen.getAllByRole('article');
+    expect(articles).toHaveLength(3);
+
+    // Property cards have 3 spec placeholders (beds, baths, area) in their specs row
+    // Tour cards have 2 (duration, capacity) — verify the structure differs
+    // Each article should have skeleton zones
+    articles.forEach((article) => {
+      expect(article.querySelector('[data-testid="skeleton-image"]')).toBeTruthy();
+      expect(article.querySelector('[data-testid="skeleton-title"]')).toBeTruthy();
+    });
+  });
+
+  it('renders inside a responsive grid container', () => {
+    const { container } = render(<ListingSkeleton variant="tour" count={2} />);
+
+    // The wrapper grid should have the responsive classes
+    const grid = container.firstElementChild;
+    expect(grid).toBeTruthy();
+    expect(grid!.className).toContain('grid');
+  });
+
+  it('accepts and applies className to the grid container', () => {
+    const { container } = render(
+      <ListingSkeleton variant="tour" count={1} className="extra-class" />
+    );
+
+    const grid = container.firstElementChild;
+    expect(grid!.className).toContain('extra-class');
+  });
+});

--- a/frontend/src/__tests__/components/skeletons/PropertyCardSkeleton.test.tsx
+++ b/frontend/src/__tests__/components/skeletons/PropertyCardSkeleton.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview PropertyCardSkeleton tests / Tests del esqueleto de PropertyCard
+ * @description Validates PropertyCardSkeleton mirrors PropertyCard layout structure
+ *              with Skeleton primitives (image, title, location, specs, price+cta)
+ * @module __tests__/components/skeletons/PropertyCardSkeleton.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PropertyCardSkeleton } from '../../../components/ui/skeletons/PropertyCardSkeleton';
+
+describe('PropertyCardSkeleton (T2.3)', () => {
+  it('renders an article element matching PropertyCard outer structure', () => {
+    render(<PropertyCardSkeleton />);
+
+    const article = screen.getByRole('article');
+    expect(article).toBeInTheDocument();
+  });
+
+  it('renders skeleton zones for image, title, location, specs, and price areas', () => {
+    const { container } = render(<PropertyCardSkeleton />);
+
+    // Image skeleton
+    const imageSkeleton = container.querySelector('[data-testid="skeleton-image"]');
+    expect(imageSkeleton).toBeInTheDocument();
+
+    // Title skeleton
+    const titleSkeleton = container.querySelector('[data-testid="skeleton-title"]');
+    expect(titleSkeleton).toBeInTheDocument();
+
+    // Location skeleton
+    const locationSkeleton = container.querySelector('[data-testid="skeleton-location"]');
+    expect(locationSkeleton).toBeInTheDocument();
+
+    // Specs row skeleton (bedrooms, bathrooms, area for properties)
+    const specsSkeleton = container.querySelector('[data-testid="skeleton-specs"]');
+    expect(specsSkeleton).toBeInTheDocument();
+
+    // Price skeleton
+    const priceSkeleton = container.querySelector('[data-testid="skeleton-price"]');
+    expect(priceSkeleton).toBeInTheDocument();
+  });
+
+  it('accepts and applies className prop', () => {
+    render(<PropertyCardSkeleton className="custom-class" />);
+
+    const article = screen.getByRole('article');
+    expect(article.className).toContain('custom-class');
+  });
+});

--- a/frontend/src/__tests__/components/skeletons/TourCardSkeleton.test.tsx
+++ b/frontend/src/__tests__/components/skeletons/TourCardSkeleton.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview TourCardSkeleton tests / Tests del esqueleto de TourCard
+ * @description Validates TourCardSkeleton mirrors TourCard layout structure
+ *              with Skeleton primitives (image, title, location, specs, price+cta)
+ * @module __tests__/components/skeletons/TourCardSkeleton.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TourCardSkeleton } from '../../../components/ui/skeletons/TourCardSkeleton';
+
+describe('TourCardSkeleton (T2.3)', () => {
+  it('renders an article element matching TourCard outer structure', () => {
+    render(<TourCardSkeleton />);
+
+    const article = screen.getByRole('article');
+    expect(article).toBeInTheDocument();
+  });
+
+  it('renders skeleton zones for image, title, location, specs, and price areas', () => {
+    const { container } = render(<TourCardSkeleton />);
+
+    // The image skeleton should have h-52 matching the real card image container
+    const imageSkeleton = container.querySelector('[data-testid="skeleton-image"]');
+    expect(imageSkeleton).toBeInTheDocument();
+
+    // Title skeleton
+    const titleSkeleton = container.querySelector('[data-testid="skeleton-title"]');
+    expect(titleSkeleton).toBeInTheDocument();
+
+    // Location skeleton
+    const locationSkeleton = container.querySelector('[data-testid="skeleton-location"]');
+    expect(locationSkeleton).toBeInTheDocument();
+
+    // Specs row skeleton (duration + capacity for tours)
+    const specsSkeleton = container.querySelector('[data-testid="skeleton-specs"]');
+    expect(specsSkeleton).toBeInTheDocument();
+
+    // Price skeleton
+    const priceSkeleton = container.querySelector('[data-testid="skeleton-price"]');
+    expect(priceSkeleton).toBeInTheDocument();
+  });
+
+  it('accepts and applies className prop', () => {
+    render(<TourCardSkeleton className="my-custom-class" />);
+
+    const article = screen.getByRole('article');
+    expect(article.className).toContain('my-custom-class');
+  });
+});

--- a/frontend/src/__tests__/pages/Checkout.buttons.test.tsx
+++ b/frontend/src/__tests__/pages/Checkout.buttons.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * @fileoverview Checkout button migration tests / Tests de migración de botones en Checkout
+ * @description Validates all raw <button> elements are replaced with shadcn <Button>.
+ *              Payment CTA must have Lock icon. Confirm/Cancel modal uses default/outline pair.
+ *              Verifica migración de botones y que el CTA de pago tenga ícono Lock.
+ * @module __tests__/pages/Checkout.buttons.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('../../services/api', () => ({
+  orderService: {
+    createOrder: vi.fn().mockResolvedValue({ id: 'order-1' }),
+  },
+  productService: {
+    getProduct: vi.fn().mockResolvedValue({
+      id: 'prod-1',
+      name: 'Test Product',
+      price: 299.99,
+      currency: 'USD',
+      durationDays: 30,
+      isActive: true,
+      description: 'A test product',
+    }),
+  },
+}));
+
+vi.mock('../../components/OrderSummary', () => ({
+  OrderSummary: () => <div data-testid="order-summary">Order Summary</div>,
+}));
+
+vi.mock('../../components/CheckoutForm', () => ({
+  CheckoutForm: ({ onSubmit }: { onSubmit: (method: string) => void }) => (
+    <div data-testid="checkout-form">
+      <button onClick={() => onSubmit('simulated')} data-testid="mock-pay-btn">
+        Pay
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../../components/EmptyState', () => ({
+  EmptyState: ({ title, onAction }: { title: string; onAction?: () => void }) => (
+    <div data-testid="empty-state">{title}</div>
+  ),
+}));
+
+import Checkout from '../../pages/Checkout';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderCheckout() {
+  return render(
+    <MemoryRouter initialEntries={['/checkout/prod-1']}>
+      <Routes>
+        <Route path="/checkout/:productId" element={<Checkout />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Checkout — Button migration (T1.7)', () => {
+  it('renders NO raw <button> — all buttons use shadcn Button component', async () => {
+    const { container } = renderCheckout();
+
+    // Wait for product to load — t('checkout.title') → 'Checkout'
+    await screen.findByText('Checkout');
+
+    const allButtons = container.querySelectorAll('button');
+    const shadcnBaseFragment = 'ring-offset-background';
+
+    // Filter out buttons inside mocked components (data-testid="mock-pay-btn")
+    const realButtons = Array.from(allButtons).filter(
+      (btn) => !btn.dataset.testid?.startsWith('mock-')
+    );
+
+    expect(realButtons.length).toBeGreaterThan(0);
+    realButtons.forEach((btn) => {
+      expect(
+        btn.className.includes(shadcnBaseFragment),
+        `Button "${btn.textContent?.trim()}" is missing shadcn buttonVariants class`
+      ).toBe(true);
+    });
+  });
+
+  it('back button uses ghost variant (icon button) with size="icon"', async () => {
+    const { container } = renderCheckout();
+    await screen.findByText('Checkout');
+
+    // The back button renders an ArrowLeft icon
+    const backBtn = container.querySelector('button svg.lucide-arrow-left')?.closest('button');
+    expect(backBtn).toBeTruthy();
+    expect(backBtn!.className).toContain('ring-offset-background');
+  });
+
+  it('modal confirm uses default variant and cancel uses outline variant', async () => {
+    const { container } = renderCheckout();
+    await screen.findByText('Checkout');
+
+    // Trigger modal by clicking the mocked pay button
+    const mockPayBtn = screen.getByTestId('mock-pay-btn');
+    fireEvent.click(mockPayBtn);
+
+    // Wait for modal to appear — header shows translated 'Confirmar compra'
+    await screen.findByRole('heading', { name: /confirmar compra/i });
+
+    // Confirm button should have bg-primary (default variant)
+    // The button text also contains 'Confirmar compra' from t('checkout.confirmPurchase')
+    const confirmBtn = screen
+      .getAllByRole('button')
+      .find(
+        (btn) =>
+          btn.textContent?.includes('Confirmar compra') && btn.className.includes('bg-primary')
+      );
+    expect(confirmBtn).toBeTruthy();
+    expect(confirmBtn!.className).toContain('bg-primary');
+
+    // Cancel button should have border (outline variant) — t('common.cancel') → 'Cancelar'
+    const cancelBtn = screen.getByRole('button', { name: /cancelar/i });
+    expect(cancelBtn.className).toContain('border');
+  });
+
+  it('modal confirm button has Lock icon for secure payment', async () => {
+    const { container } = renderCheckout();
+    await screen.findByText('Checkout');
+
+    // Trigger modal
+    fireEvent.click(screen.getByTestId('mock-pay-btn'));
+    await screen.findByRole('heading', { name: /confirmar compra/i });
+
+    // Find the confirm purchase button and check for Lock SVG
+    const confirmBtn = screen
+      .getAllByRole('button')
+      .find(
+        (btn) =>
+          btn.textContent?.includes('Confirmar compra') && btn.className.includes('bg-primary')
+      );
+    expect(confirmBtn).toBeTruthy();
+    const lockIcon = confirmBtn!.querySelector('svg.lucide-lock');
+    expect(lockIcon).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/pages/Checkout.loading.test.tsx
+++ b/frontend/src/__tests__/pages/Checkout.loading.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview Checkout payment loading overlay tests / Tests del overlay de carga de pago
+ * @description Validates the payment processing overlay appears when isSubmitting is true,
+ *              shows Loader2 spinner and loading.processingPayment text.
+ *              Verifica que el overlay de procesamiento aparezca con spinner y texto i18n.
+ * @module __tests__/pages/Checkout.loading.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+// Never-resolving createOrder keeps isSubmitting stuck at true
+const mockCreateOrder = vi.fn().mockImplementation(() => new Promise(() => {}));
+
+vi.mock('../../services/api', () => ({
+  orderService: {
+    createOrder: (...args: unknown[]) => mockCreateOrder(...args),
+  },
+  productService: {
+    getProduct: vi.fn().mockResolvedValue({
+      id: 'prod-1',
+      name: 'Test Product',
+      price: 299.99,
+      currency: 'USD',
+      durationDays: 30,
+      isActive: true,
+      description: 'A test product',
+    }),
+  },
+}));
+
+vi.mock('../../components/OrderSummary', () => ({
+  OrderSummary: () => <div data-testid="order-summary">Order Summary</div>,
+}));
+
+vi.mock('../../components/CheckoutForm', () => ({
+  CheckoutForm: ({
+    onSubmit,
+    isProcessing,
+  }: {
+    onSubmit: (method: string) => void;
+    isProcessing: boolean;
+  }) => (
+    <div data-testid="checkout-form">
+      <button onClick={() => onSubmit('simulated')} data-testid="mock-pay-btn">
+        Pay
+      </button>
+      {isProcessing && <span data-testid="form-processing-indicator">Processing</span>}
+    </div>
+  ),
+}));
+
+vi.mock('../../components/EmptyState', () => ({
+  EmptyState: ({ title }: { title: string }) => <div data-testid="empty-state">{title}</div>,
+}));
+
+import Checkout from '../../pages/Checkout';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderCheckout() {
+  return render(
+    <MemoryRouter initialEntries={['/checkout/prod-1']}>
+      <Routes>
+        <Route path="/checkout/:productId" element={<Checkout />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Checkout — Payment loading overlay (T3.5)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does NOT show payment overlay when not submitting', async () => {
+    renderCheckout();
+
+    await screen.findByText('Checkout');
+
+    const overlay = screen.queryByTestId('payment-loading-overlay');
+    expect(overlay).toBeNull();
+  });
+
+  it('payment form container has relative class for overlay positioning', async () => {
+    const { container } = renderCheckout();
+
+    await screen.findByText('Checkout');
+
+    // The parent of checkout-form should have 'relative' class
+    const checkoutForm = screen.getByTestId('checkout-form');
+    const parent = checkoutForm.parentElement;
+    expect(parent).toBeTruthy();
+    expect(parent!.className).toContain('relative');
+  });
+
+  it('shows payment loading overlay after confirming purchase', async () => {
+    renderCheckout();
+
+    await screen.findByText('Checkout');
+
+    // Trigger the payment flow — mock CheckoutForm calls onSubmit('simulated')
+    const payBtn = screen.getByTestId('mock-pay-btn');
+    fireEvent.click(payBtn);
+
+    // The Checkout component shows a confirm modal after onSubmit
+    // Then clicking confirm triggers handleConfirmPurchase → sets isSubmitting
+    // Find the confirm button in the modal
+    await waitFor(() => {
+      const confirmButtons = screen.getAllByText('Confirmar compra');
+      expect(confirmButtons.length).toBeGreaterThan(0);
+    });
+
+    // Click the action button (not the heading)
+    const allConfirmElements = screen.getAllByText('Confirmar compra');
+    const confirmButton = allConfirmElements.find(
+      (el) => el.tagName === 'BUTTON' || el.closest('button')
+    );
+
+    if (confirmButton) {
+      const btn =
+        confirmButton.tagName === 'BUTTON' ? confirmButton : confirmButton.closest('button')!;
+      fireEvent.click(btn);
+
+      // isSubmitting becomes true, overlay should appear
+      await waitFor(() => {
+        const overlay = screen.queryByTestId('payment-loading-overlay');
+        expect(overlay).toBeTruthy();
+      });
+
+      // Overlay has the loading text
+      await waitFor(() => {
+        expect(screen.getByText('Procesando pago...')).toBeTruthy();
+      });
+    }
+  });
+});

--- a/frontend/src/__tests__/pages/Checkout.mobile.test.tsx
+++ b/frontend/src/__tests__/pages/Checkout.mobile.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview Checkout mobile responsive tests / Tests de responsividad móvil del Checkout
+ * @description Validates mobile column stacking and responsive payment method grid.
+ *              Verifica apilamiento de columnas en móvil y grilla responsiva de métodos de pago.
+ * @module __tests__/pages/Checkout.mobile.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('../../services/api', () => ({
+  orderService: {
+    createOrder: vi.fn().mockResolvedValue({ id: 'order-1' }),
+  },
+  productService: {
+    getProduct: vi.fn().mockResolvedValue({
+      id: 'prod-1',
+      name: 'Test Product',
+      price: 299.99,
+      currency: 'USD',
+      durationDays: 30,
+      isActive: true,
+      description: 'A test product',
+    }),
+  },
+}));
+
+vi.mock('../../components/OrderSummary', () => ({
+  OrderSummary: () => <div data-testid="order-summary">Order Summary</div>,
+}));
+
+vi.mock('../../components/CheckoutForm', () => ({
+  CheckoutForm: ({
+    isProcessing,
+  }: {
+    onSubmit: (method: string) => void;
+    isProcessing: boolean;
+  }) => (
+    <div data-testid="checkout-form" data-processing={isProcessing}>
+      <div className="grid gap-3 sm:grid-cols-2" data-testid="payment-methods-grid">
+        <label>Method 1</label>
+        <label>Method 2</label>
+      </div>
+    </div>
+  ),
+}));
+
+vi.mock('../../components/EmptyState', () => ({
+  EmptyState: ({ title }: { title: string }) => <div data-testid="empty-state">{title}</div>,
+}));
+
+import Checkout from '../../pages/Checkout';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderCheckout() {
+  return render(
+    <MemoryRouter initialEntries={['/checkout/prod-1']}>
+      <Routes>
+        <Route path="/checkout/:productId" element={<Checkout />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Checkout — Mobile responsive (T3.3)', () => {
+  it('main content grid uses grid-cols-1 with lg:grid-cols-2 for mobile stacking', async () => {
+    const { container } = renderCheckout();
+
+    await screen.findByText('Checkout');
+
+    // The main content grid
+    const mainGrid = container.querySelector('.grid.grid-cols-1.lg\\:grid-cols-2');
+    expect(mainGrid).toBeTruthy();
+  });
+
+  it('payment form container uses relative positioning for overlay support', async () => {
+    const { container } = renderCheckout();
+
+    await screen.findByText('Checkout');
+
+    // The payment form wrapper div should have relative class
+    const paymentContainer = container.querySelector('.relative');
+    expect(paymentContainer).toBeTruthy();
+
+    // It should contain the CheckoutForm
+    const checkoutForm = paymentContainer?.querySelector('[data-testid="checkout-form"]');
+    expect(checkoutForm).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/pages/MisReservasPage.buttons.test.tsx
+++ b/frontend/src/__tests__/pages/MisReservasPage.buttons.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @fileoverview MisReservasPage button migration tests / Tests de migración de botones en MisReservasPage
+ * @description Validates all raw <button> elements are replaced with shadcn <Button>
+ *              Verifica que todos los <button> crudos se reemplazaron con <Button> de shadcn
+ * @module __tests__/pages/MisReservasPage.buttons.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockFetchMyReservations = vi.fn();
+const mockCancelReservation = vi.fn();
+
+vi.mock('../../stores/reservationStore', () => ({
+  useMyReservations: () => ({
+    myReservations: [
+      {
+        id: 'res-1',
+        status: 'pending',
+        propertyId: 'prop-1',
+        property: { title: 'Beach House', city: 'Mar del Plata' },
+        tourPackage: null,
+        checkIn: '2026-05-01',
+        checkOut: '2026-05-05',
+        guests: 2,
+        totalAmount: 5000,
+        currency: 'USD',
+        createdAt: '2026-04-10',
+      },
+      {
+        id: 'res-2',
+        status: 'confirmed',
+        propertyId: null,
+        property: null,
+        tourPackageId: 'tour-1',
+        tourPackage: { title: 'Mendoza Wine Tour', destination: 'Mendoza' },
+        checkIn: undefined,
+        checkOut: undefined,
+        guests: 4,
+        totalAmount: 8000,
+        currency: 'USD',
+        createdAt: '2026-04-08',
+      },
+    ],
+    reservationsPagination: { total: 20, page: 1, limit: 8, totalPages: 3 },
+    isFetchingReservations: false,
+    reservationsError: null,
+    isCancelling: false,
+    cancelError: null,
+    fetchMyReservations: mockFetchMyReservations,
+    cancelReservation: mockCancelReservation,
+  }),
+}));
+
+import MisReservasPage from '../../pages/MisReservasPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderMisReservasPage() {
+  return render(
+    <MemoryRouter>
+      <MisReservasPage />
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('MisReservasPage — Button migration (T1.6)', () => {
+  beforeEach(() => {
+    mockFetchMyReservations.mockReset();
+    mockCancelReservation.mockReset();
+  });
+
+  it('renders NO raw <button> — all buttons use shadcn Button component', () => {
+    const { container } = renderMisReservasPage();
+
+    const allButtons = container.querySelectorAll('button');
+    const shadcnBaseFragment = 'ring-offset-background';
+
+    expect(allButtons.length).toBeGreaterThan(0);
+    allButtons.forEach((btn) => {
+      expect(
+        btn.className.includes(shadcnBaseFragment),
+        `Button "${btn.textContent?.trim()}" is missing shadcn buttonVariants class`
+      ).toBe(true);
+    });
+  });
+
+  it('filter buttons are present (5 status filters)', () => {
+    renderMisReservasPage();
+
+    const filterButtons = screen
+      .getAllByRole('button')
+      .filter((btn) =>
+        ['Todas', 'Pendientes', 'Confirmadas', 'Canceladas', 'Completadas'].includes(
+          btn.textContent?.trim() ?? ''
+        )
+      );
+    expect(filterButtons.length).toBe(5);
+  });
+
+  it('pagination buttons use outline variant (secondary action)', () => {
+    renderMisReservasPage();
+
+    const prevBtn = screen.getByRole('button', { name: /anterior/i });
+    const nextBtn = screen.getByRole('button', { name: /siguiente/i });
+
+    // outline variant has 'border' in class
+    expect(prevBtn.className).toContain('border');
+    expect(nextBtn.className).toContain('border');
+  });
+
+  it('cancel buttons on cancellable reservations use destructive variant', () => {
+    renderMisReservasPage();
+
+    // Both pending + confirmed reservations have cancel buttons
+    const cancelBtns = screen.getAllByRole('button', { name: /cancelar/i });
+    expect(cancelBtns.length).toBe(2);
+    cancelBtns.forEach((btn) => {
+      expect(btn.className).toContain('destructive');
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/OrderSuccess.buttons.test.tsx
+++ b/frontend/src/__tests__/pages/OrderSuccess.buttons.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview OrderSuccess button migration tests / Tests de migración de botones en OrderSuccess
+ * @description Validates all raw <button> elements are replaced with shadcn <Button>
+ *              Verifica que todos los <button> crudos se reemplazaron con <Button> de shadcn
+ * @module __tests__/pages/OrderSuccess.buttons.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('../../services/api', () => ({
+  orderService: {
+    getOrder: vi.fn().mockResolvedValue({
+      id: 'order-1',
+      orderNumber: 'NXR-1234',
+      status: 'completed',
+      amount: 5000,
+      currency: 'USD',
+      commissionTotal: 500,
+      items: [{ id: 'item-1', name: 'Test Product', price: 5000, quantity: 1 }],
+    }),
+  },
+  productService: {
+    getProduct: vi.fn(),
+  },
+}));
+
+vi.mock('../../components/OrderSummary', () => ({
+  OrderSummary: () => <div data-testid="order-summary">Order Summary</div>,
+}));
+
+vi.mock('../../components/OrderStatus', () => ({
+  OrderStatus: ({ status }: { status: string }) => <span data-testid="order-status">{status}</span>,
+}));
+
+import OrderSuccess from '../../pages/OrderSuccess';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderOrderSuccess() {
+  return render(
+    <MemoryRouter initialEntries={['/orders/order-1/success']}>
+      <Routes>
+        <Route path="/orders/:orderId/success" element={<OrderSuccess />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('OrderSuccess — Button migration (T1.6)', () => {
+  it('renders NO raw <button> — all buttons use shadcn Button component', async () => {
+    const { container } = renderOrderSuccess();
+
+    // Wait for order to load
+    await screen.findByText('NXR-1234');
+
+    const allButtons = container.querySelectorAll('button');
+    const shadcnBaseFragment = 'ring-offset-background';
+
+    expect(allButtons.length).toBeGreaterThan(0);
+    allButtons.forEach((btn) => {
+      expect(
+        btn.className.includes(shadcnBaseFragment),
+        `Button "${btn.textContent?.trim()}" is missing shadcn buttonVariants class`
+      ).toBe(true);
+    });
+  });
+
+  it('"Continue Shopping" uses outline variant (secondary)', async () => {
+    renderOrderSuccess();
+    await screen.findByText('NXR-1234');
+
+    const shopBtn = screen.getByRole('button', { name: /orders\.continueShopping/i });
+    expect(shopBtn.className).toContain('border');
+  });
+
+  it('"Go to Dashboard" uses default variant (primary)', async () => {
+    renderOrderSuccess();
+    await screen.findByText('NXR-1234');
+
+    const dashBtn = screen.getByRole('button', { name: /orders\.goToDashboard/i });
+    expect(dashBtn.className).toContain('bg-primary');
+  });
+
+  it('copy order number button uses ghost variant (icon action)', async () => {
+    renderOrderSuccess();
+    await screen.findByText('NXR-1234');
+
+    // The copy button is a ghost/icon button
+    const copyBtn = screen.getByTitle('common.copy');
+    expect(copyBtn.tagName).toBe('BUTTON');
+    expect(copyBtn.className).toContain('ring-offset-background');
+  });
+});

--- a/frontend/src/__tests__/pages/PropertiesPage.buttons.test.tsx
+++ b/frontend/src/__tests__/pages/PropertiesPage.buttons.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview PropertiesPage button migration tests / Tests de migración de botones en PropertiesPage
+ * @description Validates all raw <button> elements are replaced with shadcn <Button>
+ *              Verifica que todos los <button> crudos se reemplazaron con <Button> de shadcn
+ * @module __tests__/pages/PropertiesPage.buttons.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockGetProperties = vi.fn();
+vi.mock('../../services/propertyService', () => ({
+  propertyService: {
+    getProperties: (...args: unknown[]) => mockGetProperties(...args),
+  },
+}));
+
+vi.mock('react-helmet-async', () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="helmet">{children}</div>
+  ),
+}));
+
+vi.mock('../../config/app.config', () => ({
+  APP_URL: 'http://test.nexo.real',
+}));
+
+import PropertiesPage from '../../pages/PropertiesPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderPropertiesPage() {
+  return render(
+    <MemoryRouter>
+      <PropertiesPage />
+    </MemoryRouter>
+  );
+}
+
+const MOCK_PROPERTIES = [
+  {
+    id: 'prop-1',
+    title: 'Test Property Alpha',
+    address: 'Av. Libertador 1234',
+    city: 'Buenos Aires',
+    price: '250000',
+    currency: 'USD',
+    type: 'sale',
+    bedrooms: 3,
+    bathrooms: 2,
+    areaM2: 120,
+    images: ['https://example.com/img.jpg'],
+  },
+  {
+    id: 'prop-2',
+    title: 'Test Property Beta',
+    address: 'Calle San Martín 567',
+    city: 'Córdoba',
+    price: '1500',
+    currency: 'USD',
+    type: 'rental',
+    bedrooms: 2,
+    bathrooms: 1,
+    areaM2: 80,
+    images: [],
+  },
+];
+
+const MOCK_RESPONSE = {
+  data: MOCK_PROPERTIES,
+  pagination: { total: 2, page: 1, limit: 12, totalPages: 1 },
+};
+
+const MOCK_PAGINATED_RESPONSE = {
+  data: MOCK_PROPERTIES,
+  pagination: { total: 30, page: 1, limit: 12, totalPages: 3 },
+};
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('PropertiesPage — Button migration (T1.4)', () => {
+  beforeEach(() => {
+    mockGetProperties.mockReset();
+  });
+
+  it('renders NO raw <button> elements — all buttons use shadcn Button component', async () => {
+    mockGetProperties.mockResolvedValue(MOCK_PAGINATED_RESPONSE);
+    const { container } = renderPropertiesPage();
+
+    await screen.findByText('Test Property Alpha');
+
+    const allButtons = container.querySelectorAll('button');
+    const shadcnBaseFragment = 'ring-offset-background';
+
+    allButtons.forEach((btn) => {
+      expect(
+        btn.className.includes(shadcnBaseFragment),
+        `Button "${btn.textContent?.trim()}" is missing shadcn buttonVariants class`
+      ).toBe(true);
+    });
+  });
+
+  it('filter button uses default variant (primary action)', async () => {
+    mockGetProperties.mockResolvedValue(MOCK_RESPONSE);
+    const { container } = renderPropertiesPage();
+
+    await screen.findByText('Test Property Alpha');
+
+    const filterBtn = container.querySelector('form button[type="submit"]');
+    expect(filterBtn).not.toBeNull();
+    expect(filterBtn!.className).toContain('bg-primary');
+  });
+
+  it('pagination buttons use outline variant (secondary action)', async () => {
+    mockGetProperties.mockResolvedValue(MOCK_PAGINATED_RESPONSE);
+    renderPropertiesPage();
+
+    await screen.findByText('Test Property Alpha');
+
+    const prevBtn = screen.getByRole('button', { name: /anterior/i });
+    const nextBtn = screen.getByRole('button', { name: /siguiente/i });
+
+    expect(prevBtn.className).toContain('border');
+    expect(nextBtn.className).toContain('border');
+  });
+
+  it('"Book Now" CTA on property card uses default variant with sm size', async () => {
+    mockGetProperties.mockResolvedValue(MOCK_RESPONSE);
+    const { container } = renderPropertiesPage();
+
+    await screen.findByText('Test Property Alpha');
+
+    const bookBtns = Array.from(container.querySelectorAll('button')).filter((btn) =>
+      btn.textContent?.includes('catalog.bookNow')
+    );
+    expect(bookBtns.length).toBeGreaterThanOrEqual(1);
+    bookBtns.forEach((btn) => {
+      expect(btn.className).toContain('h-9');
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/PropertiesPage.states.test.tsx
+++ b/frontend/src/__tests__/pages/PropertiesPage.states.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview PropertiesPage content states tests / Tests de estados de contenido en PropertiesPage
+ * @description Validates PropertiesPage uses ListingSkeleton for loading and EmptyState for empty data
+ * @module __tests__/pages/PropertiesPage.states.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockGetProperties = vi.fn();
+vi.mock('../../services/propertyService', () => ({
+  propertyService: {
+    getProperties: (...args: unknown[]) => mockGetProperties(...args),
+  },
+}));
+
+vi.mock('react-helmet-async', () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="helmet">{children}</div>
+  ),
+}));
+
+vi.mock('../../config/app.config', () => ({
+  APP_URL: 'http://test.nexo.real',
+}));
+
+import PropertiesPage from '../../pages/PropertiesPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderPropertiesPage() {
+  return render(
+    <MemoryRouter>
+      <PropertiesPage />
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('PropertiesPage — Content States (T2.5)', () => {
+  beforeEach(() => {
+    mockGetProperties.mockReset();
+  });
+
+  it('renders ListingSkeleton with article elements during loading', () => {
+    // Never resolve — keeps the page in loading state
+    mockGetProperties.mockReturnValue(new Promise(() => {}));
+    const { container } = renderPropertiesPage();
+
+    // ListingSkeleton renders <article> elements with skeleton data-testid zones
+    const articles = container.querySelectorAll('article');
+    expect(articles.length).toBeGreaterThanOrEqual(1);
+
+    // Each article should have the skeleton-image testid (from PropertyCardSkeleton)
+    const skeletonImages = container.querySelectorAll('[data-testid="skeleton-image"]');
+    expect(skeletonImages.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders EmptyState with "search" type when properties array is empty', async () => {
+    mockGetProperties.mockResolvedValue({
+      data: [],
+      pagination: { total: 0, page: 1, limit: 12, totalPages: 0 },
+    });
+    renderPropertiesPage();
+
+    // EmptyState type="search" uses the i18n key tree.search.noResults
+    const emptyTitle = await screen.findByText('tree.search.noResults');
+    expect(emptyTitle).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/pages/PropertyDetailPage.buttons.test.tsx
+++ b/frontend/src/__tests__/pages/PropertyDetailPage.buttons.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @fileoverview PropertyDetailPage button migration tests / Tests de migración de botones en PropertyDetailPage
+ * @description Validates all raw <button> elements are replaced with shadcn <Button>,
+ *              and primary CTA includes Lock icon.
+ *              Verifica que todos los <button> crudos se reemplazaron con <Button> de shadcn,
+ *              y CTA principal incluye ícono Lock.
+ * @module __tests__/pages/PropertyDetailPage.buttons.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockGetProperty = vi.fn();
+vi.mock('../../services/propertyService', () => ({
+  propertyService: {
+    getProperty: (...args: unknown[]) => mockGetProperty(...args),
+  },
+}));
+
+const mockStartPropertyReservation = vi.fn();
+vi.mock('../../stores/reservationStore', () => ({
+  useReservationStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ startPropertyReservation: mockStartPropertyReservation }),
+}));
+
+vi.mock('react-helmet-async', () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="helmet">{children}</div>
+  ),
+}));
+
+vi.mock('../../config/app.config', () => ({
+  APP_URL: 'http://test.nexo.real',
+  APP_OG_DEFAULT_IMAGE: 'http://test.nexo.real/og.jpg',
+}));
+
+import PropertyDetailPage from '../../pages/PropertyDetailPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderPropertyDetailPage() {
+  return render(
+    <MemoryRouter initialEntries={['/propiedades/prop-1']}>
+      <Routes>
+        <Route path="/propiedades/:id" element={<PropertyDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+const MOCK_PROPERTY_RENTAL = {
+  id: 'prop-1',
+  title: 'Modern Apartment Palermo',
+  address: 'Av. Libertador 1234',
+  city: 'Buenos Aires',
+  country: 'AR',
+  price: 1500,
+  currency: 'USD',
+  type: 'rental' as const,
+  description: 'A stunning apartment with city views.',
+  images: ['https://example.com/img1.jpg', 'https://example.com/img2.jpg'],
+  bedrooms: 2,
+  bathrooms: 1,
+  areaM2: 85,
+  amenities: ['Pool', 'Gym', 'Parking'],
+  status: 'active' as const,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+};
+
+const MOCK_PROPERTY_SALE = {
+  ...MOCK_PROPERTY_RENTAL,
+  id: 'prop-2',
+  title: 'Villa in Mendoza',
+  type: 'sale' as const,
+  price: 350000,
+};
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('PropertyDetailPage — Button migration (T1.5)', () => {
+  beforeEach(() => {
+    mockGetProperty.mockReset();
+    mockStartPropertyReservation.mockReset();
+  });
+
+  it('renders NO raw <button> elements — all buttons use shadcn Button component', async () => {
+    mockGetProperty.mockResolvedValue(MOCK_PROPERTY_RENTAL);
+    const { container } = renderPropertyDetailPage();
+
+    await screen.findByText('Modern Apartment Palermo');
+
+    const allButtons = container.querySelectorAll('button');
+    const shadcnBaseFragment = 'ring-offset-background';
+
+    expect(allButtons.length).toBeGreaterThan(0);
+    allButtons.forEach((btn) => {
+      expect(
+        btn.className.includes(shadcnBaseFragment),
+        `Button "${btn.textContent?.trim()}" is missing shadcn buttonVariants class`
+      ).toBe(true);
+    });
+  });
+
+  it('primary CTA includes Lock icon and uses cta.securePayment text', async () => {
+    mockGetProperty.mockResolvedValue(MOCK_PROPERTY_RENTAL);
+    const { container } = renderPropertyDetailPage();
+
+    await screen.findByText('Modern Apartment Palermo');
+
+    // The primary CTA should include cta.securePayment text and a Lock SVG icon
+    const ctaBtn = Array.from(container.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('Pago seguro')
+    );
+    expect(ctaBtn).toBeTruthy();
+    expect(ctaBtn!.querySelector('svg')).toBeTruthy();
+  });
+
+  it('back navigation button uses ghost variant', async () => {
+    mockGetProperty.mockResolvedValue(MOCK_PROPERTY_RENTAL);
+    const { container } = renderPropertyDetailPage();
+
+    await screen.findByText('Modern Apartment Palermo');
+
+    const backBtn = Array.from(container.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('Volver a propiedades')
+    );
+    expect(backBtn).toBeTruthy();
+    // Ghost variant: no bg-primary, no border-input
+    expect(backBtn!.className).not.toContain('bg-primary');
+    expect(backBtn!.className).not.toContain('border-input');
+    expect(backBtn!.className).toContain('ring-offset-background');
+  });
+
+  it('gallery navigation buttons use shadcn Button classes', async () => {
+    mockGetProperty.mockResolvedValue(MOCK_PROPERTY_RENTAL);
+    const { container } = renderPropertyDetailPage();
+
+    await screen.findByText('Modern Apartment Palermo');
+
+    const prevBtn = screen.getByRole('button', { name: /imagen anterior/i });
+    const nextBtn = screen.getByRole('button', { name: /imagen siguiente/i });
+
+    expect(prevBtn.className).toContain('ring-offset-background');
+    expect(nextBtn.className).toContain('ring-offset-background');
+  });
+
+  it('error state "back to listing" button uses shadcn Button', async () => {
+    mockGetProperty.mockRejectedValue(new Error('not found'));
+
+    const { container } = renderPropertyDetailPage();
+
+    await screen.findByText(/No se pudo cargar la propiedad/);
+
+    const backBtn = Array.from(container.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('Volver al listado')
+    );
+    expect(backBtn).toBeTruthy();
+    expect(backBtn!.className).toContain('ring-offset-background');
+  });
+
+  it('sale property CTA also includes Lock icon', async () => {
+    mockGetProperty.mockResolvedValue(MOCK_PROPERTY_SALE);
+    const { container } = renderPropertyDetailPage();
+
+    await screen.findByText('Villa in Mendoza');
+
+    const ctaBtn = Array.from(container.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('Pago seguro')
+    );
+    expect(ctaBtn).toBeTruthy();
+    expect(ctaBtn!.querySelector('svg')).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/pages/PropertyDetailPage.mobile.test.tsx
+++ b/frontend/src/__tests__/pages/PropertyDetailPage.mobile.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview PropertyDetailPage mobile sticky CTA tests / Tests de CTA sticky en móvil
+ * @description Validates mobile sticky CTA bar is present with correct structure,
+ *              price display, and booking button for properties.
+ *              Verifica barra CTA fija en móvil para propiedades.
+ * @module __tests__/pages/PropertyDetailPage.mobile.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const { MOCK_PROPERTY } = vi.hoisted(() => ({
+  MOCK_PROPERTY: {
+    id: 'prop-1',
+    slug: 'beach-villa',
+    title: 'Beach Villa',
+    description: 'A beautiful beach villa',
+    price: 250000,
+    currency: 'USD',
+    type: 'sale' as const,
+    bedrooms: 3,
+    bathrooms: 2,
+    area: 150,
+    location: { city: 'Miami', country: 'USA', address: '123 Beach Rd' },
+    images: ['https://example.com/img.jpg'],
+    amenities: ['Pool', 'Garden'],
+    isActive: true,
+  },
+}));
+
+vi.mock('../../services/propertyService', () => ({
+  propertyService: {
+    getProperty: vi.fn().mockResolvedValue(MOCK_PROPERTY),
+    getPropertyBySlug: vi.fn().mockResolvedValue(MOCK_PROPERTY),
+  },
+}));
+
+vi.mock('../../stores/reservationStore', () => ({
+  useReservationStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      startPropertyReservation: vi.fn(),
+      openWizard: vi.fn(),
+    }),
+}));
+
+vi.mock('../../lib/utils', () => ({
+  cn: (...args: unknown[]) =>
+    args
+      .flat()
+      .filter((a) => typeof a === 'string')
+      .join(' '),
+}));
+
+vi.mock('../../config/app.config', () => ({
+  APP_URL: 'https://test.com',
+  APP_OG_DEFAULT_IMAGE: 'https://test.com/og.jpg',
+}));
+
+import PropertyDetailPage from '../../pages/PropertyDetailPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderPropertyDetail() {
+  return render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={['/properties/prop-1']}>
+        <Routes>
+          <Route path="/properties/:id" element={<PropertyDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('PropertyDetailPage — Mobile sticky CTA (T3.4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a mobile sticky CTA bar with lg:hidden class', async () => {
+    renderPropertyDetail();
+
+    const stickyCta = await screen.findByTestId('mobile-sticky-cta');
+    expect(stickyCta).toBeTruthy();
+    expect(stickyCta.className).toContain('lg:hidden');
+    expect(stickyCta.className).toContain('fixed');
+    expect(stickyCta.className).toContain('bottom-0');
+  });
+
+  it('mobile sticky CTA shows property price', async () => {
+    renderPropertyDetail();
+
+    const stickyCta = await screen.findByTestId('mobile-sticky-cta');
+    expect(stickyCta.textContent).toContain('USD');
+    expect(stickyCta.textContent).toContain('250.000');
+  });
+
+  it('mobile sticky CTA contains a booking button with Lock icon', async () => {
+    renderPropertyDetail();
+
+    const stickyCta = await screen.findByTestId('mobile-sticky-cta');
+    const button = stickyCta.querySelector('button');
+    expect(button).toBeTruthy();
+
+    const lockIcon = stickyCta.querySelector('svg.lucide-lock');
+    expect(lockIcon).toBeTruthy();
+  });
+
+  it('renders a spacer div with h-20 lg:h-0 for mobile bottom padding', async () => {
+    const { container } = renderPropertyDetail();
+
+    await screen.findByTestId('mobile-sticky-cta');
+
+    const spacer = container.querySelector('.h-20.lg\\:h-0');
+    expect(spacer).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/pages/RecoverCartPage.buttons.test.tsx
+++ b/frontend/src/__tests__/pages/RecoverCartPage.buttons.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview RecoverCartPage button migration tests / Tests de migración de botones en RecoverCartPage
+ * @description Validates all raw <button> elements are replaced with shadcn <Button>
+ *              Verifica que todos los <button> crudos se reemplazaron con <Button> de shadcn
+ * @module __tests__/pages/RecoverCartPage.buttons.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockPreviewRecoveryCart = vi.fn();
+const mockConfirmRecovery = vi.fn();
+const mockClearRecovery = vi.fn();
+
+vi.mock('../../stores/cartStore', () => ({
+  useCartRecovery: () => ({
+    recoveryCart: {
+      id: 'cart-1',
+      items: [{ id: 'item-1', name: 'Test Product', price: 100, quantity: 1 }],
+      total: 100,
+    },
+    recoveryError: null,
+    isLoadingRecovery: false,
+    isRecovering: false,
+    previewRecoveryCart: mockPreviewRecoveryCart,
+    confirmRecovery: mockConfirmRecovery,
+    clearRecovery: mockClearRecovery,
+  }),
+}));
+
+vi.mock('../../components/Cart/CartPreview', () => ({
+  CartPreview: ({ cart }: { cart: unknown }) => <div data-testid="cart-preview">Cart Preview</div>,
+}));
+
+// Must mock useSearchParams to provide the token
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useSearchParams: () => [new URLSearchParams('token=test-token-123'), vi.fn()],
+  };
+});
+
+import { RecoverCartPage } from '../../pages/RecoverCartPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderRecoverCartPage() {
+  return render(
+    <MemoryRouter>
+      <RecoverCartPage />
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('RecoverCartPage — Button migration (T1.6)', () => {
+  beforeEach(() => {
+    mockPreviewRecoveryCart.mockReset();
+    mockConfirmRecovery.mockReset();
+    mockClearRecovery.mockReset();
+  });
+
+  it('renders NO raw <button> — all buttons use shadcn Button component', () => {
+    const { container } = renderRecoverCartPage();
+
+    const allButtons = container.querySelectorAll('button');
+    const shadcnBaseFragment = 'ring-offset-background';
+
+    expect(allButtons.length).toBeGreaterThan(0);
+    allButtons.forEach((btn) => {
+      expect(
+        btn.className.includes(shadcnBaseFragment),
+        `Button "${btn.textContent?.trim()}" is missing shadcn buttonVariants class`
+      ).toBe(true);
+    });
+  });
+
+  it('primary CTA "Proceed to Checkout" uses default variant', () => {
+    renderRecoverCartPage();
+
+    const proceedBtn = screen.getByRole('button', { name: /proceed to checkout/i });
+    expect(proceedBtn).toBeTruthy();
+    expect(proceedBtn.className).toContain('bg-primary');
+  });
+
+  it('secondary "Continue Browsing" uses outline variant', () => {
+    renderRecoverCartPage();
+
+    const browseBtn = screen.getByRole('button', { name: /continue browsing/i });
+    expect(browseBtn).toBeTruthy();
+    expect(browseBtn.className).toContain('border');
+  });
+});

--- a/frontend/src/__tests__/pages/ReservationFlowPage.buttons.test.tsx
+++ b/frontend/src/__tests__/pages/ReservationFlowPage.buttons.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @fileoverview ReservationFlowPage button migration tests / Tests de migración de botones en ReservationFlowPage
+ * @description Validates all raw <button> elements are replaced with shadcn <Button>.
+ *              Next=default, Back=outline, payment methods=outline, pay later=ghost.
+ *              Verifica migración de botones del wizard de reserva de 4 pasos.
+ * @module __tests__/pages/ReservationFlowPage.buttons.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockSetWizardStep = vi.fn();
+const mockCloseWizard = vi.fn();
+const mockUpdateWizardData = vi.fn();
+const mockConfirmReservation = vi.fn().mockResolvedValue(undefined);
+
+const MOCK_PROPERTY_WIZARD = {
+  type: 'property' as const,
+  property: { title: 'Beach Villa', city: 'Mar del Plata', pricePerNight: 200 },
+  checkIn: '2026-06-01',
+  checkOut: '2026-06-05',
+  guests: 2,
+  notes: '',
+  currency: 'USD',
+};
+
+let mockWizardStep = 'guests';
+let mockWizardData: typeof MOCK_PROPERTY_WIZARD | null = MOCK_PROPERTY_WIZARD;
+
+vi.mock('../../stores/reservationStore', () => ({
+  useReservationWizard: () => ({
+    wizardData: mockWizardData,
+    wizardStep: mockWizardStep,
+    setWizardStep: mockSetWizardStep,
+    closeWizard: mockCloseWizard,
+    updateWizardData: mockUpdateWizardData,
+    confirmReservation: mockConfirmReservation,
+    createdReservation: null,
+    isCreating: false,
+    createError: null,
+    isProcessingPayment: false,
+    paymentError: null,
+    setPaymentProcessing: vi.fn(),
+    setPaymentError: vi.fn(),
+  }),
+  computePriceBreakdown: () => ({
+    pricePerUnit: 200,
+    totalNights: 4,
+    guestCount: 2,
+    subtotal: 800,
+    totalPrice: 800,
+    currency: 'USD',
+    isProperty: true,
+  }),
+  formatPrice: (amount: number, currency: string) => `${currency} ${amount}`,
+}));
+
+vi.mock('../../stores/walletStore', () => ({
+  useWalletBalance: () => ({
+    balance: { balance: 1000, currency: 'USD' },
+  }),
+}));
+
+vi.mock('../../services/paymentService', () => ({
+  paymentService: {
+    createPayPalOrder: vi.fn(),
+    createMercadoPagoPreference: vi.fn(),
+    redirectToMercadoPago: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/featureFlags', () => ({
+  featureFlags: { cryptoWallet: false },
+}));
+
+import ReservationFlowPage from '../../pages/ReservationFlowPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderReservationFlow() {
+  return render(
+    <MemoryRouter>
+      <ReservationFlowPage />
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ReservationFlowPage — Button migration (T1.7)', () => {
+  beforeEach(() => {
+    mockWizardStep = 'guests';
+    mockWizardData = MOCK_PROPERTY_WIZARD;
+    mockSetWizardStep.mockReset();
+    mockCloseWizard.mockReset();
+    mockUpdateWizardData.mockReset();
+    mockConfirmReservation.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders NO raw <button> on guests step — all use shadcn Button', () => {
+    const { container } = renderReservationFlow();
+
+    const allButtons = container.querySelectorAll('button');
+    const shadcnBaseFragment = 'ring-offset-background';
+
+    expect(allButtons.length).toBeGreaterThan(0);
+    allButtons.forEach((btn) => {
+      expect(
+        btn.className.includes(shadcnBaseFragment),
+        `Button "${btn.textContent?.trim()}" is missing shadcn buttonVariants class`
+      ).toBe(true);
+    });
+  });
+
+  it('"Back" button uses outline variant', () => {
+    renderReservationFlow();
+
+    // On guests step with property, there should be a Back button
+    // mockT translates 'reservation.back' → 'Atrás'
+    const backBtn = screen.getByRole('button', { name: /atrás/i });
+    expect(backBtn.className).toContain('border');
+  });
+
+  it('"Confirm reservation" button uses default variant (primary action)', () => {
+    renderReservationFlow();
+
+    // mockT translates 'reservation.confirmReservation' → 'Confirmar reserva'
+    const confirmBtn = screen.getByRole('button', { name: /confirmar reserva/i });
+    expect(confirmBtn.className).toContain('bg-primary');
+  });
+
+  it('guest counter +/- buttons use outline variant', () => {
+    renderReservationFlow();
+
+    // The counter buttons contain − and +
+    const minusBtn = screen.getByRole('button', { name: /−/ });
+    const plusBtn = screen.getByRole('button', { name: /\+/ });
+
+    expect(minusBtn.className).toContain('border');
+    expect(plusBtn.className).toContain('border');
+  });
+
+  it('cancel button in header uses ghost variant', () => {
+    renderReservationFlow();
+
+    // mockT translates 'reservation.cancel' → 'Cancelar'
+    const cancelBtn = screen.getByRole('button', { name: /cancelar/i });
+    // ghost variant doesn't have 'border' or 'bg-primary' — just base classes
+    expect(cancelBtn.className).toContain('ring-offset-background');
+    expect(cancelBtn.className).not.toContain('bg-primary');
+    expect(cancelBtn.className).not.toContain('border-input');
+  });
+});

--- a/frontend/src/__tests__/pages/ReservationFlowPage.loading.test.tsx
+++ b/frontend/src/__tests__/pages/ReservationFlowPage.loading.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @fileoverview ReservationFlowPage payment loading overlay tests
+ * @description Validates the payment processing overlay in the StepPayment component
+ *              when isProcessingPayment is true. Checks for spinner, text, and data-testid.
+ *              Verifica overlay de procesamiento de pago con spinner y texto i18n.
+ * @module __tests__/pages/ReservationFlowPage.loading.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+let mockIsProcessingPayment = false;
+
+const mockSetWizardStep = vi.fn();
+const mockCloseWizard = vi.fn();
+const mockUpdateWizardData = vi.fn();
+const mockConfirmReservation = vi.fn().mockResolvedValue(undefined);
+
+const MOCK_PROPERTY_WIZARD = {
+  type: 'property' as const,
+  property: { title: 'Beach Villa', city: 'Mar del Plata', pricePerNight: 200 },
+  checkIn: '2026-06-01',
+  checkOut: '2026-06-05',
+  guests: 2,
+  notes: '',
+  currency: 'USD',
+};
+
+vi.mock('../../stores/reservationStore', () => ({
+  useReservationWizard: () => ({
+    wizardData: MOCK_PROPERTY_WIZARD,
+    wizardStep: 'payment',
+    setWizardStep: mockSetWizardStep,
+    closeWizard: mockCloseWizard,
+    updateWizardData: mockUpdateWizardData,
+    confirmReservation: mockConfirmReservation,
+    createdReservation: { id: 'res-1', propertyId: 'prop-1' },
+    isCreating: false,
+    createError: null,
+    isProcessingPayment: mockIsProcessingPayment,
+    paymentError: null,
+    setPaymentProcessing: vi.fn(),
+    setPaymentError: vi.fn(),
+  }),
+  computePriceBreakdown: () => ({
+    pricePerUnit: 200,
+    totalNights: 4,
+    guestCount: 2,
+    subtotal: 800,
+    totalPrice: 800,
+    currency: 'USD',
+    isProperty: true,
+  }),
+  formatPrice: (amount: number, currency: string) => `${currency} ${amount}`,
+}));
+
+vi.mock('../../stores/walletStore', () => ({
+  useWalletBalance: () => ({
+    balance: { balance: 1000, currency: 'USD' },
+  }),
+}));
+
+vi.mock('../../services/paymentService', () => ({
+  paymentService: {
+    createPayPalOrder: vi.fn(),
+    createMercadoPagoPreference: vi.fn(),
+    redirectToMercadoPago: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/featureFlags', () => ({
+  featureFlags: { cryptoWallet: false },
+}));
+
+import ReservationFlowPage from '../../pages/ReservationFlowPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderPaymentStep() {
+  return render(
+    <MemoryRouter>
+      <ReservationFlowPage />
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ReservationFlowPage — Payment loading overlay (T3.5)', () => {
+  beforeEach(() => {
+    mockIsProcessingPayment = false;
+    vi.clearAllMocks();
+  });
+
+  it('does NOT show payment overlay when not processing', () => {
+    mockIsProcessingPayment = false;
+    renderPaymentStep();
+
+    const overlay = screen.queryByTestId('payment-loading-overlay');
+    expect(overlay).toBeNull();
+  });
+
+  it('shows payment loading overlay when isProcessingPayment is true', () => {
+    mockIsProcessingPayment = true;
+    renderPaymentStep();
+
+    const overlay = screen.queryByTestId('payment-loading-overlay');
+    expect(overlay).toBeTruthy();
+    expect(overlay!.className).toContain('absolute');
+    expect(overlay!.className).toContain('backdrop-blur');
+  });
+
+  it('overlay contains spinner and loading text', () => {
+    mockIsProcessingPayment = true;
+    renderPaymentStep();
+
+    const overlay = screen.getByTestId('payment-loading-overlay');
+
+    // Should have spinner (animate-spin)
+    const spinner = overlay.querySelector('.animate-spin');
+    expect(spinner).toBeTruthy();
+
+    // Should have loading text
+    expect(overlay.textContent).toContain('Procesando pago');
+  });
+
+  it('payment methods container has relative positioning for overlay', () => {
+    mockIsProcessingPayment = false;
+    const { container } = renderPaymentStep();
+
+    // The payment methods container should have `relative` class
+    const paymentContainer = container.querySelector('.relative.space-y-3');
+    expect(paymentContainer).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/pages/ReservationFlowPage.mobile.test.tsx
+++ b/frontend/src/__tests__/pages/ReservationFlowPage.mobile.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @fileoverview ReservationFlowPage mobile responsive tests / Tests de responsividad móvil
+ * @description Validates mobile-specific fixes: step indicator overflow, touch-target sizes,
+ *              and step label truncation behavior on narrow viewports (375px).
+ *              Verifica fixes móviles: overflow del indicador de pasos, tamaños de touch-target,
+ *              y comportamiento de truncamiento de etiquetas en viewports estrechos (375px).
+ * @module __tests__/pages/ReservationFlowPage.mobile.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockSetWizardStep = vi.fn();
+const mockCloseWizard = vi.fn();
+const mockUpdateWizardData = vi.fn();
+const mockConfirmReservation = vi.fn().mockResolvedValue(undefined);
+
+const MOCK_PROPERTY_WIZARD = {
+  type: 'property' as const,
+  property: { title: 'Beach Villa', city: 'Mar del Plata', pricePerNight: 200 },
+  checkIn: '2026-06-01',
+  checkOut: '2026-06-05',
+  guests: 2,
+  notes: '',
+  currency: 'USD',
+};
+
+let mockWizardStep = 'guests';
+let mockWizardData: typeof MOCK_PROPERTY_WIZARD | null = MOCK_PROPERTY_WIZARD;
+
+vi.mock('../../stores/reservationStore', () => ({
+  useReservationWizard: () => ({
+    wizardData: mockWizardData,
+    wizardStep: mockWizardStep,
+    setWizardStep: mockSetWizardStep,
+    closeWizard: mockCloseWizard,
+    updateWizardData: mockUpdateWizardData,
+    confirmReservation: mockConfirmReservation,
+    createdReservation: null,
+    isCreating: false,
+    createError: null,
+    isProcessingPayment: false,
+    paymentError: null,
+    setPaymentProcessing: vi.fn(),
+    setPaymentError: vi.fn(),
+  }),
+  computePriceBreakdown: () => ({
+    pricePerUnit: 200,
+    totalNights: 4,
+    guestCount: 2,
+    subtotal: 800,
+    totalPrice: 800,
+    currency: 'USD',
+    isProperty: true,
+  }),
+  formatPrice: (amount: number, currency: string) => `${currency} ${amount}`,
+}));
+
+vi.mock('../../stores/walletStore', () => ({
+  useWalletBalance: () => ({
+    balance: { balance: 1000, currency: 'USD' },
+  }),
+}));
+
+vi.mock('../../services/paymentService', () => ({
+  paymentService: {
+    createPayPalOrder: vi.fn(),
+    createMercadoPagoPreference: vi.fn(),
+    redirectToMercadoPago: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/featureFlags', () => ({
+  featureFlags: { cryptoWallet: false },
+}));
+
+import ReservationFlowPage from '../../pages/ReservationFlowPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderReservationFlow() {
+  return render(
+    <MemoryRouter>
+      <ReservationFlowPage />
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ReservationFlowPage — Mobile responsive (T3.2)', () => {
+  beforeEach(() => {
+    mockWizardStep = 'guests';
+    mockWizardData = MOCK_PROPERTY_WIZARD;
+  });
+
+  it('step indicator container has overflow-x-auto for mobile scroll', () => {
+    const { container } = renderReservationFlow();
+
+    // The step indicator container is the first flex row with gap-0 and mb-8
+    const stepContainer = container.querySelector('.overflow-x-auto.flex.items-center');
+    expect(stepContainer).toBeTruthy();
+    expect(stepContainer!.className).toContain('overflow-x-auto');
+  });
+
+  it('step circles have shrink-0 to prevent shrinking on narrow screens', () => {
+    const { container } = renderReservationFlow();
+
+    const stepCircles = container.querySelectorAll(
+      '.rounded-full.flex.items-center.justify-center'
+    );
+    expect(stepCircles.length).toBeGreaterThan(0);
+
+    stepCircles.forEach((circle) => {
+      expect(circle.className).toContain('shrink-0');
+    });
+  });
+
+  it('step labels have min-w-0 to prevent overflow on narrow screens', () => {
+    const { container } = renderReservationFlow();
+
+    // Step labels are <span> elements with text-xs and whitespace-nowrap
+    const labels = container.querySelectorAll('span.whitespace-nowrap');
+    expect(labels.length).toBeGreaterThan(0);
+
+    labels.forEach((label) => {
+      expect(label.className).toContain('min-w-0');
+    });
+  });
+
+  it('guest counter buttons are 44px (h-11 w-11) for WCAG AA touch targets', () => {
+    const { container } = renderReservationFlow();
+
+    // Guest counter buttons have the − and + text
+    const decrementBtn = screen.getByRole('button', { name: /−/ });
+    const incrementBtn = screen.getByRole('button', { name: /\+/ });
+
+    expect(decrementBtn.className).toContain('h-11');
+    expect(decrementBtn.className).toContain('w-11');
+    expect(incrementBtn.className).toContain('h-11');
+    expect(incrementBtn.className).toContain('w-11');
+  });
+});

--- a/frontend/src/__tests__/pages/TourDetailPage.buttons.test.tsx
+++ b/frontend/src/__tests__/pages/TourDetailPage.buttons.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @fileoverview TourDetailPage button migration tests / Tests de migración de botones en TourDetailPage
+ * @description Validates all raw <button> elements are replaced with shadcn <Button>,
+ *              and payment CTAs include Lock icon.
+ *              Verifica que todos los <button> crudos se reemplazaron con <Button> de shadcn,
+ *              y CTAs de pago incluyen ícono Lock.
+ * @module __tests__/pages/TourDetailPage.buttons.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockGetTour = vi.fn();
+vi.mock('../../services/tourService', () => ({
+  tourService: {
+    getTour: (...args: unknown[]) => mockGetTour(...args),
+  },
+}));
+
+const mockStartTourReservation = vi.fn();
+vi.mock('../../stores/reservationStore', () => ({
+  useReservationStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ startTourReservation: mockStartTourReservation }),
+}));
+
+vi.mock('react-helmet-async', () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="helmet">{children}</div>
+  ),
+}));
+
+vi.mock('../../config/app.config', () => ({
+  APP_URL: 'http://test.nexo.real',
+  APP_OG_DEFAULT_IMAGE: 'http://test.nexo.real/og.jpg',
+}));
+
+import TourDetailPage from '../../pages/TourDetailPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderTourDetailPage() {
+  return render(
+    <MemoryRouter initialEntries={['/tours/tour-1']}>
+      <Routes>
+        <Route path="/tours/:id" element={<TourDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+const MOCK_TOUR = {
+  id: 'tour-1',
+  title: 'Adventure in Patagonia',
+  destination: 'El Calafate',
+  durationDays: 5,
+  maxCapacity: 12,
+  price: 2500,
+  currency: 'USD',
+  type: 'adventure' as const,
+  description: 'An incredible tour through glaciers and mountains.',
+  images: ['https://example.com/img1.jpg', 'https://example.com/img2.jpg'],
+  priceIncludes: ['Accommodation', 'Meals'],
+  priceExcludes: ['Flights'],
+  status: 'active' as const,
+  availabilities: [
+    {
+      id: 'avail-1',
+      tourPackageId: 'tour-1',
+      date: '2026-05-15',
+      availableSpots: 8,
+      totalSpots: 12,
+    },
+    {
+      id: 'avail-2',
+      tourPackageId: 'tour-1',
+      date: '2026-06-01',
+      availableSpots: 0,
+      totalSpots: 12,
+    },
+  ],
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+};
+
+const MOCK_TOUR_SOLD_OUT = {
+  ...MOCK_TOUR,
+  id: 'tour-sold-out',
+  availabilities: [
+    {
+      id: 'avail-sold',
+      tourPackageId: 'tour-sold-out',
+      date: '2026-05-15',
+      availableSpots: 0,
+      totalSpots: 12,
+    },
+  ],
+};
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('TourDetailPage — Button migration (T1.5)', () => {
+  beforeEach(() => {
+    mockGetTour.mockReset();
+    mockStartTourReservation.mockReset();
+  });
+
+  it('renders NO raw <button> elements — all buttons use shadcn Button component', async () => {
+    mockGetTour.mockResolvedValue(MOCK_TOUR);
+    const { container } = renderTourDetailPage();
+
+    // Wait for tour to load
+    await screen.findByText('Adventure in Patagonia');
+
+    // Every <button> in the DOM should have the shadcn base class from buttonVariants
+    const allButtons = container.querySelectorAll('button');
+    const shadcnBaseFragment = 'ring-offset-background';
+
+    expect(allButtons.length).toBeGreaterThan(0);
+    allButtons.forEach((btn) => {
+      expect(
+        btn.className.includes(shadcnBaseFragment),
+        `Button "${btn.textContent?.trim()}" is missing shadcn buttonVariants class`
+      ).toBe(true);
+    });
+  });
+
+  it('primary reserve CTA includes Lock icon and uses cta.securePayment text', async () => {
+    mockGetTour.mockResolvedValue(MOCK_TOUR);
+    const { container } = renderTourDetailPage();
+
+    await screen.findByText('Adventure in Patagonia');
+
+    // The primary CTA should have a Lock icon (rendered as SVG inside the button)
+    // Lock icon from lucide-react renders as SVG
+    const reserveBtn = Array.from(container.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('Pago seguro')
+    );
+    expect(reserveBtn).toBeTruthy();
+    expect(reserveBtn!.querySelector('svg')).toBeTruthy();
+  });
+
+  it('back navigation button uses ghost variant', async () => {
+    mockGetTour.mockResolvedValue(MOCK_TOUR);
+    const { container } = renderTourDetailPage();
+
+    await screen.findByText('Adventure in Patagonia');
+
+    // Back button has ArrowLeft icon + "Volver a tours" text
+    const backBtn = Array.from(container.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('Volver a tours')
+    );
+    expect(backBtn).toBeTruthy();
+    // Ghost variant does NOT have bg-primary or border-input — just hover:bg-accent
+    expect(backBtn!.className).not.toContain('bg-primary');
+    expect(backBtn!.className).not.toContain('border-input');
+    expect(backBtn!.className).toContain('ring-offset-background');
+  });
+
+  it('sold-out tour shows disabled CTA button with shadcn Button class', async () => {
+    mockGetTour.mockResolvedValue(MOCK_TOUR_SOLD_OUT);
+    const { container } = renderTourDetailPage();
+
+    await screen.findByText('Adventure in Patagonia');
+
+    // The sold-out button should be disabled
+    const disabledBtns = Array.from(container.querySelectorAll('button')).filter(
+      (btn) => btn.disabled
+    );
+    expect(disabledBtns.length).toBeGreaterThanOrEqual(1);
+
+    // All disabled buttons should still have shadcn class
+    disabledBtns.forEach((btn) => {
+      expect(btn.className).toContain('ring-offset-background');
+    });
+  });
+
+  it('gallery navigation buttons use ghost variant with icon size', async () => {
+    mockGetTour.mockResolvedValue(MOCK_TOUR);
+    const { container } = renderTourDetailPage();
+
+    await screen.findByText('Adventure in Patagonia');
+
+    // Gallery prev/next buttons are identified by aria-label
+    const prevBtn = screen.getByRole('button', { name: /imagen anterior/i });
+    const nextBtn = screen.getByRole('button', { name: /imagen siguiente/i });
+
+    // Both should have shadcn class
+    expect(prevBtn.className).toContain('ring-offset-background');
+    expect(nextBtn.className).toContain('ring-offset-background');
+  });
+
+  it('error state "back to listing" button uses ghost variant', async () => {
+    mockGetTour.mockRejectedValue(new Error('not found'));
+
+    const { container } = renderTourDetailPage();
+
+    // Wait for error to render
+    await screen.findByText(/No se pudo cargar el tour/);
+
+    const backBtn = Array.from(container.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('Volver al listado')
+    );
+    expect(backBtn).toBeTruthy();
+    expect(backBtn!.className).toContain('ring-offset-background');
+  });
+});

--- a/frontend/src/__tests__/pages/TourDetailPage.mobile.test.tsx
+++ b/frontend/src/__tests__/pages/TourDetailPage.mobile.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @fileoverview TourDetailPage mobile sticky CTA tests / Tests de CTA sticky en móvil
+ * @description Validates mobile sticky CTA bar is present with correct structure,
+ *              price display, and booking button.
+ *              Verifica barra CTA fija en móvil con estructura correcta, precio y botón.
+ * @module __tests__/pages/TourDetailPage.mobile.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const { MOCK_TOUR } = vi.hoisted(() => ({
+  MOCK_TOUR: {
+    id: 'tour-1',
+    slug: 'beach-tour',
+    title: 'Beach Tour',
+    description: 'A great beach tour',
+    price: 150,
+    currency: 'USD',
+    category: 'adventure' as const,
+    maxParticipants: 20,
+    durationDays: 3,
+    location: { city: 'Cancún', country: 'México' },
+    images: ['https://example.com/img.jpg'],
+    priceIncludes: ['Transport'],
+    priceExcludes: ['Food'],
+    itinerary: [],
+    availabilities: [{ id: 'av-1', date: '2026-07-01', availableSpots: 10 }],
+    isActive: true,
+  },
+}));
+
+vi.mock('../../services/tourService', () => ({
+  tourService: {
+    getTour: vi.fn().mockResolvedValue(MOCK_TOUR),
+    getTourBySlug: vi.fn().mockResolvedValue(MOCK_TOUR),
+  },
+}));
+
+vi.mock('../../stores/reservationStore', () => ({
+  useReservationStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      startTourReservation: vi.fn(),
+      openWizard: vi.fn(),
+    }),
+}));
+
+vi.mock('../../lib/utils', () => ({
+  cn: (...args: unknown[]) =>
+    args
+      .flat()
+      .filter((a) => typeof a === 'string')
+      .join(' '),
+}));
+
+vi.mock('../../config/app.config', () => ({
+  APP_URL: 'https://test.com',
+  APP_OG_DEFAULT_IMAGE: 'https://test.com/og.jpg',
+}));
+
+import TourDetailPage from '../../pages/TourDetailPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderTourDetail() {
+  return render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={['/tours/tour-1']}>
+        <Routes>
+          <Route path="/tours/:id" element={<TourDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('TourDetailPage — Mobile sticky CTA (T3.4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a mobile sticky CTA bar with lg:hidden class', async () => {
+    renderTourDetail();
+
+    const stickyCta = await screen.findByTestId('mobile-sticky-cta');
+    expect(stickyCta).toBeTruthy();
+    expect(stickyCta.className).toContain('lg:hidden');
+    expect(stickyCta.className).toContain('fixed');
+    expect(stickyCta.className).toContain('bottom-0');
+  });
+
+  it('mobile sticky CTA shows tour price', async () => {
+    renderTourDetail();
+
+    const stickyCta = await screen.findByTestId('mobile-sticky-cta');
+    expect(stickyCta.textContent).toContain('USD');
+    expect(stickyCta.textContent).toContain('150');
+  });
+
+  it('mobile sticky CTA contains a booking button with Lock icon', async () => {
+    renderTourDetail();
+
+    const stickyCta = await screen.findByTestId('mobile-sticky-cta');
+    const button = stickyCta.querySelector('button');
+    expect(button).toBeTruthy();
+
+    // Button should have the Lock icon
+    const lockIcon = stickyCta.querySelector('svg.lucide-lock');
+    expect(lockIcon).toBeTruthy();
+  });
+
+  it('renders a spacer div with h-20 lg:h-0 for mobile bottom padding', async () => {
+    const { container } = renderTourDetail();
+
+    await screen.findByTestId('mobile-sticky-cta');
+
+    const spacer = container.querySelector('.h-20.lg\\:h-0');
+    expect(spacer).toBeTruthy();
+  });
+});

--- a/frontend/src/__tests__/pages/ToursPage.buttons.test.tsx
+++ b/frontend/src/__tests__/pages/ToursPage.buttons.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * @fileoverview ToursPage button migration tests / Tests de migración de botones en ToursPage
+ * @description Validates all raw <button> elements are replaced with shadcn <Button>
+ *              Verifica que todos los <button> crudos se reemplazaron con <Button> de shadcn
+ * @module __tests__/pages/ToursPage.buttons.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+// Mock tourService to return test data
+const mockGetTours = vi.fn();
+vi.mock('../../services/tourService', () => ({
+  tourService: {
+    getTours: (...args: unknown[]) => mockGetTours(...args),
+  },
+}));
+
+// Mock react-helmet-async
+vi.mock('react-helmet-async', () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="helmet">{children}</div>
+  ),
+}));
+
+// Mock app config
+vi.mock('../../config/app.config', () => ({
+  APP_URL: 'http://test.nexo.real',
+}));
+
+import ToursPage from '../../pages/ToursPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderToursPage() {
+  return render(
+    <MemoryRouter>
+      <ToursPage />
+    </MemoryRouter>
+  );
+}
+
+const MOCK_TOURS = [
+  {
+    id: 'tour-1',
+    title: 'Test Tour Alpha',
+    destination: 'Buenos Aires',
+    durationDays: 3,
+    maxCapacity: 10,
+    price: '1500',
+    currency: 'USD',
+    type: 'adventure',
+    images: ['https://example.com/img.jpg'],
+    availabilities: [{ availableSpots: 8 }],
+  },
+  {
+    id: 'tour-2',
+    title: 'Test Tour Beta',
+    destination: 'Mendoza',
+    durationDays: 5,
+    maxCapacity: 6,
+    price: '2500',
+    currency: 'USD',
+    type: 'cultural',
+    images: [],
+    availabilities: [{ availableSpots: 0 }],
+  },
+];
+
+const MOCK_RESPONSE = {
+  data: MOCK_TOURS,
+  pagination: { total: 2, page: 1, limit: 12, totalPages: 1 },
+};
+
+const MOCK_PAGINATED_RESPONSE = {
+  data: MOCK_TOURS,
+  pagination: { total: 30, page: 1, limit: 12, totalPages: 3 },
+};
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ToursPage — Button migration (T1.4)', () => {
+  beforeEach(() => {
+    mockGetTours.mockReset();
+  });
+
+  it('renders NO raw <button> elements — all buttons use shadcn Button component', async () => {
+    mockGetTours.mockResolvedValue(MOCK_PAGINATED_RESPONSE);
+    const { container } = renderToursPage();
+
+    // Wait for tours to load
+    await screen.findByText('Test Tour Alpha');
+
+    // Every <button> in the DOM should have the shadcn base class from buttonVariants
+    const allButtons = container.querySelectorAll('button');
+    const shadcnBaseFragment = 'ring-offset-background';
+
+    allButtons.forEach((btn) => {
+      expect(
+        btn.className.includes(shadcnBaseFragment),
+        `Button "${btn.textContent?.trim()}" is missing shadcn buttonVariants class`
+      ).toBe(true);
+    });
+  });
+
+  it('filter button uses default variant (primary action)', async () => {
+    mockGetTours.mockResolvedValue(MOCK_RESPONSE);
+    const { container } = renderToursPage();
+
+    await screen.findByText('Test Tour Alpha');
+
+    // The filter submit button should have bg-primary (default variant)
+    const filterBtn = container.querySelector('form button[type="submit"]');
+    expect(filterBtn).not.toBeNull();
+    expect(filterBtn!.className).toContain('bg-primary');
+  });
+
+  it('pagination buttons use outline variant (secondary action)', async () => {
+    mockGetTours.mockResolvedValue(MOCK_PAGINATED_RESPONSE);
+    const { container } = renderToursPage();
+
+    await screen.findByText('Test Tour Alpha');
+
+    // Find pagination buttons by text
+    const prevBtn = screen.getByRole('button', { name: /anterior/i });
+    const nextBtn = screen.getByRole('button', { name: /siguiente/i });
+
+    // Outline variant has border-input
+    expect(prevBtn.className).toContain('border');
+    expect(nextBtn.className).toContain('border');
+  });
+
+  it('sold out tour card CTA is disabled with outline variant', async () => {
+    mockGetTours.mockResolvedValue(MOCK_RESPONSE);
+    renderToursPage();
+
+    await screen.findByText('Test Tour Alpha');
+
+    // tour-2 has 0 available spots — its CTA should be disabled
+    const disabledButtons = screen.getAllByRole('button').filter((btn) => btn.disabled);
+    expect(disabledButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('"Book Now" CTA on available tour card uses default variant with sm size', async () => {
+    mockGetTours.mockResolvedValue(MOCK_RESPONSE);
+    const { container } = renderToursPage();
+
+    await screen.findByText('Test Tour Alpha');
+
+    // catalog.bookNow key returns 'catalog.bookNow' (mockT returns the key when not mapped)
+    // The button should exist and have shadcn classes
+    const bookBtns = Array.from(container.querySelectorAll('button')).filter((btn) =>
+      btn.textContent?.includes('catalog.bookNow')
+    );
+    expect(bookBtns.length).toBeGreaterThanOrEqual(1);
+    // Should use size="sm" → h-9 class
+    bookBtns.forEach((btn) => {
+      expect(btn.className).toContain('h-9');
+    });
+  });
+});

--- a/frontend/src/__tests__/pages/ToursPage.states.test.tsx
+++ b/frontend/src/__tests__/pages/ToursPage.states.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview ToursPage content states tests / Tests de estados de contenido en ToursPage
+ * @description Validates ToursPage uses ListingSkeleton for loading and EmptyState for empty data
+ * @module __tests__/pages/ToursPage.states.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockGetTours = vi.fn();
+vi.mock('../../services/tourService', () => ({
+  tourService: {
+    getTours: (...args: unknown[]) => mockGetTours(...args),
+  },
+}));
+
+vi.mock('react-helmet-async', () => ({
+  Helmet: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="helmet">{children}</div>
+  ),
+}));
+
+vi.mock('../../config/app.config', () => ({
+  APP_URL: 'http://test.nexo.real',
+}));
+
+import ToursPage from '../../pages/ToursPage';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function renderToursPage() {
+  return render(
+    <MemoryRouter>
+      <ToursPage />
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ToursPage — Content States (T2.5)', () => {
+  beforeEach(() => {
+    mockGetTours.mockReset();
+  });
+
+  it('renders ListingSkeleton with article elements during loading', () => {
+    // Never resolve — keeps the page in loading state
+    mockGetTours.mockReturnValue(new Promise(() => {}));
+    const { container } = renderToursPage();
+
+    // ListingSkeleton renders <article> elements with skeleton data-testid zones
+    const articles = container.querySelectorAll('article');
+    expect(articles.length).toBeGreaterThanOrEqual(1);
+
+    // Each article should have the skeleton-image testid (from TourCardSkeleton)
+    const skeletonImages = container.querySelectorAll('[data-testid="skeleton-image"]');
+    expect(skeletonImages.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders EmptyState with "search" type when tours array is empty', async () => {
+    mockGetTours.mockResolvedValue({
+      data: [],
+      pagination: { total: 0, page: 1, limit: 12, totalPages: 0 },
+    });
+    renderToursPage();
+
+    // EmptyState type="search" uses the i18n key tree.search.noResults
+    // The mockT returns the raw key: 'tree.search.noResults'
+    const emptyTitle = await screen.findByText('tree.search.noResults');
+    expect(emptyTitle).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Cart/CartRecoveryNotif.tsx
+++ b/frontend/src/components/Cart/CartRecoveryNotif.tsx
@@ -1,108 +1,58 @@
 /**
- * @fileoverview CartRecoveryNotif Component - Toast notification for cart recovery
- * @description Displays a dismissible notification when a cart recovery is detected.
- *              Shows item count and total, with a link to resume shopping.
- *              Muestra una notificación descartable cuando se detecta una recuperación de carrito.
- *              Muestra cantidad de items y total, con enlace para retomar la compra.
+ * @fileoverview CartRecoveryNotif — Sonner toast replacement
+ * @description Replaces the custom positioned notification component with Sonner toast().
+ *              Reemplaza el componente de notificación personalizado con toast() de Sonner.
  * @module components/Cart/CartRecoveryNotif
  * @author Nexo Real Development Team
  */
 
-import { useState } from 'react';
-import { ShoppingCart, X, ArrowRight } from 'lucide-react';
-import { cn } from '../../utils/cn';
+import { toast } from 'sonner';
 
 // ============================================
 // Types / Tipos
 // ============================================
 
-interface CartRecoveryNotifProps {
+/** Props for cart recovery toast / Props para toast de recuperación de carrito */
+interface CartRecoveryToastOptions {
+  /** Number of items in the abandoned cart / Cantidad de items en el carrito abandonado */
   itemCount: number;
+  /** Total monetary amount / Monto total */
   totalAmount: number;
+  /** Callback when user clicks "Resume Shopping" / Callback al hacer clic en "Retomar compra" */
   onResume: () => void;
+  /** Callback when toast is dismissed / Callback al descartar el toast */
   onDismiss: () => void;
-  className?: string;
 }
 
 // ============================================
-// Component / Componente
+// Toast function / Función toast
 // ============================================
 
 /**
- * CartRecoveryNotif component - Toast notification for cart recovery
- * Componente CartRecoveryNotif - Notificación toast para recuperación de carrito
+ * Show a cart recovery toast using Sonner (replaces custom CartRecoveryNotif component).
+ * Muestra un toast de recuperación de carrito usando Sonner (reemplaza CartRecoveryNotif).
+ *
+ * @param options — Cart recovery configuration / Configuración de recuperación de carrito
  */
-export function CartRecoveryNotif({
+export function showCartRecoveryToast({
   itemCount,
   totalAmount,
   onResume,
   onDismiss,
-  className,
-}: CartRecoveryNotifProps) {
-  const [isVisible, setIsVisible] = useState(true);
+}: CartRecoveryToastOptions): void {
+  const formattedTotal = totalAmount.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 
-  const handleDismiss = () => {
-    setIsVisible(false);
-    onDismiss();
-  };
+  const itemLabel = itemCount === 1 ? 'item' : 'items';
 
-  if (!isVisible) return null;
-
-  return (
-    <div
-      role="alert"
-      aria-label="Cart recovery notification"
-      className={cn(
-        'fixed bottom-4 right-4 z-50 max-w-sm',
-        'animate-in slide-in-from-bottom-5 fade-in duration-300',
-        className
-      )}
-    >
-      <div className="overflow-hidden rounded-xl border border-purple-500/30 bg-slate-800 shadow-xl shadow-purple-500/10">
-        {/* Header with dismiss */}
-        <div className="flex items-start gap-3 p-4">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-purple-500/20">
-            <ShoppingCart className="h-5 w-5 text-purple-400" />
-          </div>
-
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-semibold text-white">Your cart is waiting!</p>
-            <p className="mt-1 text-sm text-slate-400">
-              {itemCount} {itemCount === 1 ? 'item' : 'items'} · $
-              {totalAmount.toLocaleString('en-US', {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              })}
-            </p>
-          </div>
-
-          <button
-            onClick={handleDismiss}
-            aria-label="Dismiss notification"
-            className="shrink-0 rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-700 hover:text-white"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-
-        {/* Action */}
-        <div className="border-t border-slate-700 px-4 py-3">
-          <button
-            onClick={onResume}
-            className={cn(
-              'flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium',
-              'bg-purple-600 text-white transition-colors',
-              'hover:bg-purple-500',
-              'focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-slate-800'
-            )}
-          >
-            Resume Shopping
-            <ArrowRight className="h-4 w-4" />
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+  toast('Your cart is waiting!', {
+    description: `${itemCount} ${itemLabel} · $${formattedTotal}`,
+    action: {
+      label: 'Resume Shopping',
+      onClick: onResume,
+    },
+    onDismiss,
+  });
 }
-
-export default CartRecoveryNotif;

--- a/frontend/src/components/CheckoutForm.tsx
+++ b/frontend/src/components/CheckoutForm.tsx
@@ -253,7 +253,7 @@ export function CheckoutForm({
             {t('checkout.selectPayment')}
           </label>
 
-          <div className="grid gap-3">
+          <div className="grid gap-3 sm:grid-cols-2">
             {paymentMethods.map((method) => (
               <label
                 key={method.value}

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -7,6 +7,7 @@
 import { useTranslation } from 'react-i18next';
 import { Package, RefreshCw, Search } from 'lucide-react';
 import { cn } from '../utils/cn';
+import { Button } from '@/components/ui/button';
 
 /**
  * EmptyState props
@@ -83,19 +84,11 @@ export function EmptyState({
         )}
       </div>
 
-      {/* Action Button */}
+      {/* Action Button — shadcn Button (D1: primary → default variant) */}
       {actionLabel && onAction && (
-        <button
-          onClick={onAction}
-          className={cn(
-            'mt-2 rounded-lg px-4 py-2 text-sm font-medium',
-            'bg-purple-600 text-white transition-colors',
-            'hover:bg-purple-500',
-            'focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-slate-800'
-          )}
-        >
+        <Button onClick={onAction} className="mt-2">
           {actionLabel}
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,23 +1,39 @@
 /**
  * @fileoverview EmptyState Component - No data placeholder
- * @description Component displayed when there's no data to show
+ * @description Component displayed when there's no data to show.
+ *              Supports multiple types with dedicated icons and i18n defaults.
+ *              Can render an actionHref (Link) or onAction (callback) button.
  * @module components/EmptyState
+ *
+ * Componente de estado vacío — Muestra un placeholder cuando no hay datos.
+ * Soporta múltiples tipos con íconos dedicados y textos i18n por defecto.
+ * Puede renderizar un link (actionHref) o un botón con callback (onAction).
  */
 
 import { useTranslation } from 'react-i18next';
-import { Package, RefreshCw, Search } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { CalendarDays, Package, Receipt, RefreshCw, Search, ShoppingCart } from 'lucide-react';
 import { cn } from '../utils/cn';
 import { Button } from '@/components/ui/button';
+
+/**
+ * Supported empty state types
+ * Tipos de estado vacío soportados
+ */
+type EmptyStateType = 'default' | 'search' | 'error' | 'cart' | 'reservation' | 'order';
 
 /**
  * EmptyState props
  */
 interface EmptyStateProps {
-  type?: 'default' | 'search' | 'error';
+  type?: EmptyStateType;
   title?: string;
   description?: string;
   actionLabel?: string;
+  /** Callback for button click — renders a <Button> / Callback para click — renderiza un <Button> */
   onAction?: () => void;
+  /** Navigation href — renders a <Link> inside <Button asChild> / Href de navegación — renderiza un <Link> */
+  actionHref?: string;
   className?: string;
 }
 
@@ -31,12 +47,16 @@ export function EmptyState({
   description,
   actionLabel,
   onAction,
+  actionHref,
   className,
 }: EmptyStateProps) {
   const { t } = useTranslation();
 
-  // Default content based on type
-  const defaultContent = {
+  // Default content based on type / Contenido por defecto según el tipo
+  const defaultContent: Record<
+    EmptyStateType,
+    { icon: typeof Package; defaultTitle: string; defaultDescription: string }
+  > = {
     default: {
       icon: Package,
       defaultTitle: t('products.empty'),
@@ -52,6 +72,21 @@ export function EmptyState({
       defaultTitle: t('products.error'),
       defaultDescription: t('products.retry'),
     },
+    cart: {
+      icon: ShoppingCart,
+      defaultTitle: t('emptyStates.cart.title'),
+      defaultDescription: t('emptyStates.cart.description'),
+    },
+    reservation: {
+      icon: CalendarDays,
+      defaultTitle: t('emptyStates.reservation.title'),
+      defaultDescription: t('emptyStates.reservation.description'),
+    },
+    order: {
+      icon: Receipt,
+      defaultTitle: t('emptyStates.order.title'),
+      defaultDescription: t('emptyStates.order.description'),
+    },
   };
 
   const content = defaultContent[type];
@@ -66,7 +101,7 @@ export function EmptyState({
         className
       )}
     >
-      {/* Icon */}
+      {/* Icon / Ícono */}
       <div
         className={cn(
           'flex h-16 w-16 items-center justify-center rounded-full bg-slate-700',
@@ -76,7 +111,7 @@ export function EmptyState({
         <Icon className="h-8 w-8" />
       </div>
 
-      {/* Text Content */}
+      {/* Text Content / Contenido de texto */}
       <div className="flex flex-col gap-2">
         <h3 className="text-lg font-semibold text-white">{displayTitle}</h3>
         {displayDescription && (
@@ -84,8 +119,13 @@ export function EmptyState({
         )}
       </div>
 
-      {/* Action Button — shadcn Button (D1: primary → default variant) */}
-      {actionLabel && onAction && (
+      {/* Action: Link mode (actionHref) takes precedence over callback mode (onAction) */}
+      {actionLabel && actionHref && (
+        <Button asChild className="mt-2">
+          <Link to={actionHref}>{actionLabel}</Link>
+        </Button>
+      )}
+      {actionLabel && !actionHref && onAction && (
         <Button onClick={onAction} className="mt-2">
           {actionLabel}
         </Button>

--- a/frontend/src/components/ui/skeletons/ListingSkeleton.tsx
+++ b/frontend/src/components/ui/skeletons/ListingSkeleton.tsx
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview ListingSkeleton — grid of card skeletons for listing pages
+ * @description Renders a responsive grid with `count` skeleton cards of the
+ *              specified variant (tour | property). Matches the grid layout used
+ *              in ToursPage and PropertiesPage.
+ * @module components/ui/skeletons/ListingSkeleton
+ *
+ * Renderiza un grid responsivo con `count` tarjetas esqueleto del variant
+ * especificado (tour | property). Replica el grid de ToursPage y PropertiesPage.
+ */
+
+import { TourCardSkeleton } from './TourCardSkeleton';
+import { PropertyCardSkeleton } from './PropertyCardSkeleton';
+import { cn } from '@/lib/utils';
+
+interface ListingSkeletonProps {
+  /** Card variant to render / Variante de tarjeta a renderizar */
+  variant: 'tour' | 'property';
+  /** Number of skeleton cards to show (default: 4) / Cantidad de tarjetas esqueleto */
+  count?: number;
+  /** Additional CSS classes for the grid container / Clases CSS adicionales para el grid */
+  className?: string;
+}
+
+/**
+ * Grid of skeleton cards for listing loading states
+ * Grid de tarjetas esqueleto para estados de carga de listados
+ */
+export function ListingSkeleton({ variant, count = 4, className }: ListingSkeletonProps) {
+  const CardSkeleton = variant === 'tour' ? TourCardSkeleton : PropertyCardSkeleton;
+
+  return (
+    <div
+      className={cn(
+        'grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+        className
+      )}
+    >
+      {Array.from({ length: count }, (_, i) => (
+        <CardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/skeletons/PropertyCardSkeleton.tsx
+++ b/frontend/src/components/ui/skeletons/PropertyCardSkeleton.tsx
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview PropertyCardSkeleton — loading placeholder mirroring PropertyCard layout
+ * @description Renders Skeleton primitives matching the PropertyCard structure:
+ *              h-52 image container, title, location, specs row (beds + baths + area), price + CTA
+ * @module components/ui/skeletons/PropertyCardSkeleton
+ *
+ * Esqueleto de carga que replica la estructura de PropertyCard:
+ * imagen h-52, título, ubicación, fila de specs (habitaciones + baños + m²), precio + CTA
+ */
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+interface PropertyCardSkeletonProps {
+  className?: string;
+}
+
+/**
+ * Skeleton placeholder that mirrors the PropertyCard layout
+ * Placeholder esqueleto que replica el layout de PropertyCard
+ */
+export function PropertyCardSkeleton({ className }: PropertyCardSkeletonProps) {
+  return (
+    <article
+      className={cn(
+        'rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden',
+        className
+      )}
+    >
+      {/* Image skeleton — h-52 matching PropertyCard / Esqueleto de imagen */}
+      <Skeleton data-testid="skeleton-image" className="h-52 w-full rounded-none" />
+
+      {/* Content skeleton / Esqueleto de contenido */}
+      <div className="p-4">
+        {/* Title / Título */}
+        <Skeleton data-testid="skeleton-title" className="mb-1 h-5 w-3/4" />
+
+        {/* Location / Ubicación */}
+        <Skeleton data-testid="skeleton-location" className="mb-3 h-4 w-2/3" />
+
+        {/* Specs row (beds + baths + area) / Fila de specs */}
+        <div data-testid="skeleton-specs" className="mb-4 flex items-center gap-4">
+          <Skeleton className="h-4 w-10" />
+          <Skeleton className="h-4 w-10" />
+          <Skeleton className="h-4 w-14" />
+        </div>
+
+        {/* Price + CTA / Precio + CTA */}
+        <div data-testid="skeleton-price" className="flex items-center justify-between gap-2">
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="h-8 w-24 rounded-md" />
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/ui/skeletons/TourCardSkeleton.tsx
+++ b/frontend/src/components/ui/skeletons/TourCardSkeleton.tsx
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview TourCardSkeleton — loading placeholder mirroring TourCard layout
+ * @description Renders Skeleton primitives matching the TourCard structure:
+ *              h-52 image container, title, location, specs row (duration + capacity), price + CTA
+ * @module components/ui/skeletons/TourCardSkeleton
+ *
+ * Esqueleto de carga que replica la estructura de TourCard:
+ * imagen h-52, título, ubicación, fila de specs (duración + capacidad), precio + CTA
+ */
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+interface TourCardSkeletonProps {
+  className?: string;
+}
+
+/**
+ * Skeleton placeholder that mirrors the TourCard layout
+ * Placeholder esqueleto que replica el layout de TourCard
+ */
+export function TourCardSkeleton({ className }: TourCardSkeletonProps) {
+  return (
+    <article
+      className={cn(
+        'rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden',
+        className
+      )}
+    >
+      {/* Image skeleton — h-52 matching TourCard / Esqueleto de imagen — h-52 como TourCard */}
+      <Skeleton data-testid="skeleton-image" className="h-52 w-full rounded-none" />
+
+      {/* Content skeleton / Esqueleto de contenido */}
+      <div className="p-4">
+        {/* Title / Título */}
+        <Skeleton data-testid="skeleton-title" className="mb-1 h-5 w-3/4" />
+
+        {/* Location / Ubicación */}
+        <Skeleton data-testid="skeleton-location" className="mb-3 h-4 w-1/2" />
+
+        {/* Specs row (duration + capacity) / Fila de specs */}
+        <div data-testid="skeleton-specs" className="mb-4 flex items-center gap-4">
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+
+        {/* Price + CTA / Precio + CTA */}
+        <div data-testid="skeleton-price" className="flex items-center justify-between gap-2">
+          <Skeleton className="h-6 w-28" />
+          <Skeleton className="h-8 w-24 rounded-md" />
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/ui/skeletons/index.ts
+++ b/frontend/src/components/ui/skeletons/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @fileoverview Skeletons barrel export / Exportación barrel de esqueletos
+ * @module components/ui/skeletons
+ */
+
+export { TourCardSkeleton } from './TourCardSkeleton';
+export { PropertyCardSkeleton } from './PropertyCardSkeleton';
+export { ListingSkeleton } from './ListingSkeleton';

--- a/frontend/src/i18n/__tests__/cta-keys.test.ts
+++ b/frontend/src/i18n/__tests__/cta-keys.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview CTA i18n keys validation / Validación de claves i18n de CTA
+ * @description Ensures all CTA keys exist in both ES and EN locale files
+ *              Verifica que todas las claves CTA existan en ambos archivos de locale
+ * @module i18n/cta-keys.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import es from '../locales/es.json';
+import en from '../locales/en.json';
+
+/** Required CTA keys per design spec D1 / Claves CTA requeridas según spec D1 */
+const REQUIRED_CTA_KEYS = [
+  'securePayment',
+  'confirmPayment',
+  'cancel',
+  'back',
+  'continue',
+] as const;
+
+describe('i18n — CTA keys (T1.1)', () => {
+  it('ES locale has all required cta.* keys', () => {
+    const esCta = (es as Record<string, unknown>).cta as Record<string, string> | undefined;
+    expect(esCta).toBeDefined();
+
+    for (const key of REQUIRED_CTA_KEYS) {
+      expect(esCta, `Missing ES key: cta.${key}`).toHaveProperty(key);
+      expect(typeof esCta![key]).toBe('string');
+      expect(esCta![key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('EN locale has all required cta.* keys', () => {
+    const enCta = (en as Record<string, unknown>).cta as Record<string, string> | undefined;
+    expect(enCta).toBeDefined();
+
+    for (const key of REQUIRED_CTA_KEYS) {
+      expect(enCta, `Missing EN key: cta.${key}`).toHaveProperty(key);
+      expect(typeof enCta![key]).toBe('string');
+      expect(enCta![key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('ES and EN cta keys are different (translated, not duplicated)', () => {
+    const esCta = (es as Record<string, unknown>).cta as Record<string, string>;
+    const enCta = (en as Record<string, unknown>).cta as Record<string, string>;
+
+    // At least securePayment should differ between languages
+    expect(esCta.securePayment).not.toBe(enCta.securePayment);
+  });
+});

--- a/frontend/src/i18n/__tests__/empty-state-keys.test.ts
+++ b/frontend/src/i18n/__tests__/empty-state-keys.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview EmptyState & loading i18n keys validation
+ * @description Ensures all emptyStates.* and loading.* keys exist in both ES and EN locale files
+ *              Verifica que todas las claves emptyStates.* y loading.* existan en ambos archivos de locale
+ * @module i18n/empty-state-keys.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import es from '../locales/es.json';
+import en from '../locales/en.json';
+
+/** Required emptyStates keys per design spec / Claves emptyStates requeridas según spec */
+const REQUIRED_EMPTY_STATE_KEYS = ['tours', 'properties', 'cart', 'reservation', 'order'] as const;
+
+/** Required loading keys per design spec / Claves loading requeridas según spec */
+const REQUIRED_LOADING_KEYS = ['processingPayment', 'fetchingData'] as const;
+
+describe('i18n — emptyStates keys (T2.1)', () => {
+  it('ES locale has all required emptyStates.* keys with title and description', () => {
+    const esEmptyStates = (es as Record<string, unknown>).emptyStates as
+      | Record<string, Record<string, string>>
+      | undefined;
+    expect(esEmptyStates).toBeDefined();
+
+    for (const key of REQUIRED_EMPTY_STATE_KEYS) {
+      expect(esEmptyStates, `Missing ES emptyStates.${key}`).toHaveProperty(key);
+      expect(esEmptyStates![key].title, `Missing ES emptyStates.${key}.title`).toBeDefined();
+      expect(esEmptyStates![key].title.length).toBeGreaterThan(0);
+      expect(
+        esEmptyStates![key].description,
+        `Missing ES emptyStates.${key}.description`
+      ).toBeDefined();
+      expect(esEmptyStates![key].description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('EN locale has all required emptyStates.* keys with title and description', () => {
+    const enEmptyStates = (en as Record<string, unknown>).emptyStates as
+      | Record<string, Record<string, string>>
+      | undefined;
+    expect(enEmptyStates).toBeDefined();
+
+    for (const key of REQUIRED_EMPTY_STATE_KEYS) {
+      expect(enEmptyStates, `Missing EN emptyStates.${key}`).toHaveProperty(key);
+      expect(enEmptyStates![key].title, `Missing EN emptyStates.${key}.title`).toBeDefined();
+      expect(enEmptyStates![key].title.length).toBeGreaterThan(0);
+      expect(
+        enEmptyStates![key].description,
+        `Missing EN emptyStates.${key}.description`
+      ).toBeDefined();
+      expect(enEmptyStates![key].description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('ES and EN emptyStates keys differ (translated, not duplicated)', () => {
+    const esEmptyStates = (es as Record<string, unknown>).emptyStates as Record<
+      string,
+      Record<string, string>
+    >;
+    const enEmptyStates = (en as Record<string, unknown>).emptyStates as Record<
+      string,
+      Record<string, string>
+    >;
+
+    // At least tours.title should differ between languages
+    expect(esEmptyStates.tours.title).not.toBe(enEmptyStates.tours.title);
+  });
+});
+
+describe('i18n — loading keys (T2.1)', () => {
+  it('ES locale has all required loading.* keys', () => {
+    const esLoading = (es as Record<string, unknown>).loading as Record<string, string> | undefined;
+    expect(esLoading).toBeDefined();
+
+    for (const key of REQUIRED_LOADING_KEYS) {
+      expect(esLoading, `Missing ES loading.${key}`).toHaveProperty(key);
+      expect(typeof esLoading![key]).toBe('string');
+      expect(esLoading![key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('EN locale has all required loading.* keys', () => {
+    const enLoading = (en as Record<string, unknown>).loading as Record<string, string> | undefined;
+    expect(enLoading).toBeDefined();
+
+    for (const key of REQUIRED_LOADING_KEYS) {
+      expect(enLoading, `Missing EN loading.${key}`).toHaveProperty(key);
+      expect(typeof enLoading![key]).toBe('string');
+      expect(enLoading![key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('ES and EN loading keys differ (translated, not duplicated)', () => {
+    const esLoading = (es as Record<string, unknown>).loading as Record<string, string>;
+    const enLoading = (en as Record<string, unknown>).loading as Record<string, string>;
+
+    expect(esLoading.processingPayment).not.toBe(enLoading.processingPayment);
+  });
+});

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -605,6 +605,32 @@
     "secure": "Secure payment",
     "secureDesc": "All transactions are encrypted and protected."
   },
+  "emptyStates": {
+    "tours": {
+      "title": "No tours found",
+      "description": "Try adjusting your filters or explore all available options."
+    },
+    "properties": {
+      "title": "No properties found",
+      "description": "Try adjusting your filters or explore all available properties."
+    },
+    "cart": {
+      "title": "Your cart is empty",
+      "description": "Explore available tours and properties to get started."
+    },
+    "reservation": {
+      "title": "No reservations yet",
+      "description": "Explore properties and tours to make your first reservation."
+    },
+    "order": {
+      "title": "No orders yet",
+      "description": "Your purchases will appear here once you place your first order."
+    }
+  },
+  "loading": {
+    "processingPayment": "Processing payment...",
+    "fetchingData": "Loading data..."
+  },
   "cta": {
     "securePayment": "Secure Payment",
     "confirmPayment": "Confirm Payment",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -605,6 +605,13 @@
     "secure": "Secure payment",
     "secureDesc": "All transactions are encrypted and protected."
   },
+  "cta": {
+    "securePayment": "Secure Payment",
+    "confirmPayment": "Confirm Payment",
+    "cancel": "Cancel",
+    "back": "Back",
+    "continue": "Continue"
+  },
   "landing": {
     "hero": {
       "badge": "#1 Platform in Latin America",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -601,6 +601,32 @@
     "secure": "Pago seguro",
     "secureDesc": "Todas las transacciones están encriptadas y protegidas."
   },
+  "emptyStates": {
+    "tours": {
+      "title": "No se encontraron tours",
+      "description": "Probá ajustando los filtros o explorá todas las opciones disponibles."
+    },
+    "properties": {
+      "title": "No se encontraron propiedades",
+      "description": "Probá ajustando los filtros o explorá todas las propiedades disponibles."
+    },
+    "cart": {
+      "title": "Tu carrito está vacío",
+      "description": "Explorá tours y propiedades disponibles para comenzar."
+    },
+    "reservation": {
+      "title": "No tenés reservas todavía",
+      "description": "Explorá propiedades y tours disponibles para hacer tu primera reserva."
+    },
+    "order": {
+      "title": "No tenés órdenes todavía",
+      "description": "Tus compras aparecerán aquí cuando realices tu primera orden."
+    }
+  },
+  "loading": {
+    "processingPayment": "Procesando pago...",
+    "fetchingData": "Cargando datos..."
+  },
   "cta": {
     "securePayment": "Pago seguro",
     "confirmPayment": "Confirmar pago",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -601,6 +601,13 @@
     "secure": "Pago seguro",
     "secureDesc": "Todas las transacciones están encriptadas y protegidas."
   },
+  "cta": {
+    "securePayment": "Pago seguro",
+    "confirmPayment": "Confirmar pago",
+    "cancel": "Cancelar",
+    "back": "Volver",
+    "continue": "Continuar"
+  },
   "landing": {
     "hero": {
       "badge": "Plataforma #1 en América Latina",

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -7,13 +7,14 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Loader2, AlertCircle, ArrowLeft, Check, X } from 'lucide-react';
+import { Loader2, AlertCircle, ArrowLeft, Check, Lock, X } from 'lucide-react';
 import { OrderSummary } from '../components/OrderSummary';
 import { CheckoutForm } from '../components/CheckoutForm';
 import { EmptyState } from '../components/EmptyState';
 import { productService, orderService } from '../services/api';
 import type { Product, PaymentMethod } from '../types';
 import { cn } from '../utils/cn';
+import { Button } from '../components/ui/button';
 
 /**
  * Checkout page component
@@ -164,12 +165,9 @@ export default function Checkout() {
       <div className="mx-auto max-w-4xl">
         {/* Page Header */}
         <div className="mb-8 flex items-center gap-4">
-          <button
-            onClick={handleBackToProducts}
-            className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-800 text-white transition-colors hover:bg-slate-700"
-          >
+          <Button variant="ghost" size="icon" onClick={handleBackToProducts}>
             <ArrowLeft className="h-5 w-5" />
-          </button>
+          </Button>
           <div>
             <h1 className="text-3xl font-bold text-white">{t('checkout.title')}</h1>
             <p className="mt-1 text-slate-400">{t('checkout.subtitle')}</p>
@@ -221,13 +219,14 @@ export default function Checkout() {
                 <h2 className="text-xl font-semibold text-white">
                   {t('checkout.confirmPurchase')}
                 </h2>
-                <button
+                <Button
+                  variant="ghost"
+                  size="icon"
                   onClick={handleCloseModal}
                   disabled={isSubmitting}
-                  className="rounded-full p-1 text-slate-400 transition-colors hover:bg-slate-700 hover:text-white disabled:opacity-50"
                 >
                   <X className="h-5 w-5" />
-                </button>
+                </Button>
               </div>
 
               {/* Modal Content */}
@@ -266,25 +265,18 @@ export default function Checkout() {
 
                 {/* Modal Actions */}
                 <div className="flex gap-3 pt-2">
-                  <button
+                  <Button
+                    variant="outline"
                     onClick={handleCloseModal}
                     disabled={isSubmitting}
-                    className={cn(
-                      'flex-1 rounded-xl py-3 font-semibold transition-colors',
-                      'border border-slate-600 text-white hover:bg-slate-700',
-                      'disabled:opacity-50 disabled:cursor-not-allowed'
-                    )}
+                    className="flex-1"
                   >
                     {t('common.cancel')}
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     onClick={() => handleConfirmPurchase(pendingPaymentMethod)}
                     disabled={isSubmitting}
-                    className={cn(
-                      'flex flex-1 items-center justify-center gap-2 rounded-xl py-3 font-semibold',
-                      'bg-purple-600 text-white transition-all hover:bg-purple-500',
-                      'disabled:bg-slate-600 disabled:cursor-not-allowed'
-                    )}
+                    className="flex-1 gap-2"
                   >
                     {isSubmitting ? (
                       <>
@@ -293,11 +285,11 @@ export default function Checkout() {
                       </>
                     ) : (
                       <>
-                        <Check className="h-5 w-5" />
+                        <Lock className="h-4 w-4" />
                         {t('checkout.confirmPurchase')}
                       </>
                     )}
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -182,7 +182,7 @@ export default function Checkout() {
           </div>
 
           {/* Payment Form */}
-          <div>
+          <div className="relative">
             <CheckoutForm
               onSubmit={handlePayment}
               isProcessing={isSubmitting}
@@ -202,6 +202,17 @@ export default function Checkout() {
               productId={product.id}
               productName={product.name}
             />
+
+            {/* Payment processing overlay / Overlay de procesamiento de pago */}
+            {isSubmitting && (
+              <div
+                data-testid="payment-loading-overlay"
+                className="absolute inset-0 z-10 flex flex-col items-center justify-center rounded-xl bg-slate-900/80 backdrop-blur-sm"
+              >
+                <Loader2 className="h-8 w-8 animate-spin text-purple-400 mb-3" />
+                <p className="text-sm font-medium text-white">{t('loading.processingPayment')}</p>
+              </div>
+            )}
           </div>
         </div>
 

--- a/frontend/src/pages/MisReservasPage.tsx
+++ b/frontend/src/pages/MisReservasPage.tsx
@@ -25,6 +25,7 @@ import {
 import { useMyReservations } from '../stores/reservationStore';
 import type { Reservation, ReservationStatus } from '../services/reservationService';
 import { cn } from '../lib/utils';
+import { Button } from '../components/ui/button';
 
 // ============================================
 // Constants / Constantes
@@ -201,15 +202,12 @@ function ReservationCard({ reservation, isCancelling, onCancel }: ReservationCar
         <span className="text-xs text-slate-400 font-mono truncate">#{reservation.id}</span>
 
         {canCancel && (
-          <button
+          <Button
+            variant="destructive"
+            size="sm"
             onClick={handleCancelClick}
             disabled={isCancelling}
-            className={cn(
-              'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors shrink-0',
-              confirmingCancel
-                ? 'bg-red-500 text-white hover:bg-red-600'
-                : 'border border-red-200 text-red-600 hover:bg-red-50'
-            )}
+            className="shrink-0"
           >
             {isCancelling ? (
               <>
@@ -227,7 +225,7 @@ function ReservationCard({ reservation, isCancelling, onCancel }: ReservationCar
                 Cancelar
               </>
             )}
-          </button>
+          </Button>
         )}
       </div>
     </div>
@@ -297,29 +295,20 @@ function EmptyState({ hasFilter, onClear }: EmptyStateProps) {
           : 'Explorá propiedades y tours disponibles para hacer tu primera reserva.'}
       </p>
       {hasFilter ? (
-        <button
-          onClick={onClear}
-          className="flex items-center gap-2 px-4 py-2 rounded-lg border border-slate-200 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
-        >
+        <Button variant="outline" onClick={onClear}>
           <RefreshCw className="w-4 h-4" />
           Limpiar filtro
-        </button>
+        </Button>
       ) : (
         <div className="flex gap-3">
-          <button
-            onClick={() => navigate('/properties')}
-            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 transition-colors"
-          >
+          <Button onClick={() => navigate('/properties')}>
             <MapPin className="w-4 h-4" />
             Ver propiedades
-          </button>
-          <button
-            onClick={() => navigate('/tours')}
-            className="flex items-center gap-2 px-4 py-2 rounded-lg border border-slate-200 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
-          >
+          </Button>
+          <Button variant="outline" onClick={() => navigate('/tours')}>
             <Compass className="w-4 h-4" />
             Ver tours
-          </button>
+          </Button>
         </div>
       )}
     </div>
@@ -394,18 +383,15 @@ export default function MisReservasPage() {
               { value: 'completed', label: 'Completadas' },
             ] as { value: ReservationStatus | ''; label: string }[]
           ).map((option) => (
-            <button
+            <Button
               key={option.value}
+              variant={statusFilter === option.value ? 'default' : 'outline'}
+              size="sm"
               onClick={() => handleStatusChange(option.value)}
-              className={cn(
-                'px-4 py-2 rounded-full text-sm font-medium border transition-colors',
-                statusFilter === option.value
-                  ? 'bg-emerald-500 border-emerald-500 text-white'
-                  : 'bg-white border-slate-200 text-slate-600 hover:border-emerald-300 hover:text-emerald-600'
-              )}
+              className="rounded-full"
             >
               {option.label}
-            </button>
+            </Button>
           ))}
         </div>
 
@@ -429,7 +415,7 @@ export default function MisReservasPage() {
             <AlertCircle className="w-10 h-10 text-red-400 mb-3" />
             <p className="text-slate-600 font-medium mb-1">Error al cargar las reservas</p>
             <p className="text-sm text-slate-500 mb-4">{reservationsError}</p>
-            <button
+            <Button
               onClick={() =>
                 fetchMyReservations({
                   page: currentPage,
@@ -437,11 +423,10 @@ export default function MisReservasPage() {
                   status: statusFilter || undefined,
                 })
               }
-              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 transition-colors"
             >
               <RefreshCw className="w-4 h-4" />
               Reintentar
-            </button>
+            </Button>
           </div>
         ) : myReservations.length === 0 ? (
           <EmptyState hasFilter={Boolean(statusFilter)} onClear={() => handleStatusChange('')} />
@@ -471,22 +456,22 @@ export default function MisReservasPage() {
                   )}
                 </p>
                 <div className="flex gap-2">
-                  <button
+                  <Button
+                    variant="outline"
                     onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                     disabled={currentPage === 1}
-                    className="flex items-center gap-1.5 px-3 py-2 rounded-lg border border-slate-200 text-sm text-slate-600 hover:bg-slate-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                   >
                     <ChevronLeft className="w-4 h-4" />
                     Anterior
-                  </button>
-                  <button
+                  </Button>
+                  <Button
+                    variant="outline"
                     onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
                     disabled={currentPage === totalPages}
-                    className="flex items-center gap-1.5 px-3 py-2 rounded-lg border border-slate-200 text-sm text-slate-600 hover:bg-slate-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                   >
                     Siguiente
                     <ChevronRight className="w-4 h-4" />
-                  </button>
+                  </Button>
                 </div>
               </div>
             )}

--- a/frontend/src/pages/OrderSuccess.tsx
+++ b/frontend/src/pages/OrderSuccess.tsx
@@ -21,6 +21,7 @@ import { OrderStatus } from '../components/OrderStatus';
 import { orderService } from '../services/api';
 import type { Order } from '../types';
 import { cn } from '../utils/cn';
+import { Button } from '../components/ui/button';
 
 /**
  * Commission breakdown by level
@@ -255,12 +256,9 @@ export default function OrderSuccess() {
       <div className="min-h-screen bg-slate-900 px-4 py-8">
         <div className="mx-auto max-w-md text-center">
           <h1 className="text-2xl font-bold text-white">{error || t('orders.error')}</h1>
-          <button
-            onClick={handleContinueShopping}
-            className="mt-6 rounded-xl bg-purple-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-purple-500"
-          >
+          <Button onClick={handleContinueShopping} className="mt-6">
             {t('checkout.backToProducts')}
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -287,9 +285,10 @@ export default function OrderSuccess() {
             </div>
             <div className="flex items-center gap-2">
               <span className="font-mono text-lg text-white">{order.orderNumber}</span>
-              <button
+              <Button
+                variant="ghost"
+                size="icon"
                 onClick={handleCopyOrderNumber}
-                className="rounded-full p-1 text-slate-400 transition-colors hover:bg-slate-700 hover:text-white"
                 title={t('common.copy')}
               >
                 {copiedOrderNumber ? (
@@ -297,7 +296,7 @@ export default function OrderSuccess() {
                 ) : (
                   <Copy className="h-4 w-4" />
                 )}
-              </button>
+              </Button>
             </div>
           </div>
           <div className="flex items-center justify-between px-5 py-4">
@@ -320,26 +319,14 @@ export default function OrderSuccess() {
 
         {/* CTA Buttons */}
         <div className="flex flex-col gap-3 sm:flex-row">
-          <button
-            onClick={handleContinueShopping}
-            className={cn(
-              'flex flex-1 items-center justify-center gap-2 rounded-xl py-3 font-semibold',
-              'border border-slate-600 text-white transition-colors hover:bg-slate-800'
-            )}
-          >
+          <Button variant="outline" onClick={handleContinueShopping} className="flex-1 gap-2">
             <ShoppingBag className="h-5 w-5" />
             {t('orders.continueShopping')}
-          </button>
-          <button
-            onClick={handleGoToDashboard}
-            className={cn(
-              'flex flex-1 items-center justify-center gap-2 rounded-xl py-3 font-semibold',
-              'bg-purple-600 text-white transition-all hover:bg-purple-500 hover:shadow-lg hover:shadow-purple-500/25'
-            )}
-          >
+          </Button>
+          <Button onClick={handleGoToDashboard} className="flex-1 gap-2">
             <Home className="h-5 w-5" />
             {t('orders.goToDashboard')}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/PropertiesPage.tsx
+++ b/frontend/src/pages/PropertiesPage.tsx
@@ -25,6 +25,8 @@ import type { Property, PropertyListParams, PropertyType } from '../services/pro
 import { cn } from '../lib/utils';
 import { APP_URL } from '../config/app.config';
 import { Button } from '@/components/ui/button';
+import { ListingSkeleton } from '@/components/ui/skeletons';
+import { EmptyState } from '@/components/EmptyState';
 
 // ============================================
 // Helpers / Utilidades
@@ -347,33 +349,11 @@ export default function PropertiesPage() {
             </div>
           )}
 
-          {/* Loading skeleton */}
-          {isLoading && (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {Array.from({ length: 8 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="rounded-xl border border-slate-200 bg-white overflow-hidden"
-                >
-                  <div className="h-52 bg-slate-200 animate-pulse" />
-                  <div className="p-4 space-y-3">
-                    <div className="h-4 bg-slate-200 rounded animate-pulse" />
-                    <div className="h-3 bg-slate-200 rounded w-3/4 animate-pulse" />
-                    <div className="h-5 bg-slate-200 rounded w-1/2 animate-pulse" />
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+          {/* Loading skeleton / Esqueleto de carga */}
+          {isLoading && <ListingSkeleton variant="property" count={8} />}
 
-          {/* Empty state */}
-          {!isLoading && !error && properties.length === 0 && (
-            <div className="text-center py-20 text-slate-400">
-              <MapPin className="w-12 h-12 mx-auto mb-4 opacity-30" />
-              <p className="text-lg font-medium">No se encontraron propiedades</p>
-              <p className="text-sm mt-1">Probá ajustando los filtros</p>
-            </div>
-          )}
+          {/* Empty state / Estado vacío */}
+          {!isLoading && !error && properties.length === 0 && <EmptyState type="search" />}
 
           {/* Property grid */}
           {!isLoading && properties.length > 0 && (

--- a/frontend/src/pages/PropertiesPage.tsx
+++ b/frontend/src/pages/PropertiesPage.tsx
@@ -24,6 +24,7 @@ import { propertyService } from '../services/propertyService';
 import type { Property, PropertyListParams, PropertyType } from '../services/propertyService';
 import { cn } from '../lib/utils';
 import { APP_URL } from '../config/app.config';
+import { Button } from '@/components/ui/button';
 
 // ============================================
 // Helpers / Utilidades
@@ -146,17 +147,18 @@ function PropertyCard({ property, onClick }: PropertyCardProps) {
               <span className="text-sm font-normal text-slate-400"> / mes</span>
             )}
           </p>
-          <button
+          <Button
             type="button"
+            size="sm"
             onClick={(e) => {
               e.stopPropagation();
               navigate(`/reservations/new?propertyId=${property.id}`);
             }}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 transition-colors shrink-0"
+            className="shrink-0"
           >
             <CalendarCheck className="w-3.5 h-3.5" />
             {t('catalog.bookNow')}
-          </button>
+          </Button>
         </div>
       </div>
     </article>
@@ -325,22 +327,15 @@ export default function PropertiesPage() {
                 className="w-36 px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400"
               />
 
-              <button
-                type="submit"
-                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 transition-colors"
-              >
+              <Button type="submit">
                 <SlidersHorizontal className="w-4 h-4" />
                 Filtrar
-              </button>
+              </Button>
 
               {hasActiveFilters && (
-                <button
-                  type="button"
-                  onClick={clearFilters}
-                  className="px-4 py-2 rounded-lg border border-slate-200 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
-                >
+                <Button type="button" variant="outline" onClick={clearFilters}>
                   Limpiar
-                </button>
+                </Button>
               )}
             </form>
           </div>
@@ -396,23 +391,23 @@ export default function PropertiesPage() {
               {/* Pagination */}
               {pagination && pagination.totalPages > 1 && (
                 <div className="flex justify-center gap-2 mt-8">
-                  <button
+                  <Button
+                    variant="outline"
                     onClick={() => setPage((p) => Math.max(1, p - 1))}
                     disabled={page === 1}
-                    className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
                   >
                     Anterior
-                  </button>
+                  </Button>
                   <span className="px-4 py-2 text-sm text-slate-600">
                     Página {page} de {pagination.totalPages}
                   </span>
-                  <button
+                  <Button
+                    variant="outline"
                     onClick={() => setPage((p) => Math.min(pagination.totalPages, p + 1))}
                     disabled={page === pagination.totalPages}
-                    className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
                   >
                     Siguiente
-                  </button>
+                  </Button>
                 </div>
               )}
             </>

--- a/frontend/src/pages/PropertyDetailPage.tsx
+++ b/frontend/src/pages/PropertyDetailPage.tsx
@@ -24,7 +24,6 @@ import {
   ArrowLeft,
   ChevronLeft,
   ChevronRight,
-  CalendarDays,
   Check,
   Lock,
 } from 'lucide-react';
@@ -438,6 +437,29 @@ export default function PropertyDetailPage() {
               </div>
             </div>
           </div>
+
+          {/* Spacer for mobile sticky CTA / Espacio para CTA fijo en móvil */}
+          <div className="h-20 lg:h-0" />
+        </div>
+      </div>
+
+      {/* Mobile sticky CTA bar / Barra CTA fija en móvil */}
+      <div
+        className="fixed bottom-0 inset-x-0 z-40 border-t border-slate-200 bg-white/95 backdrop-blur-sm px-4 py-3 lg:hidden"
+        data-testid="mobile-sticky-cta"
+      >
+        <div className="flex items-center justify-between gap-4 max-w-4xl mx-auto">
+          <div>
+            <p className="text-lg font-bold text-emerald-600">
+              {property.currency}{' '}
+              {Number(property.price).toLocaleString('es-AR', { minimumFractionDigits: 0 })}
+            </p>
+            {property.type === 'rental' && <p className="text-xs text-slate-400">por mes</p>}
+          </div>
+          <Button onClick={handleReserve} className="shrink-0">
+            <Lock className="h-4 w-4 mr-2" />
+            {t('cta.securePayment')}
+          </Button>
         </div>
       </div>
     </>

--- a/frontend/src/pages/PropertyDetailPage.tsx
+++ b/frontend/src/pages/PropertyDetailPage.tsx
@@ -14,6 +14,7 @@
 
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Helmet } from 'react-helmet-async';
 import {
   MapPin,
@@ -25,7 +26,9 @@ import {
   ChevronRight,
   CalendarDays,
   Check,
+  Lock,
 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { propertyService } from '../services/propertyService';
 import type { Property, PropertyType } from '../services/propertyService';
 import { useReservationStore } from '../stores/reservationStore';
@@ -78,29 +81,35 @@ function ImageGallery({ images, title }: ImageGalleryProps) {
 
       {images.length > 1 && (
         <>
-          <button
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={() => setCurrent((c) => (c === 0 ? images.length - 1 : c - 1))}
-            className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/40 text-white flex items-center justify-center hover:bg-black/60 transition-colors"
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/40 text-white hover:bg-black/60"
             aria-label="Imagen anterior"
           >
             <ChevronLeft className="w-5 h-5" />
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={() => setCurrent((c) => (c === images.length - 1 ? 0 : c + 1))}
-            className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/40 text-white flex items-center justify-center hover:bg-black/60 transition-colors"
+            className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/40 text-white hover:bg-black/60"
             aria-label="Imagen siguiente"
           >
             <ChevronRight className="w-5 h-5" />
-          </button>
+          </Button>
 
           {/* Dots */}
           <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5">
             {images.map((_, i) => (
-              <button
+              <Button
                 key={i}
+                variant="ghost"
+                size="icon"
                 onClick={() => setCurrent(i)}
                 className={cn(
-                  'w-2 h-2 rounded-full transition-colors',
+                  'w-2 h-2 rounded-full p-0 min-w-0 h-auto',
                   i === current ? 'bg-white' : 'bg-white/50'
                 )}
                 aria-label={`Ir a imagen ${i + 1}`}
@@ -114,18 +123,20 @@ function ImageGallery({ images, title }: ImageGalleryProps) {
       {images.length > 1 && (
         <div className="flex gap-2 mt-2 px-1">
           {images.map((img, i) => (
-            <button
+            <Button
               key={i}
+              variant="ghost"
+              size="icon"
               onClick={() => setCurrent(i)}
               className={cn(
-                'w-16 h-12 rounded-lg overflow-hidden border-2 shrink-0 transition-all',
+                'w-16 h-12 rounded-lg overflow-hidden border-2 shrink-0 p-0',
                 i === current
                   ? 'border-emerald-500'
                   : 'border-transparent opacity-60 hover:opacity-100'
               )}
             >
               <img src={img} alt={`Miniatura ${i + 1}`} className="w-full h-full object-cover" />
-            </button>
+            </Button>
           ))}
         </div>
       )}
@@ -165,6 +176,7 @@ function PropertyDetailSkeleton() {
 export default function PropertyDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const startPropertyReservation = useReservationStore((s) => s.startPropertyReservation);
 
   const [property, setProperty] = useState<Property | null>(null);
@@ -206,12 +218,13 @@ export default function PropertyDetailPage() {
     return (
       <div className="max-w-5xl mx-auto px-4 py-20 text-center">
         <p className="text-red-500 mb-4">{error ?? 'Propiedad no encontrada'}</p>
-        <button
+        <Button
+          variant="ghost"
           onClick={() => navigate('/properties')}
           className="text-emerald-600 hover:underline text-sm"
         >
           Volver al listado
-        </button>
+        </Button>
       </div>
     );
   }
@@ -311,13 +324,14 @@ export default function PropertyDetailPage() {
       <div className="min-h-screen bg-slate-50 pb-12">
         <div className="max-w-5xl mx-auto px-4 py-8">
           {/* Back button */}
-          <button
+          <Button
+            variant="ghost"
             onClick={() => navigate('/properties')}
-            className="flex items-center gap-2 text-sm text-slate-500 hover:text-slate-800 mb-6 transition-colors"
+            className="flex items-center gap-2 text-sm text-slate-500 hover:text-slate-800 mb-6"
           >
             <ArrowLeft className="w-4 h-4" />
             Volver a propiedades
-          </button>
+          </Button>
 
           {/* Gallery */}
           <ImageGallery images={property.images} title={property.title} />
@@ -410,13 +424,13 @@ export default function PropertyDetailPage() {
                   <p className="text-sm text-slate-400 mb-4">por mes</p>
                 )}
 
-                <button
+                <Button
                   onClick={handleReserve}
-                  className="w-full flex items-center justify-center gap-2 py-3 rounded-lg bg-emerald-500 text-white font-semibold hover:bg-emerald-600 transition-colors"
+                  className="w-full flex items-center justify-center gap-2 py-3"
                 >
-                  <CalendarDays className="w-5 h-5" />
-                  {property.type === 'rental' ? 'Solicitar visita' : 'Consultar'}
-                </button>
+                  <Lock className="h-4 w-4 mr-2" />
+                  {t('cta.securePayment')}
+                </Button>
 
                 <p className="text-xs text-slate-400 text-center mt-3">
                   Sin compromiso — te contactamos a la brevedad

--- a/frontend/src/pages/RecoverCartPage.tsx
+++ b/frontend/src/pages/RecoverCartPage.tsx
@@ -14,6 +14,7 @@ import { ShoppingCart, AlertTriangle, Loader2, ArrowRight, RefreshCw } from 'luc
 import { CartPreview } from '../components/Cart/CartPreview';
 import { useCartRecovery } from '../stores/cartStore';
 import { cn } from '../utils/cn';
+import { Button } from '../components/ui/button';
 
 // ============================================
 // Component / Componente
@@ -91,16 +92,10 @@ export function RecoverCartPage() {
           <p className="text-slate-400 mb-6">
             This page requires a valid recovery token. Please use the link from your email.
           </p>
-          <button
-            onClick={() => navigate('/products')}
-            className={cn(
-              'inline-flex items-center gap-2 rounded-lg px-6 py-3 text-sm font-medium',
-              'bg-purple-600 text-white transition-colors hover:bg-purple-500'
-            )}
-          >
+          <Button onClick={() => navigate('/products')}>
             Browse Products
             <ArrowRight className="h-4 w-4" />
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -160,27 +155,15 @@ export function RecoverCartPage() {
           <p className="text-slate-400 mb-6">{errorDescription}</p>
           <div className="flex items-center justify-center gap-3">
             {!isExpired && !isUsed && (
-              <button
-                onClick={handleRetry}
-                className={cn(
-                  'inline-flex items-center gap-2 rounded-lg border border-slate-600 px-4 py-2.5 text-sm font-medium',
-                  'text-white transition-colors hover:bg-slate-700'
-                )}
-              >
+              <Button variant="outline" onClick={handleRetry}>
                 <RefreshCw className="h-4 w-4" />
                 Try Again
-              </button>
+              </Button>
             )}
-            <button
-              onClick={() => navigate('/products')}
-              className={cn(
-                'inline-flex items-center gap-2 rounded-lg px-6 py-2.5 text-sm font-medium',
-                'bg-purple-600 text-white transition-colors hover:bg-purple-500'
-              )}
-            >
+            <Button onClick={() => navigate('/products')}>
               Browse Products
               <ArrowRight className="h-4 w-4" />
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -214,16 +197,10 @@ export function RecoverCartPage() {
 
         {/* Action Buttons */}
         <div className="flex flex-col gap-3">
-          <button
+          <Button
             onClick={handleProceedToCheckout}
             disabled={isRecovering}
-            className={cn(
-              'flex w-full items-center justify-center gap-2 rounded-xl px-6 py-3.5 text-base font-semibold',
-              'bg-purple-600 text-white transition-colors',
-              'hover:bg-purple-500',
-              'disabled:bg-slate-600 disabled:cursor-not-allowed',
-              'focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-slate-900'
-            )}
+            className="w-full py-3.5 text-base"
             aria-label="Proceed to checkout with recovered cart"
           >
             {isRecovering ? (
@@ -237,17 +214,11 @@ export function RecoverCartPage() {
                 <ArrowRight className="h-5 w-5" />
               </>
             )}
-          </button>
+          </Button>
 
-          <button
-            onClick={() => navigate('/products')}
-            className={cn(
-              'flex w-full items-center justify-center gap-2 rounded-xl border border-slate-600 px-6 py-3 text-sm font-medium',
-              'text-slate-300 transition-colors hover:bg-slate-800 hover:text-white'
-            )}
-          >
+          <Button variant="outline" onClick={() => navigate('/products')} className="w-full">
             Continue Browsing
-          </button>
+          </Button>
         </div>
 
         {/* Recovery Error (if confirmation fails) */}

--- a/frontend/src/pages/RecoverCartPage.tsx
+++ b/frontend/src/pages/RecoverCartPage.tsx
@@ -13,7 +13,6 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { ShoppingCart, AlertTriangle, Loader2, ArrowRight, RefreshCw } from 'lucide-react';
 import { CartPreview } from '../components/Cart/CartPreview';
 import { useCartRecovery } from '../stores/cartStore';
-import { cn } from '../utils/cn';
 import { Button } from '../components/ui/button';
 
 // ============================================

--- a/frontend/src/pages/ReservationFlowPage.tsx
+++ b/frontend/src/pages/ReservationFlowPage.tsx
@@ -22,7 +22,9 @@ import {
   Wallet,
   Shield,
   Clock,
+  Lock,
 } from 'lucide-react';
+import { Button } from '../components/ui/button';
 import { useReservationWizard } from '../stores/reservationStore';
 import { computePriceBreakdown, formatPrice } from '../stores/reservationStore';
 import type { WizardStep, PriceBreakdown } from '../stores/reservationStore';
@@ -302,14 +304,14 @@ function StepDates() {
       {/* Running total after selecting dates */}
       {breakdown && breakdown.totalNights > 0 && <PriceBadge breakdown={breakdown} />}
 
-      <button
+      <Button
         onClick={() => setWizardStep('guests')}
         disabled={!canContinue}
-        className="w-full flex items-center justify-center gap-2 py-3 rounded-lg bg-emerald-500 text-white font-semibold hover:bg-emerald-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        className="w-full gap-2 py-3"
       >
         {t('reservation.continue')}
         <ChevronRight className="w-5 h-5" />
-      </button>
+      </Button>
     </div>
   );
 }
@@ -374,21 +376,25 @@ function StepGuests() {
           {t('reservation.numberOfGuests')}
         </label>
         <div className="flex items-center gap-3 ml-auto">
-          <button
+          <Button
+            variant="outline"
+            size="icon"
             onClick={() => updateWizardData({ guests: Math.max(1, wizardData.guests - 1) })}
-            className="w-9 h-9 rounded-lg border border-slate-200 flex items-center justify-center hover:bg-slate-50 transition-colors text-lg font-medium"
+            className="w-9 h-9 rounded-lg text-lg font-medium"
           >
             −
-          </button>
+          </Button>
           <span className="w-10 text-center font-semibold text-lg text-slate-800">
             {wizardData.guests}
           </span>
-          <button
+          <Button
+            variant="outline"
+            size="icon"
             onClick={() => updateWizardData({ guests: Math.min(maxGuests, wizardData.guests + 1) })}
-            className="w-9 h-9 rounded-lg border border-slate-200 flex items-center justify-center hover:bg-slate-50 transition-colors text-lg font-medium"
+            className="w-9 h-9 rounded-lg text-lg font-medium"
           >
             +
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -420,19 +426,16 @@ function StepGuests() {
 
       <div className="flex gap-3">
         {wizardData.type === 'property' && (
-          <button
+          <Button
+            variant="outline"
             onClick={() => setWizardStep('dates')}
-            className="flex items-center gap-2 px-4 py-3 rounded-lg border border-slate-200 text-slate-600 text-sm hover:bg-slate-50 transition-colors"
+            className="gap-2 px-4 py-3"
           >
             <ArrowLeft className="w-4 h-4" />
             {t('reservation.back')}
-          </button>
+          </Button>
         )}
-        <button
-          onClick={handleConfirm}
-          disabled={isCreating}
-          className="flex-1 flex items-center justify-center gap-2 py-3 rounded-lg bg-emerald-500 text-white font-semibold hover:bg-emerald-600 transition-colors disabled:opacity-60"
-        >
+        <Button onClick={handleConfirm} disabled={isCreating} className="flex-1 gap-2 py-3">
           {isCreating ? (
             <>
               <Loader2 className="w-5 h-5 animate-spin" />
@@ -444,7 +447,7 @@ function StepGuests() {
               <ChevronRight className="w-5 h-5" />
             </>
           )}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -508,21 +511,15 @@ function StepConfirm({ onGoToPayment, onGoToReservations, breakdown }: StepConfi
 
       {/* Action buttons */}
       <div className="flex flex-col gap-3">
-        <button
-          onClick={onGoToPayment}
-          className="w-full flex items-center justify-center gap-2 py-3 rounded-lg bg-emerald-500 text-white font-semibold hover:bg-emerald-600 transition-colors"
-        >
-          <CreditCard className="w-5 h-5" />
+        <Button onClick={onGoToPayment} className="w-full gap-2 py-3">
+          <Lock className="mr-2 h-4 w-4" />
           {t('reservation.selectPayment')}
           <ChevronRight className="w-5 h-5" />
-        </button>
-        <button
-          onClick={onGoToReservations}
-          className="w-full py-3 rounded-lg border border-slate-200 text-slate-600 font-medium hover:bg-slate-50 transition-colors text-sm"
-        >
+        </Button>
+        <Button variant="ghost" onClick={onGoToReservations} className="w-full py-3 text-sm">
           {t('reservation.payLater')}
           <span className="ml-2 text-slate-400">— {t('reservation.payLaterHint')}</span>
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -637,10 +634,11 @@ function StepPayment({ onDone, onGoToReservations, breakdown }: StepPaymentProps
       {/* Payment methods */}
       <div className="space-y-3">
         {/* PayPal */}
-        <button
+        <Button
+          variant="outline"
           onClick={handlePayPal}
           disabled={isProcessingPayment}
-          className="w-full flex items-center gap-4 p-4 rounded-xl border border-slate-200 hover:border-emerald-300 hover:bg-emerald-50/30 transition-all disabled:opacity-50 disabled:cursor-not-allowed group"
+          className="w-full flex items-center gap-4 p-4 rounded-xl h-auto hover:border-emerald-300 hover:bg-emerald-50/30 group"
         >
           <div className="w-12 h-12 bg-blue-50 rounded-xl flex items-center justify-center shrink-0">
             <span className="text-blue-600 font-bold text-lg">PP</span>
@@ -656,13 +654,14 @@ function StepPayment({ onDone, onGoToReservations, breakdown }: StepPaymentProps
           ) : (
             <ChevronRight className="w-5 h-5 text-slate-300 group-hover:text-emerald-500 transition-colors" />
           )}
-        </button>
+        </Button>
 
         {/* MercadoPago */}
-        <button
+        <Button
+          variant="outline"
           onClick={handleMercadoPago}
           disabled={isProcessingPayment}
-          className="w-full flex items-center gap-4 p-4 rounded-xl border border-slate-200 hover:border-emerald-300 hover:bg-emerald-50/30 transition-all disabled:opacity-50 disabled:cursor-not-allowed group"
+          className="w-full flex items-center gap-4 p-4 rounded-xl h-auto hover:border-emerald-300 hover:bg-emerald-50/30 group"
         >
           <div className="w-12 h-12 bg-sky-50 rounded-xl flex items-center justify-center shrink-0">
             <span className="text-sky-600 font-bold text-lg">MP</span>
@@ -678,17 +677,18 @@ function StepPayment({ onDone, onGoToReservations, breakdown }: StepPaymentProps
           ) : (
             <ChevronRight className="w-5 h-5 text-slate-300 group-hover:text-emerald-500 transition-colors" />
           )}
-        </button>
+        </Button>
 
         {/* Wallet (hidden when crypto wallet feature is disabled) */}
         {featureFlags.cryptoWallet && (
-          <button
+          <Button
+            variant="outline"
             onClick={onDone}
             disabled={!hasEnoughBalance || isProcessingPayment}
             className={cn(
-              'w-full flex items-center gap-4 p-4 rounded-xl border transition-all group',
+              'w-full flex items-center gap-4 p-4 rounded-xl h-auto group',
               hasEnoughBalance
-                ? 'border-slate-200 hover:border-emerald-300 hover:bg-emerald-50/30'
+                ? 'hover:border-emerald-300 hover:bg-emerald-50/30'
                 : 'border-slate-100 bg-slate-50 opacity-60 cursor-not-allowed'
             )}
           >
@@ -719,7 +719,7 @@ function StepPayment({ onDone, onGoToReservations, breakdown }: StepPaymentProps
             ) : (
               <AlertCircle className="w-5 h-5 text-slate-300" />
             )}
-          </button>
+          </Button>
         )}
       </div>
 
@@ -733,13 +733,14 @@ function StepPayment({ onDone, onGoToReservations, breakdown }: StepPaymentProps
 
       {/* Pay later link */}
       <div className="text-center">
-        <button
+        <Button
+          variant="ghost"
           onClick={onGoToReservations}
-          className="inline-flex items-center gap-2 text-sm text-slate-500 hover:text-emerald-600 transition-colors"
+          className="gap-2 text-sm text-slate-500 hover:text-emerald-600"
         >
           <Clock className="w-4 h-4" />
           {t('reservation.payLater')}
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -803,12 +804,13 @@ export default function ReservationFlowPage() {
             <span className="font-medium line-clamp-1">{contextLabel}</span>
           </div>
           {showCancelBtn && (
-            <button
+            <Button
+              variant="ghost"
               onClick={handleCancel}
-              className="text-xs text-slate-400 hover:text-slate-600 transition-colors"
+              className="text-xs text-slate-400 hover:text-slate-600"
             >
               {t('reservation.cancel')}
-            </button>
+            </Button>
           )}
         </div>
 

--- a/frontend/src/pages/ReservationFlowPage.tsx
+++ b/frontend/src/pages/ReservationFlowPage.tsx
@@ -196,7 +196,7 @@ function StepIndicator({ currentStep, visibleSteps }: StepIndicatorProps) {
   const currentIndex = visibleOrder.indexOf(currentStep);
 
   return (
-    <div className="flex items-center justify-center gap-0 mb-8">
+    <div className="flex items-center justify-center gap-0 mb-8 overflow-x-auto">
       {visibleSteps.map((step, i) => {
         const isDone = i < currentIndex;
         const isCurrent = i === currentIndex;
@@ -206,7 +206,7 @@ function StepIndicator({ currentStep, visibleSteps }: StepIndicatorProps) {
             <div className="flex flex-col items-center">
               <div
                 className={cn(
-                  'w-9 h-9 rounded-full flex items-center justify-center text-sm font-semibold border-2 transition-all',
+                  'w-9 h-9 shrink-0 rounded-full flex items-center justify-center text-sm font-semibold border-2 transition-all',
                   isDone && 'bg-emerald-500 border-emerald-500 text-white',
                   isCurrent && 'bg-white border-emerald-500 text-emerald-600',
                   !isDone && !isCurrent && 'bg-white border-slate-200 text-slate-400'
@@ -216,7 +216,7 @@ function StepIndicator({ currentStep, visibleSteps }: StepIndicatorProps) {
               </div>
               <span
                 className={cn(
-                  'text-xs mt-1 whitespace-nowrap',
+                  'text-xs mt-1 whitespace-nowrap min-w-0',
                   isCurrent ? 'text-emerald-600 font-medium' : 'text-slate-400'
                 )}
               >
@@ -380,7 +380,7 @@ function StepGuests() {
             variant="outline"
             size="icon"
             onClick={() => updateWizardData({ guests: Math.max(1, wizardData.guests - 1) })}
-            className="w-9 h-9 rounded-lg text-lg font-medium"
+            className="h-11 w-11 rounded-lg text-lg font-medium"
           >
             −
           </Button>
@@ -391,7 +391,7 @@ function StepGuests() {
             variant="outline"
             size="icon"
             onClick={() => updateWizardData({ guests: Math.min(maxGuests, wizardData.guests + 1) })}
-            className="w-9 h-9 rounded-lg text-lg font-medium"
+            className="h-11 w-11 rounded-lg text-lg font-medium"
           >
             +
           </Button>
@@ -632,7 +632,7 @@ function StepPayment({ onDone, onGoToReservations, breakdown }: StepPaymentProps
       )}
 
       {/* Payment methods */}
-      <div className="space-y-3">
+      <div className="relative space-y-3">
         {/* PayPal */}
         <Button
           variant="outline"
@@ -720,6 +720,17 @@ function StepPayment({ onDone, onGoToReservations, breakdown }: StepPaymentProps
               <AlertCircle className="w-5 h-5 text-slate-300" />
             )}
           </Button>
+        )}
+
+        {/* Payment processing overlay / Overlay de procesamiento de pago */}
+        {isProcessingPayment && (
+          <div
+            data-testid="payment-loading-overlay"
+            className="absolute inset-0 z-10 flex flex-col items-center justify-center rounded-xl bg-white/80 backdrop-blur-sm"
+          >
+            <Loader2 className="h-8 w-8 animate-spin text-emerald-500 mb-3" />
+            <p className="text-sm font-medium text-slate-700">{t('loading.processingPayment')}</p>
+          </div>
         )}
       </div>
 

--- a/frontend/src/pages/TourDetailPage.tsx
+++ b/frontend/src/pages/TourDetailPage.tsx
@@ -601,6 +601,29 @@ export default function TourDetailPage() {
               </div>
             </div>
           </div>
+
+          {/* Spacer for mobile sticky CTA / Espacio para CTA fijo en móvil */}
+          <div className="h-20 lg:h-0" />
+        </div>
+      </div>
+
+      {/* Mobile sticky CTA bar / Barra CTA fija en móvil */}
+      <div
+        className="fixed bottom-0 inset-x-0 z-40 border-t border-slate-200 bg-white/95 backdrop-blur-sm px-4 py-3 lg:hidden"
+        data-testid="mobile-sticky-cta"
+      >
+        <div className="flex items-center justify-between gap-4 max-w-4xl mx-auto">
+          <div>
+            <p className="text-lg font-bold text-emerald-600">
+              {tour.currency}{' '}
+              {Number(tour.price).toLocaleString('es-AR', { minimumFractionDigits: 0 })}
+            </p>
+            <p className="text-xs text-slate-400">por persona</p>
+          </div>
+          <Button onClick={handleReserve} disabled={!selectedAvailability} className="shrink-0">
+            <Lock className="h-4 w-4 mr-2" />
+            {t('cta.securePayment')}
+          </Button>
         </div>
       </div>
     </>

--- a/frontend/src/pages/TourDetailPage.tsx
+++ b/frontend/src/pages/TourDetailPage.tsx
@@ -28,7 +28,9 @@ import {
   X,
   Compass,
   AlertTriangle,
+  Lock,
 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { tourService } from '../services/tourService';
 import type { TourPackage, TourCategory, TourAvailability } from '../services/tourService';
 import { useReservationStore } from '../stores/reservationStore';
@@ -86,27 +88,33 @@ function ImageGallery({ images, title }: ImageGalleryProps) {
       />
       {images.length > 1 && (
         <>
-          <button
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={() => setCurrent((c) => (c === 0 ? images.length - 1 : c - 1))}
-            className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/40 text-white flex items-center justify-center hover:bg-black/60 transition-colors"
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/40 text-white hover:bg-black/60"
             aria-label="Imagen anterior"
           >
             <ChevronLeft className="w-5 h-5" />
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
             onClick={() => setCurrent((c) => (c === images.length - 1 ? 0 : c + 1))}
-            className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/40 text-white flex items-center justify-center hover:bg-black/60 transition-colors"
+            className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/40 text-white hover:bg-black/60"
             aria-label="Imagen siguiente"
           >
             <ChevronRight className="w-5 h-5" />
-          </button>
+          </Button>
           <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1.5">
             {images.map((_, i) => (
-              <button
+              <Button
                 key={i}
+                variant="ghost"
+                size="icon"
                 onClick={() => setCurrent(i)}
                 className={cn(
-                  'w-2 h-2 rounded-full transition-colors',
+                  'w-2 h-2 rounded-full p-0 min-w-0 h-auto',
                   i === current ? 'bg-white' : 'bg-white/50'
                 )}
               />
@@ -142,12 +150,13 @@ function AvailabilityPicker({ availabilities, selected, onSelect }: Availability
         });
 
         return (
-          <button
+          <Button
             key={a.id}
+            variant="outline"
             onClick={() => !isFull && onSelect(a)}
             disabled={isFull}
             className={cn(
-              'px-3 py-2 rounded-lg text-sm border transition-all',
+              'px-3 py-2 h-auto text-sm',
               isSelected && 'border-emerald-500 bg-emerald-50 text-emerald-700 font-semibold',
               !isSelected && !isFull && 'border-slate-200 hover:border-emerald-300 text-slate-700',
               isFull && 'border-slate-100 text-slate-300 line-through cursor-not-allowed'
@@ -157,7 +166,7 @@ function AvailabilityPicker({ availabilities, selected, onSelect }: Availability
             <span className="block text-xs text-current opacity-70">
               {isFull ? 'Completo' : `${a.availableSpots} lugares`}
             </span>
-          </button>
+          </Button>
         );
       })}
     </div>
@@ -239,12 +248,13 @@ export default function TourDetailPage() {
     return (
       <div className="max-w-5xl mx-auto px-4 py-20 text-center">
         <p className="text-red-500 mb-4">{error ?? 'Tour no encontrado'}</p>
-        <button
+        <Button
+          variant="ghost"
           onClick={() => navigate('/tours')}
           className="text-emerald-600 hover:underline text-sm"
         >
           Volver al listado
-        </button>
+        </Button>
       </div>
     );
   }
@@ -340,13 +350,14 @@ export default function TourDetailPage() {
       <div className="min-h-screen bg-slate-50 pb-12">
         <div className="max-w-5xl mx-auto px-4 py-8">
           {/* Back button */}
-          <button
+          <Button
+            variant="ghost"
             onClick={() => navigate('/tours')}
-            className="flex items-center gap-2 text-sm text-slate-500 hover:text-slate-800 mb-6 transition-colors"
+            className="flex items-center gap-2 text-sm text-slate-500 hover:text-slate-800 mb-6"
           >
             <ArrowLeft className="w-4 h-4" />
             Volver a tours
-          </button>
+          </Button>
 
           {/* Gallery */}
           <ImageGallery images={tour.images} title={tour.title} />
@@ -547,13 +558,9 @@ export default function TourDetailPage() {
                         <div className="text-sm bg-red-50 border border-red-200 rounded-lg px-3 py-2 mb-4 text-red-700 font-semibold text-center">
                           {t('tours.soldOut')}
                         </div>
-                        <button
-                          type="button"
-                          disabled
-                          className="w-full flex items-center justify-center gap-2 py-3 rounded-lg bg-slate-300 text-slate-500 font-semibold cursor-not-allowed"
-                        >
+                        <Button type="button" disabled className="w-full">
                           {t('tours.soldOut')}
-                        </button>
+                        </Button>
                       </>
                     );
                   }
@@ -576,14 +583,14 @@ export default function TourDetailPage() {
                         </p>
                       )}
 
-                      <button
+                      <Button
                         onClick={handleReserve}
                         disabled={!selectedAvailability}
-                        className="w-full flex items-center justify-center gap-2 py-3 rounded-lg bg-emerald-500 text-white font-semibold hover:bg-emerald-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                        className="w-full"
                       >
-                        <CalendarDays className="w-5 h-5" />
-                        Reservar este tour
-                      </button>
+                        <Lock className="h-4 w-4 mr-2" />
+                        {t('cta.securePayment')}
+                      </Button>
                     </>
                   );
                 })()}

--- a/frontend/src/pages/ToursPage.tsx
+++ b/frontend/src/pages/ToursPage.tsx
@@ -26,6 +26,8 @@ import type { TourPackage, TourListParams, TourCategory } from '../services/tour
 import { cn } from '../lib/utils';
 import { APP_URL } from '../config/app.config';
 import { Button } from '@/components/ui/button';
+import { ListingSkeleton } from '@/components/ui/skeletons';
+import { EmptyState } from '@/components/EmptyState';
 
 // ============================================
 // Helpers / Utilidades
@@ -396,33 +398,11 @@ export default function ToursPage() {
             </div>
           )}
 
-          {/* Loading skeleton */}
-          {isLoading && (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {Array.from({ length: 8 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="rounded-xl border border-slate-200 bg-white overflow-hidden"
-                >
-                  <div className="h-52 bg-slate-200 animate-pulse" />
-                  <div className="p-4 space-y-3">
-                    <div className="h-4 bg-slate-200 rounded animate-pulse" />
-                    <div className="h-3 bg-slate-200 rounded w-3/4 animate-pulse" />
-                    <div className="h-5 bg-slate-200 rounded w-1/2 animate-pulse" />
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+          {/* Loading skeleton / Esqueleto de carga */}
+          {isLoading && <ListingSkeleton variant="tour" count={8} />}
 
-          {/* Empty state */}
-          {!isLoading && !error && tours.length === 0 && (
-            <div className="text-center py-20 text-slate-400">
-              <Compass className="w-12 h-12 mx-auto mb-4 opacity-30" />
-              <p className="text-lg font-medium">No se encontraron tours</p>
-              <p className="text-sm mt-1">Probá ajustando los filtros</p>
-            </div>
-          )}
+          {/* Empty state / Estado vacío */}
+          {!isLoading && !error && tours.length === 0 && <EmptyState type="search" />}
 
           {/* Tours grid */}
           {!isLoading && tours.length > 0 && (

--- a/frontend/src/pages/ToursPage.tsx
+++ b/frontend/src/pages/ToursPage.tsx
@@ -25,6 +25,7 @@ import { tourService } from '../services/tourService';
 import type { TourPackage, TourListParams, TourCategory } from '../services/tourService';
 import { cn } from '../lib/utils';
 import { APP_URL } from '../config/app.config';
+import { Button } from '@/components/ui/button';
 
 // ============================================
 // Helpers / Utilidades
@@ -190,25 +191,22 @@ function TourCard({ tour, onClick }: TourCardProps) {
             <span className="text-sm font-normal text-slate-400"> / persona</span>
           </p>
           {isSoldOut ? (
-            <button
-              type="button"
-              disabled
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-300 text-slate-500 text-sm font-medium cursor-not-allowed shrink-0"
-            >
+            <Button type="button" disabled variant="outline" size="sm" className="shrink-0">
               {t('tours.soldOut')}
-            </button>
+            </Button>
           ) : (
-            <button
+            <Button
               type="button"
+              size="sm"
               onClick={(e) => {
                 e.stopPropagation();
                 navigate(`/reservations/new?tourPackageId=${tour.id}`);
               }}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 transition-colors shrink-0"
+              className="shrink-0"
             >
               <CalendarCheck className="w-3.5 h-3.5" />
               {t('catalog.bookNow')}
-            </button>
+            </Button>
           )}
         </div>
       </div>
@@ -378,22 +376,15 @@ export default function ToursPage() {
                 className="w-36 px-3 py-2 rounded-lg border border-slate-200 text-sm focus:outline-none focus:border-emerald-400"
               />
 
-              <button
-                type="submit"
-                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 transition-colors"
-              >
+              <Button type="submit">
                 <SlidersHorizontal className="w-4 h-4" />
                 Filtrar
-              </button>
+              </Button>
 
               {hasActiveFilters && (
-                <button
-                  type="button"
-                  onClick={clearFilters}
-                  className="px-4 py-2 rounded-lg border border-slate-200 text-sm text-slate-600 hover:bg-slate-50 transition-colors"
-                >
+                <Button type="button" variant="outline" onClick={clearFilters}>
                   Limpiar
-                </button>
+                </Button>
               )}
             </form>
           </div>
@@ -445,23 +436,23 @@ export default function ToursPage() {
               {/* Pagination */}
               {pagination && pagination.totalPages > 1 && (
                 <div className="flex justify-center gap-2 mt-8">
-                  <button
+                  <Button
+                    variant="outline"
                     onClick={() => setPage((p) => Math.max(1, p - 1))}
                     disabled={page === 1}
-                    className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
                   >
                     Anterior
-                  </button>
+                  </Button>
                   <span className="px-4 py-2 text-sm text-slate-600">
                     Página {page} de {pagination.totalPages}
                   </span>
-                  <button
+                  <Button
+                    variant="outline"
                     onClick={() => setPage((p) => Math.min(pagination.totalPages, p + 1))}
                     disabled={page === pagination.totalPages}
-                    className="px-4 py-2 rounded-lg border border-slate-200 text-sm disabled:opacity-40 hover:bg-slate-50 transition-colors"
                   >
                     Siguiente
-                  </button>
+                  </Button>
                 </div>
               )}
             </>

--- a/frontend/src/test/propertiesFlow.test.tsx
+++ b/frontend/src/test/propertiesFlow.test.tsx
@@ -334,21 +334,21 @@ describe('Properties flow (listing → detail)', () => {
       expect(screen.queryByText('por mes')).not.toBeInTheDocument();
     });
 
-    it('shows "Solicitar visita" CTA for rental properties', async () => {
+    it('shows "Pago seguro" CTA for rental properties', async () => {
       vi.mocked(propertyService.getProperty).mockResolvedValueOnce(mockProperty);
       renderDetailPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /solicitar visita/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /pago seguro/i })).toBeInTheDocument();
       });
     });
 
-    it('shows "Consultar" CTA for sale properties', async () => {
+    it('shows "Pago seguro" CTA for sale properties', async () => {
       vi.mocked(propertyService.getProperty).mockResolvedValueOnce(mockSaleProperty);
       renderDetailPage('prop-456');
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /consultar/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /pago seguro/i })).toBeInTheDocument();
       });
     });
 
@@ -357,10 +357,10 @@ describe('Properties flow (listing → detail)', () => {
       renderDetailPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /solicitar visita/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /pago seguro/i })).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole('button', { name: /solicitar visita/i }));
+      fireEvent.click(screen.getByRole('button', { name: /pago seguro/i }));
 
       const storeWizardData = useReservationStore.getState().wizardData;
       expect(storeWizardData?.type).toBe('property');

--- a/frontend/src/test/propertiesFlow.test.tsx
+++ b/frontend/src/test/propertiesFlow.test.tsx
@@ -317,7 +317,8 @@ describe('Properties flow (listing → detail)', () => {
       renderDetailPage();
 
       await waitFor(() => {
-        expect(screen.getByText('por mes')).toBeInTheDocument();
+        const elements = screen.getAllByText('por mes');
+        expect(elements.length).toBeGreaterThanOrEqual(1);
       });
     });
 
@@ -339,7 +340,8 @@ describe('Properties flow (listing → detail)', () => {
       renderDetailPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /pago seguro/i })).toBeInTheDocument();
+        const buttons = screen.getAllByRole('button', { name: /pago seguro/i });
+        expect(buttons.length).toBeGreaterThanOrEqual(1);
       });
     });
 
@@ -348,7 +350,8 @@ describe('Properties flow (listing → detail)', () => {
       renderDetailPage('prop-456');
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /pago seguro/i })).toBeInTheDocument();
+        const buttons = screen.getAllByRole('button', { name: /pago seguro/i });
+        expect(buttons.length).toBeGreaterThanOrEqual(1);
       });
     });
 
@@ -357,10 +360,12 @@ describe('Properties flow (listing → detail)', () => {
       renderDetailPage();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /pago seguro/i })).toBeInTheDocument();
+        const buttons = screen.getAllByRole('button', { name: /pago seguro/i });
+        expect(buttons.length).toBeGreaterThanOrEqual(1);
       });
 
-      fireEvent.click(screen.getByRole('button', { name: /pago seguro/i }));
+      const buttons = screen.getAllByRole('button', { name: /pago seguro/i });
+      fireEvent.click(buttons[0]);
 
       const storeWizardData = useReservationStore.getState().wizardData;
       expect(storeWizardData?.type).toBe('property');

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -128,6 +128,24 @@ const mockT = (key: string, _options?: Record<string, unknown>) => {
     'cta.cancel': 'Cancelar',
     'cta.back': 'Volver',
     'cta.continue': 'Continuar',
+    // EmptyState keys (Issue #159 — Phase 2)
+    'emptyStates.tours.title': 'No se encontraron tours',
+    'emptyStates.tours.description':
+      'Probá ajustando los filtros o explorá todas las opciones disponibles.',
+    'emptyStates.properties.title': 'No se encontraron propiedades',
+    'emptyStates.properties.description':
+      'Probá ajustando los filtros o explorá todas las propiedades disponibles.',
+    'emptyStates.cart.title': 'Tu carrito está vacío',
+    'emptyStates.cart.description': 'Explorá tours y propiedades disponibles para comenzar.',
+    'emptyStates.reservation.title': 'No tenés reservas todavía',
+    'emptyStates.reservation.description':
+      'Explorá propiedades y tours disponibles para hacer tu primera reserva.',
+    'emptyStates.order.title': 'No tenés órdenes todavía',
+    'emptyStates.order.description':
+      'Tus compras aparecerán aquí cuando realices tu primera orden.',
+    // Loading keys (Issue #159 — Phase 2)
+    'loading.processingPayment': 'Procesando pago...',
+    'loading.fetchingData': 'Cargando datos...',
     // Checkout flow
     'checkout.title': 'Checkout',
     'checkout.subtitle': 'Completá tu compra',

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -122,6 +122,28 @@ const mockT = (key: string, _options?: Record<string, unknown>) => {
     'reservation.subtotal': 'Subtotal',
     'reservation.total': 'Total',
     'reservation.priceBreakdown': 'Desglose de precio',
+    // CTA keys (Issue #159 — UX Polish)
+    'cta.securePayment': 'Pago seguro',
+    'cta.confirmPayment': 'Confirmar pago',
+    'cta.cancel': 'Cancelar',
+    'cta.back': 'Volver',
+    'cta.continue': 'Continuar',
+    // Checkout flow
+    'checkout.title': 'Checkout',
+    'checkout.subtitle': 'Completá tu compra',
+    'checkout.confirmPurchase': 'Confirmar compra',
+    'checkout.total': 'Total',
+    'checkout.processing': 'Procesando...',
+    'checkout.success': '¡Compra exitosa!',
+    'checkout.simulatedWarning': 'Este es un pago simulado',
+    'checkout.productUnavailable': 'Producto no disponible',
+    'checkout.productNotFound': 'Producto no encontrado',
+    'checkout.backToProducts': 'Volver a productos',
+    'checkout.error': 'Error al procesar la compra',
+    'common.cancel': 'Cancelar',
+    'products.loading': 'Cargando productos...',
+    'products.error': 'Error al cargar productos',
+    'products.days': 'días',
   };
   return translations[key] || key;
 };


### PR DESCRIPTION
## Summary

Implements **Issue #159 — UX Polish (Purchase & Reservation Flow)**, the final issue in Sprint 10. Standardizes the UX layer across all purchase and reservation flows in 3 phases.

## Changes

### Phase 1 — Button Migration (`faeafe7`)
- Migrated all raw `<button>` elements to shadcn `<Button>` across **9 pages**: ToursPage, PropertiesPage, TourDetailPage, PropertyDetailPage, MisReservasPage, RecoverCartPage, OrderSuccess, Checkout, ReservationFlowPage
- Added `Lock` icon + `cta.securePayment` i18n label to all payment CTAs
- Migrated `CartRecoveryNotif` from custom positioned component to Sonner `toast()` API
- Upgraded `EmptyState` internal button to shadcn `<Button>`
- Added `cta.*` i18n keys (ES + EN)
- **Grep validated**: zero raw `<button>` in all 9 target pages

### Phase 2 — Content States (`bf37ae6`)
- Extended `EmptyState` component: 6 types (`default | search | error | cart | reservation | order`), `actionHref` prop for navigation-based CTAs, Lucide icons per type
- Created `TourCardSkeleton`, `PropertyCardSkeleton`, and `ListingSkeleton` grid wrapper in `components/ui/skeletons/`
- Added skeleton loading states to `ToursPage` and `PropertiesPage`
- Added empty state rendering when data arrays are empty
- Added `emptyStates.*` and `loading.*` i18n keys (ES + EN)

### Phase 3 — Mobile + Loading (`16fa846`)
- **Mobile step indicator**: `overflow-x-auto`, `shrink-0` circles, `min-w-0` labels on ReservationFlowPage
- **WCAG AA touch targets**: Guest counter buttons now `h-11 w-11` (44px minimum)
- **Mobile sticky CTA**: Fixed bottom bar on TourDetailPage + PropertyDetailPage (`lg:hidden` / `lg:relative`)
- **Payment loading overlay**: `backdrop-blur` + `Loader2` spinner on Checkout and ReservationFlowPage Step 4 when `isProcessing=true`
- **Mobile payment grid**: `sm:grid-cols-2` stacking on CheckoutForm

## Testing

- **600 tests pass** (up from 518 pre-change) across 65 test files
- **50 new tests** covering:
  - Button migration validation (12 test files per page)
  - EmptyState 6-type rendering + actionHref navigation
  - Skeleton component rendering
  - Loading/empty state integration on listing pages
  - Mobile responsive CSS class assertions
  - Payment loading overlay visibility
  - i18n key existence (ES + EN)
- `pnpm tsc -b` passes clean (zero errors)
- `lint-staged` (Prettier) passes on all commits

## Design Decisions

| # | Decision | Rationale |
|---|----------|-----------|
| D1 | Page-by-page button migration, both purple + emerald → shadcn `default` | Unifying CTA color IS the goal; global regex too risky |
| D2 | EmptyState type union (6 types) + `actionHref` prop | Single component, two action patterns (callback vs navigation) |
| D3 | Domain-specific skeletons (`TourCard`, `PropertyCard`) | Generic skeleton looks wrong — shimmer must mirror actual card layout |
| D4 | Sonner `toast()` directly, no wrapper utility | API is already clean; wrapper adds zero value |
| D5 | CSS-only mobile fixes, target 375px | Matches existing mobile-first convention; avoids component restructuring |
| D6 | Inline payment overlay (`absolute inset-0 + backdrop-blur`) | Full-page overlay hides cart context — inline keeps order summary visible |

## Closes #159