### PR TITLE
fix: Fix skipped push tests and replace console.warn with Pino logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ Todos los cambios notables de este proyecto serán documentados en este archivo.
 
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/).
 
+## [3.0.1] - 2026-06-16
+
+### Fixed — Sprint 11: Quick Wins
+
+#### Push Notification Integration Tests
+
+- **Habilitados 4 tests de push previamente ignorados** — `push.test.ts`: tests de create, unsubscribe, VAPID key con datos inválidos ahora se ejecutan y pasan
+- **Registro de PushSubscription en setup.ts** — Agregado modelo `PushSubscription` al sync de Sequelize para que la tabla `push_subscriptions` se cree durante los tests de integración
+- **Mock de uuid para Jest CJS** — Creado `__mocks__/uuid.ts` con implementación CJS-compatible de uuid v4 que genera UUIDs válidos para PostgreSQL; necesario porque uuid v14 es ESM-only y Jest no puede resolverlo con `require()`
+
+#### Centralized Logger
+
+- **Reemplazado `console.warn` por Pino logger** en `backend/src/config/env.ts` — Ahora usa el logger centralizado desde `../utils/logger` para mantener consistencia en el logging de la aplicación
+
+---
+
 ## [3.0.0] - 2026-04-13
 
 ### Added — Sprint 10: Payments, Invoices, Unilevel & UX Polish

--- a/backend/jest.integration.config.cjs
+++ b/backend/jest.integration.config.cjs
@@ -22,9 +22,11 @@ module.exports = {
   detectOpenHandles: true,
   workerIdleMemoryLimit: '512MB',
   // Mock Sentry to prevent hanging (Sentry v10 hangs on import with fake DSN)
+  // Mock uuid v14 (ESM-only) with CJS-compatible mock
   // Rewrite .js extensions to .ts for ts-jest compatibility with NodeNext imports
   moduleNameMapper: {
     '^@sentry/node$': '<rootDir>/src/__tests__/__mocks__/sentry.ts',
+    '^uuid$': '<rootDir>/src/__tests__/__mocks__/uuid.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
 };

--- a/backend/src/__tests__/__mocks__/uuid.ts
+++ b/backend/src/__tests__/__mocks__/uuid.ts
@@ -1,0 +1,16 @@
+/**
+ * @fileoverview Mock for uuid v14 (ESM-only) to work with Jest CJS runtime
+ * @description Provides CJS-compatible uuid v4 implementation producing valid UUIDs
+ */
+
+let counter = 0;
+
+export function v4(): string {
+  counter++;
+  const ts = Date.now().toString(16).padStart(12, '0');
+  const seq = counter.toString(16).padStart(6, '0').slice(0, 6);
+  const rand = Math.random().toString(16).slice(2, 14).padStart(12, '0');
+  return `${ts.slice(0, 8)}-${ts.slice(8, 12)}-4${seq.slice(0, 3)}-a${seq.slice(3, 6)}-${rand.slice(0, 12)}`;
+}
+
+export default { v4 };

--- a/backend/src/__tests__/integration/push.test.ts
+++ b/backend/src/__tests__/integration/push.test.ts
@@ -16,17 +16,27 @@ describe('Push Integration Tests', () => {
 
   beforeEach(async () => {
     // Create test user and get auth headers
-    testUser = await createTestUser({
-      email: 'push-test@test.mlm',
-      password: 'TestPass123!',
-      referralCode: 'PUSHTEST',
-    });
+    try {
+      testUser = await createTestUser({
+        email: 'push-test@test.mlm',
+        password: 'TestPass123!',
+        referralCode: 'PUSHTEST',
+      });
+    } catch (err: any) {
+      console.error('CREATE USER ERROR:', err.message);
+      if (err.parent) {
+        console.error('PARENT:', err.parent.message || err.parent);
+      }
+      if (err.sql) {
+        console.error('SQL:', err.sql);
+      }
+      throw err;
+    }
     authHeaders = getAuthHeaders(testUser);
   });
 
   describe('POST /api/push/subscribe', () => {
-    // TODO: Pre-existing failure — push subscribe returns 500 in CI (PushSubscription model issue)
-    it.skip('should create push subscription with valid data', async () => {
+    it('should create push subscription with valid data', async () => {
       const subscriptionData = {
         endpoint: 'https://fcm.googleapis.com/fcm/send/test-endpoint-123',
         keys: {
@@ -126,8 +136,7 @@ describe('Push Integration Tests', () => {
       expect(res.body.success).toBe(false);
     });
 
-    // TODO: Pre-existing failure — push subscribe returns 500 in CI (PushSubscription model issue)
-    it.skip('should create subscription with user agent', async () => {
+    it('should create subscription with user agent', async () => {
       const subscriptionData = {
         endpoint: 'https://fcm.googleapis.com/fcm/send/test-with-ua',
         keys: {
@@ -146,8 +155,7 @@ describe('Push Integration Tests', () => {
       expect(res.body.success).toBe(true);
     });
 
-    // TODO: Pre-existing failure — push subscribe returns 500 in CI (PushSubscription model issue)
-    it.skip('should update existing subscription when endpoint already exists', async () => {
+    it('should update existing subscription when endpoint already exists', async () => {
       const subscriptionData = {
         endpoint: 'https://fcm.googleapis.com/fcm/send/duplicate-endpoint',
         keys: {
@@ -183,8 +191,7 @@ describe('Push Integration Tests', () => {
   });
 
   describe('DELETE /api/push/unsubscribe', () => {
-    // TODO: Pre-existing failure — push subscribe returns 500 in CI (PushSubscription model issue)
-    it.skip('should unsubscribe with valid endpoint', async () => {
+    it('should unsubscribe with valid endpoint', async () => {
       // First subscribe
       const subscriptionData = {
         endpoint: 'https://fcm.googleapis.com/fcm/send/unsubscribe-test',

--- a/backend/src/__tests__/setup.ts
+++ b/backend/src/__tests__/setup.ts
@@ -60,6 +60,7 @@ beforeAll(async () => {
     ContractTemplate,
     AffiliateContract,
     WorkflowExecution,
+    PushSubscription,
   } = await import('../models');
 
   // Models imported for side-effect: registering with sequelize instance
@@ -93,6 +94,7 @@ beforeAll(async () => {
   void ContractTemplate;
   void AffiliateContract;
   void WorkflowExecution;
+  void PushSubscription;
 
   console.log('Models registered');
 

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -27,6 +27,7 @@
  * // Vars requeridas: BREVO_SMTP_*, BREVO_API_KEY
  */
 import dotenv from 'dotenv';
+import { logger } from '../utils/logger';
 
 dotenv.config();
 
@@ -237,7 +238,7 @@ if (!config.twoFactor.secretKey) {
  * Advertir si PLATFORM_DOMAIN no está configurado explícitamente (usa default).
  */
 if (!process.env.PLATFORM_DOMAIN) {
-  console.warn(
-    `⚠️  PLATFORM_DOMAIN is not set — defaulting to '${config.platform.domain}'. Set it in production.`
+  logger.warn(
+    `PLATFORM_DOMAIN is not set — defaulting to '${config.platform.domain}'. Set it in production.`
   );
 }


### PR DESCRIPTION
## Descripción
- Fix 4 skipped push notification tests (PushSubscription model missing from test setup, uuid mock generating invalid UUIDs)
- Replace console.warn with Pino logger in env.ts

## Tipo de Cambio
- [x] 🐛 **Bug fix** (cambio que resuelve un issue)
- [x] 🔧 **Refactorización** (cambio que no añade funcionalidad ni resuelve bug)

## Checklist
- [x] Mi código sigue las convenciones del proyecto
- [x] He añadido tests que prueban los cambios
- [x] Los tests pasan localmente (`pnpm test`)
- [ ] El build pasa (`pnpm build`)
- [x] He actualizado la documentación si es necesario

## Pasos para Testing Local
1. `pnpm test` en backend/ — push notification tests deben pasar