### PR TITLE
refactor(crm): Add foundation hooks and constants for CRM refactoring

### DIFF
--- a/frontend/src/components/crm/LeadCard.tsx
+++ b/frontend/src/components/crm/LeadCard.tsx
@@ -7,16 +7,7 @@
 import { Building, MessageSquare, Users, Filter, Edit } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Lead } from '../../types';
-
-const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
-  new: { bg: 'bg-blue-100', text: 'text-blue-700' },
-  contacted: { bg: 'bg-yellow-100', text: 'text-yellow-700' },
-  qualified: { bg: 'bg-purple-100', text: 'text-purple-700' },
-  proposal: { bg: 'bg-indigo-100', text: 'text-indigo-700' },
-  negotiation: { bg: 'bg-orange-100', text: 'text-orange-700' },
-  won: { bg: 'bg-green-100', text: 'text-green-700' },
-  lost: { bg: 'bg-red-100', text: 'text-red-700' },
-};
+import { STATUS_COLORS } from '../../features/crm/constants';
 
 const SOURCE_ICONS: Record<string, React.ReactNode> = {
   website: <MessageSquare className="w-4 h-4" />,

--- a/frontend/src/features/crm/constants.ts
+++ b/frontend/src/features/crm/constants.ts
@@ -1,0 +1,138 @@
+/**
+ * @fileoverview CRM shared constants — status colors, email templates, tab definitions
+ * @description Centralized constants extracted from CRM.tsx to avoid duplication.
+ *              Used by hooks, components, and the main CRM page.
+ *
+ * ES: Constantes compartidas de CRM — colores de estado, plantillas de email, definiciones de tabs.
+ * EN: CRM shared constants — status colors, email templates, tab definitions.
+ *
+ * @module features/crm/constants
+ */
+
+import type { i18n as I18nInstance } from 'i18next';
+
+// ============================================================================
+// Status Colors
+// ============================================================================
+
+/**
+ * Tailwind color classes for each lead status.
+ * Duplicated in LeadCard.tsx — both should import from here.
+ * Clases de color Tailwind para cada estado de lead.
+ */
+export const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
+  new: { bg: 'bg-blue-100', text: 'text-blue-700' },
+  contacted: { bg: 'bg-yellow-100', text: 'text-yellow-700' },
+  qualified: { bg: 'bg-purple-100', text: 'text-purple-700' },
+  proposal: { bg: 'bg-indigo-100', text: 'text-indigo-700' },
+  negotiation: { bg: 'bg-orange-100', text: 'text-orange-700' },
+  won: { bg: 'bg-green-100', text: 'text-green-700' },
+  lost: { bg: 'bg-red-100', text: 'text-red-700' },
+};
+
+// ============================================================================
+// Email Templates
+// ============================================================================
+
+export interface EmailTemplate {
+  id: string;
+  name: { es: string; en: string };
+  subject: { es: string; en: string };
+  content: { es: string; en: string };
+}
+
+/**
+ * Predefined email templates for quick-send from the lead detail panel.
+ * Each template is bilingual (es/en) and uses {{name}} and {{myName}} placeholders.
+ * Plantillas de email predefinidas para envío rápido desde el panel de detalle de lead.
+ */
+export const EMAIL_TEMPLATES: EmailTemplate[] = [
+  {
+    id: 'welcome',
+    name: { es: 'Bienvenida', en: 'Welcome' },
+    subject: { es: '¡Bienvenido a nuestra plataforma!', en: 'Welcome to our platform!' },
+    content: {
+      es: 'Hola {{name}},\n\n¡Gracias por tu interés en nuestra plataforma! Nos encantaría mostrarte cómo funciona y cómo puedes empezar a ganar comisiones.\n\n¿Tienes alguna pregunta?\n\nSaludos,\n{{myName}}',
+      en: 'Hi {{name}},\n\nThank you for your interest in our platform! We would love to show you how it works and how you can start earning commissions.\n\nDo you have any questions?\n\nBest regards,\n{{myName}}',
+    },
+  },
+  {
+    id: 'followup',
+    name: { es: 'Seguimiento', en: 'Follow-up' },
+    subject: { es: '¿Cómo va tu experiencia?', en: 'How is your experience going?' },
+    content: {
+      es: 'Hola {{name}},\n\nSolo quería hacer seguimiento para ver cómo va tu experiencia con nuestra plataforma.\n\n¿Hay algo en lo que pueda ayudarte?\n\nSaludos,\n{{myName}}',
+      en: 'Hi {{name}},\n\nJust wanted to follow up on how your experience with our platform is going.\n\nIs there anything I can help you with?\n\nBest regards,\n{{myName}}',
+    },
+  },
+  {
+    id: 'presentation',
+    name: { es: 'Presentación de producto', en: 'Product Presentation' },
+    subject: { es: 'Conoce más sobre nuestro producto', en: 'Learn more about our product' },
+    content: {
+      es: 'Hola {{name}},\n\nTe envío información sobre nuestro producto/servicio que creo que puede interesarte.\n\n[Descripción del producto]\n\n¿Te gustaría agendar una llamada para explicar más detalles?\n\nSaludos,\n{{myName}}',
+      en: "Hi {{name}},\n\nI'm sending you information about our product/service that I think might interest you.\n\n[Product description]\n\nWould you like to schedule a call to explain more details?\n\nBest regards,\n{{myName}}",
+    },
+  },
+  {
+    id: 'closing',
+    name: { es: 'Cierre de venta', en: 'Closing Sale' },
+    subject: { es: 'Último paso para unirte', en: 'Last step to join' },
+    content: {
+      es: 'Hola {{name}},\n\n¡Nos alegra que hayas decidido unirte a nuestra comunidad!\n\nPara completar tu registro, solo necesitas [acción requerida].\n\nSi tienes cualquier duda, estoy aquí para ayudarte.\n\nSaludos,\n{{myName}}',
+      en: "Hi {{name}},\n\nWe are glad you decided to join our community!\n\nTo complete your registration, you just need to [required action].\n\nIf you have any questions, I'm here to help.\n\nBest regards,\n{{myName}}",
+    },
+  },
+  {
+    id: 'support',
+    name: { es: 'Soporte técnico', en: 'Technical Support' },
+    subject: { es: 'Estoy aquí para ayudarte', en: "I'm here to help you" },
+    content: {
+      es: 'Hola {{name}},\n\nRecibí tu mensaje sobre [tema]. Estoy aquí para ayudarte.\n\n[Solución o siguiente paso]\n\n¿Necesitas algo más?\n\nSaludos,\n{{myName}}',
+      en: "Hi {{name}},\n\nI received your message about [topic]. I'm here to help you.\n\n[Solution or next step]\n\nDo you need anything else?\n\nBest regards,\n{{myName}}",
+    },
+  },
+];
+
+/**
+ * Resolve the appropriate localized value from a bilingual { es, en } object.
+ * Resuelve el valor localizado apropiado de un objeto bilingüe { es, en }.
+ */
+export function getLocalizedValue(value: { es: string; en: string }, i18n: I18nInstance): string {
+  return value[i18n.language as 'es' | 'en'] || value.en;
+}
+
+// ============================================================================
+// Tab Definitions
+// ============================================================================
+
+/** Available CRM tabs / Tabs disponibles de CRM */
+export const CRM_TABS = ['leads', 'kanban', 'tasks', 'stats'] as const;
+export type CRMTab = (typeof CRM_TABS)[number];
+
+// ============================================================================
+// Lead Constants
+// ============================================================================
+
+/** All possible lead statuses / Todos los estados posibles de lead */
+export const LEAD_STATUSES = [
+  'new',
+  'contacted',
+  'qualified',
+  'proposal',
+  'negotiation',
+  'won',
+  'lost',
+] as const;
+export type LeadStatus = (typeof LEAD_STATUSES)[number];
+
+/** All possible lead sources / Todas las fuentes posibles de lead */
+export const LEAD_SOURCES = [
+  'website',
+  'referral',
+  'social',
+  'landing_page',
+  'manual',
+  'other',
+] as const;
+export type LeadSource = (typeof LEAD_SOURCES)[number];

--- a/frontend/src/hooks/useCRMAnalytics.ts
+++ b/frontend/src/hooks/useCRMAnalytics.ts
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview useCRMAnalytics — CRM analytics report and insights
+ * @description Hook for fetching CRM analytics reports with period-based filtering
+ *              and CSV export. Uses the analytics API endpoints from api.ts.
+ *
+ * ES: Hook para obtener reportes de analítica de CRM con filtrado por período
+ *     y exportación CSV. Usa los endpoints de analítica de api.ts.
+ * EN: Hook for fetching CRM analytics reports with period-based filtering
+ *     and CSV export. Uses the analytics API endpoints from api.ts.
+ *
+ * @module hooks/useCRMAnalytics
+ */
+
+import { useState, useCallback } from 'react';
+import { crmService } from '../services/api';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type AnalyticsPeriod = 'week' | 'month' | 'quarter' | 'year';
+
+export interface AnalyticsReport {
+  // The shape depends on the API response; using generic record for flexibility
+  [key: string]: unknown;
+}
+
+export interface UseCRMAnalyticsResult {
+  /** Report data / Datos del reporte */
+  report: AnalyticsReport | null;
+  /** Whether the report is loading / Si el reporte se está cargando */
+  isLoading: boolean;
+  /** Error from last fetch / Error del último intento de carga */
+  error: Error | null;
+  /** Selected period / Período seleccionado */
+  period: AnalyticsPeriod;
+  /** Set the analysis period / Establecer el período de análisis */
+  setPeriod: (period: AnalyticsPeriod) => void;
+  /** Custom date range start / Inicio de rango de fechas personalizado */
+  dateFrom: string;
+  /** Set custom date range start / Establecer inicio de rango de fechas */
+  setDateFrom: (date: string) => void;
+  /** Custom date range end / Fin de rango de fechas personalizado */
+  dateTo: string;
+  /** Set custom date range end / Establecer fin de rango de fechas */
+  setDateTo: (date: string) => void;
+  /** Fetch the analytics report / Obtener el reporte de analítica */
+  fetchReport: () => Promise<void>;
+  /** Export analytics report to CSV / Exportar reporte de analítica a CSV */
+  exportReport: () => Promise<void>;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook for CRM analytics reports and insights.
+ *
+ * @returns {UseCRMAnalyticsResult} Report data, period state, and actions
+ */
+export function useCRMAnalytics(): UseCRMAnalyticsResult {
+  const [report, setReport] = useState<AnalyticsReport | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [period, setPeriod] = useState<AnalyticsPeriod>('month');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+
+  const fetchReport = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const params: { period?: AnalyticsPeriod; dateFrom?: string; dateTo?: string } = {};
+      if (dateFrom && dateTo) {
+        params.dateFrom = dateFrom;
+        params.dateTo = dateTo;
+      } else {
+        params.period = period;
+      }
+
+      const response = await crmService.getAnalyticsReport(params);
+      if (response.success) {
+        setReport(response.data);
+      }
+    } catch (err) {
+      const errorObj = err instanceof Error ? err : new Error('Failed to load analytics report');
+      setError(errorObj);
+      console.error('Failed to load analytics report:', errorObj);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [period, dateFrom, dateTo]);
+
+  const exportReport = useCallback(async () => {
+    try {
+      const params: { period?: AnalyticsPeriod; dateFrom?: string; dateTo?: string } = {};
+      if (dateFrom && dateTo) {
+        params.dateFrom = dateFrom;
+        params.dateTo = dateTo;
+      } else {
+        params.period = period;
+      }
+
+      const blob = await crmService.exportAnalyticsReport(params);
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `crm-analytics-${new Date().toISOString().split('T')[0]}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (err) {
+      console.error('Failed to export analytics report:', err);
+    }
+  }, [period, dateFrom, dateTo]);
+
+  return {
+    report,
+    isLoading,
+    error,
+    period,
+    setPeriod,
+    dateFrom,
+    setDateFrom,
+    dateTo,
+    setDateTo,
+    fetchReport,
+    exportReport,
+  };
+}

--- a/frontend/src/hooks/useCRMKanban.ts
+++ b/frontend/src/hooks/useCRMKanban.ts
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview useCRMKanban — kanban board data and drag-and-drop status updates
+ * @description Encapsulates loading leads for kanban display, grouping by status,
+ *              and handling drag-and-drop status changes. Abstracts the kanban
+ *              state management for the KanbanBoard component.
+ *
+ * ES: Hook que encapsula la carga de leads para visualización kanban,
+ *     agrupación por estado y manejo de cambios de estado por drag-and-drop.
+ * EN: Hook encapsulating loading leads for kanban display, grouping by status,
+ *     and handling drag-and-drop status changes.
+ *
+ * @module hooks/useCRMKanban
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { crmService } from '../services/crmService';
+import type { Lead, LeadStatus, LeadStats } from '../services/crmService';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface UseCRMKanbanResult {
+  /** All leads for the kanban board / Todos los leads para el tablero */
+  leads: Lead[];
+  /** Kanban stats summary / Resumen de estadísticas del kanban */
+  stats: LeadStats | null;
+  /** Whether data is loading / Si los datos se están cargando */
+  isLoading: boolean;
+  /** Error from last fetch / Error del último intento de carga */
+  error: Error | null;
+  /** Filter leads by status / Filtrar leads por estado */
+  getLeadsByStatus: (status: LeadStatus) => Lead[];
+  /** Handle drag-and-drop status change / Manejar cambio de estado por drag-and-drop */
+  handleDragEnd: (leadId: string, newStatus: LeadStatus) => Promise<void>;
+  /** Reload all kanban data / Recargar todos los datos del kanban */
+  refetch: () => Promise<void>;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook for kanban board data management.
+ *
+ * @returns {UseCRMKanbanResult} Kanban leads, stats, loading state, and actions
+ */
+export function useCRMKanban(): UseCRMKanbanResult {
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [stats, setStats] = useState<LeadStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadCRMData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [leadsData, statsData] = await Promise.all([
+        crmService.getLeads({ limit: 100 }),
+        crmService.getStats(),
+      ]);
+      setLeads(leadsData.leads);
+      setStats(statsData);
+    } catch (err) {
+      const errorObj = err instanceof Error ? err : new Error('Failed to load kanban data');
+      setError(errorObj);
+      console.error('Failed to load CRM data:', errorObj);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadCRMData();
+  }, [loadCRMData]);
+
+  const getLeadsByStatus = useCallback(
+    (status: LeadStatus): Lead[] => {
+      return leads.filter((lead) => lead.status === status);
+    },
+    [leads]
+  );
+
+  const handleDragEnd = useCallback(async (leadId: string, newStatus: LeadStatus) => {
+    try {
+      await crmService.updateLeadStatus(leadId, newStatus);
+      setLeads((prev) =>
+        prev.map((lead) => (lead.id === leadId ? { ...lead, status: newStatus } : lead))
+      );
+    } catch (err) {
+      console.error('Failed to update lead status:', err);
+    }
+  }, []);
+
+  return {
+    leads,
+    stats,
+    isLoading,
+    error,
+    getLeadsByStatus,
+    handleDragEnd,
+    refetch: loadCRMData,
+  };
+}

--- a/frontend/src/hooks/useCRMLeads.ts
+++ b/frontend/src/hooks/useCRMLeads.ts
@@ -1,0 +1,331 @@
+/**
+ * @fileoverview useCRMLeads — lead CRUD, filtering, and detail loading
+ * @description Encapsulates lead list state, filter state, CRUD operations,
+ *              lead detail loading (with tasks + communications), status changes,
+ *              task completion, and CSV export logic extracted from CRM.tsx.
+ *
+ * ES: Hook que encapsula el estado de lista de leads, filtros, operaciones CRUD,
+ *     carga de detalle (con tareas + comunicaciones), cambios de estado,
+ *     finalización de tareas y exportación CSV extraídos de CRM.tsx.
+ * EN: Hook encapsulating lead list state, filters, CRUD operations,
+ *     detail loading (with tasks + communications), status changes,
+ *     task completion, and CSV export extracted from CRM.tsx.
+ *
+ * @module hooks/useCRMLeads
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { crmService } from '../services/api';
+import { initialLeadFormData } from '../components/crm';
+import type { LeadFormData } from '../components/crm';
+import type { Lead, Task, Communication } from '../types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface UseCRMLeadsResult {
+  // Lead list
+  leads: Lead[];
+  leadsLoading: boolean;
+
+  // Filters
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
+  statusFilter: string;
+  setStatusFilter: (value: string) => void;
+  sourceFilter: string;
+  setSourceFilter: (value: string) => void;
+  dateFrom: string;
+  setDateFrom: (value: string) => void;
+  dateTo: string;
+  setDateTo: (value: string) => void;
+  valueMin: string;
+  setValueMin: (value: string) => void;
+  valueMax: string;
+  setValueMax: (value: string) => void;
+  showAdvancedFilters: boolean;
+  setShowAdvancedFilters: (value: boolean) => void;
+
+  // Lead detail
+  selectedLead: Lead | null;
+  leadTasks: Task[];
+  leadCommunications: Communication[];
+
+  // Lead form
+  showLeadForm: boolean;
+  setShowLeadForm: (value: boolean) => void;
+  leadFormData: LeadFormData;
+  setLeadFormData: (value: LeadFormData) => void;
+  editingLead: Lead | null;
+  setEditingLead: (value: Lead | null) => void;
+
+  // Email templates
+  selectedTemplate: string;
+  setSelectedTemplate: (value: string) => void;
+  showEmailTemplates: boolean;
+  setShowEmailTemplates: (value: boolean) => void;
+
+  // Actions
+  loadLeads: () => Promise<void>;
+  loadLeadDetails: (leadId: string) => Promise<void>;
+  handleCreateLead: () => Promise<void>;
+  handleUpdateLead: () => Promise<void>;
+  handleDeleteLead: (leadId: string) => Promise<void>;
+  handleStatusChange: (leadId: string, newStatus: string) => Promise<void>;
+  handleTaskComplete: (taskId: string, completed: boolean) => Promise<void>;
+  handleExportLeads: () => Promise<void>;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook encapsulating all lead-related state and operations from CRM.tsx.
+ *
+ * @returns {UseCRMLeadsResult} Lead state, setters, and action handlers
+ */
+export function useCRMLeads(): UseCRMLeadsResult {
+  // ── Lead list ─────────────────────────────────────────────────────────
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [leadsLoading, setLeadsLoading] = useState(true);
+
+  // ── Filters ──────────────────────────────────────────────────────────
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [sourceFilter, setSourceFilter] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [valueMin, setValueMin] = useState('');
+  const [valueMax, setValueMax] = useState('');
+  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
+
+  // ── Lead detail ──────────────────────────────────────────────────────
+  const [selectedLead, setSelectedLead] = useState<Lead | null>(null);
+  const [leadTasks, setLeadTasks] = useState<Task[]>([]);
+  const [leadCommunications, setLeadCommunications] = useState<Communication[]>([]);
+
+  // ── Lead form ────────────────────────────────────────────────────────
+  const [showLeadForm, setShowLeadForm] = useState(false);
+  const [leadFormData, setLeadFormData] = useState<LeadFormData>(initialLeadFormData);
+  const [editingLead, setEditingLead] = useState<Lead | null>(null);
+
+  // ── Email templates ──────────────────────────────────────────────────
+  const [selectedTemplate, setSelectedTemplate] = useState('');
+  const [showEmailTemplates, setShowEmailTemplates] = useState(false);
+
+  // ── Load leads on filter change ──────────────────────────────────────
+  const loadLeads = useCallback(async () => {
+    setLeadsLoading(true);
+    try {
+      const params: {
+        status?: string;
+        source?: string;
+        search?: string;
+        createdAtFrom?: string;
+        createdAtTo?: string;
+        valueMin?: number;
+        valueMax?: number;
+        limit: number;
+      } = {
+        limit: 50,
+      };
+      if (statusFilter) params.status = statusFilter;
+      if (sourceFilter) params.source = sourceFilter;
+      if (searchQuery) params.search = searchQuery;
+      if (dateFrom) params.createdAtFrom = dateFrom;
+      if (dateTo) params.createdAtTo = dateTo;
+      if (valueMin) params.valueMin = parseFloat(valueMin);
+      if (valueMax) params.valueMax = parseFloat(valueMax);
+
+      const response = await crmService.getLeads(params);
+      if (response.success) {
+        setLeads(response.data.leads || []);
+      }
+    } catch (error) {
+      console.error('Failed to load leads:', error);
+    } finally {
+      setLeadsLoading(false);
+    }
+  }, [statusFilter, sourceFilter, searchQuery, dateFrom, dateTo, valueMin, valueMax]);
+
+  // Auto-load leads when filters change
+  useEffect(() => {
+    loadLeads();
+  }, [loadLeads]);
+
+  // ── Load lead details ────────────────────────────────────────────────
+  const loadLeadDetails = useCallback(async (leadId: string) => {
+    try {
+      const [leadRes, tasksRes, commsRes] = await Promise.all([
+        crmService.getLead(leadId),
+        crmService.getTasks(leadId),
+        crmService.getCommunications(leadId),
+      ]);
+
+      if (leadRes.success) setSelectedLead(leadRes.data);
+      if (tasksRes.success) setLeadTasks(tasksRes.data || []);
+      if (commsRes.success) setLeadCommunications(commsRes.data || []);
+    } catch (error) {
+      console.error('Failed to load lead details:', error);
+    }
+  }, []);
+
+  // ── Create lead ──────────────────────────────────────────────────────
+  const handleCreateLead = useCallback(async () => {
+    try {
+      const response = await crmService.createLead(leadFormData);
+      if (response.success) {
+        await loadLeads();
+        setShowLeadForm(false);
+        setLeadFormData(initialLeadFormData);
+      }
+    } catch (error) {
+      console.error('Failed to create lead:', error);
+    }
+  }, [leadFormData, loadLeads]);
+
+  // ── Update lead ──────────────────────────────────────────────────────
+  const handleUpdateLead = useCallback(async () => {
+    if (!editingLead) return;
+    try {
+      const response = await crmService.updateLead(editingLead.id, leadFormData);
+      if (response.success) {
+        await loadLeads();
+        setEditingLead(null);
+        setShowLeadForm(false);
+        setLeadFormData(initialLeadFormData);
+      }
+    } catch (error) {
+      console.error('Failed to update lead:', error);
+    }
+  }, [editingLead, leadFormData, loadLeads]);
+
+  // ── Delete lead ──────────────────────────────────────────────────────
+  const handleDeleteLead = useCallback(
+    async (leadId: string) => {
+      try {
+        const response = await crmService.deleteLead(leadId);
+        if (response.success) {
+          await loadLeads();
+          if (selectedLead?.id === leadId) {
+            setSelectedLead(null);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to delete lead:', error);
+      }
+    },
+    [loadLeads, selectedLead?.id]
+  );
+
+  // ── Change lead status ───────────────────────────────────────────────
+  const handleStatusChange = useCallback(
+    async (leadId: string, newStatus: string) => {
+      try {
+        const response = await crmService.updateLead(leadId, { status: newStatus });
+        if (response.success) {
+          await loadLeads();
+          if (selectedLead?.id === leadId) {
+            loadLeadDetails(leadId);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to update lead status:', error);
+      }
+    },
+    [loadLeads, loadLeadDetails, selectedLead?.id]
+  );
+
+  // ── Complete task ────────────────────────────────────────────────────
+  const handleTaskComplete = useCallback(
+    async (taskId: string, completed: boolean) => {
+      try {
+        const response = await crmService.updateTask(taskId, {
+          status: completed ? 'completed' : 'pending',
+        });
+        if (response.success && selectedLead) {
+          loadLeadDetails(selectedLead.id);
+        }
+      } catch (error) {
+        console.error('Failed to update task:', error);
+      }
+    },
+    [loadLeadDetails, selectedLead]
+  );
+
+  // ── Export leads ────────────────────────────────────────────────────
+  const handleExportLeads = useCallback(async () => {
+    try {
+      const blob = await crmService.exportLeads({
+        status: statusFilter || undefined,
+        source: sourceFilter || undefined,
+        search: searchQuery || undefined,
+      });
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `leads-${new Date().toISOString().split('T')[0]}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch (error) {
+      console.error('Export failed:', error);
+    }
+  }, [statusFilter, sourceFilter, searchQuery]);
+
+  return {
+    // Lead list
+    leads,
+    leadsLoading,
+
+    // Filters
+    searchQuery,
+    setSearchQuery,
+    statusFilter,
+    setStatusFilter,
+    sourceFilter,
+    setSourceFilter,
+    dateFrom,
+    setDateFrom,
+    dateTo,
+    setDateTo,
+    valueMin,
+    setValueMin,
+    valueMax,
+    setValueMax,
+    showAdvancedFilters,
+    setShowAdvancedFilters,
+
+    // Lead detail
+    selectedLead,
+    leadTasks,
+    leadCommunications,
+
+    // Lead form
+    showLeadForm,
+    setShowLeadForm,
+    leadFormData,
+    setLeadFormData,
+    editingLead,
+    setEditingLead,
+
+    // Email templates
+    selectedTemplate,
+    setSelectedTemplate,
+    showEmailTemplates,
+    setShowEmailTemplates,
+
+    // Actions
+    loadLeads,
+    loadLeadDetails,
+    handleCreateLead,
+    handleUpdateLead,
+    handleDeleteLead,
+    handleStatusChange,
+    handleTaskComplete,
+    handleExportLeads,
+  };
+}

--- a/frontend/src/hooks/useCRMMetrics.ts
+++ b/frontend/src/hooks/useCRMMetrics.ts
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview useCRMMetrics — CRM stats/metrics fetching
+ * @description Encapsulates loading CRM dashboard metrics (total leads, won,
+ *              in-progress, conversion rate). Extracted from CRM.tsx's `loadStats()`.
+ *
+ * ES: Hook que encapsula la carga de métricas del dashboard de CRM (total leads,
+ *     ganados, en progreso, tasa de conversión). Extraído de `loadStats()` de CRM.tsx.
+ * EN: Hook encapsulating loading CRM dashboard metrics (total leads, won,
+ *     in-progress, conversion rate). Extracted from CRM.tsx's `loadStats()`.
+ *
+ * @module hooks/useCRMMetrics
+ */
+
+import { useState, useCallback } from 'react';
+import { crmService } from '../services/api';
+import type { CRMStats } from '../types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface UseCRMMetricsResult {
+  /** CRM stats (total, won, in-progress, conversion) / Estadísticas de CRM */
+  stats: CRMStats | null;
+  /** Whether stats are loading / Si las estadísticas se están cargando */
+  isLoading: boolean;
+  /** Error from last fetch / Error del último intento de carga */
+  error: Error | null;
+  /** Load stats from the API / Cargar estadísticas desde la API */
+  loadStats: () => Promise<void>;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook for fetching CRM dashboard metrics.
+ *
+ * @returns {UseCRMMetricsResult} Stats, loading/error state, and load function
+ */
+export function useCRMMetrics(): UseCRMMetricsResult {
+  const [stats, setStats] = useState<CRMStats | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadStats = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await crmService.getStats();
+      if (response.success) {
+        setStats(response.data);
+      }
+    } catch (err) {
+      const errorObj = err instanceof Error ? err : new Error('Failed to load CRM stats');
+      setError(errorObj);
+      console.error('Failed to load stats:', errorObj);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { stats, isLoading, error, loadStats };
+}

--- a/frontend/src/hooks/useCRMTasks.ts
+++ b/frontend/src/hooks/useCRMTasks.ts
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview useCRMTasks — all-tasks loading with loading/error state
+ * @description Encapsulates loading all upcoming CRM tasks and managing
+ *              loading/error state. Extracted from CRM.tsx's `loadAllTasks()` logic.
+ *
+ * ES: Hook que encapsula la carga de todas las tareas próximas de CRM y el
+ *     manejo del estado de carga/error. Extraído de la lógica `loadAllTasks()` de CRM.tsx.
+ * EN: Hook encapsulating loading all upcoming CRM tasks and managing
+ *     loading/error state. Extracted from CRM.tsx's `loadAllTasks()` logic.
+ *
+ * @module hooks/useCRMTasks
+ */
+
+import { useState, useCallback } from 'react';
+import { crmService } from '../services/api';
+import type { Task } from '../types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface UseCRMTasksResult {
+  /** All upcoming tasks / Todas las tareas próximas */
+  allTasks: Task[];
+  /** Whether tasks are currently loading / Si las tareas se están cargando */
+  tasksLoading: boolean;
+  /** Error from last fetch attempt / Error del último intento de carga */
+  error: Error | null;
+  /** Reload all tasks / Recargar todas las tareas */
+  loadAllTasks: () => Promise<void>;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook for loading all upcoming CRM tasks.
+ *
+ * @returns {UseCRMTasksResult} Tasks array, loading/error state, and reload function
+ */
+export function useCRMTasks(): UseCRMTasksResult {
+  const [allTasks, setAllTasks] = useState<Task[]>([]);
+  const [tasksLoading, setTasksLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const loadAllTasks = useCallback(async () => {
+    setTasksLoading(true);
+    setError(null);
+    try {
+      const response = await crmService.getUpcomingTasks();
+      if (response.success) {
+        setAllTasks(response.data || []);
+      }
+    } catch (err) {
+      const errorObj = err instanceof Error ? err : new Error('Failed to load tasks');
+      setError(errorObj);
+      console.error('Failed to load tasks:', errorObj);
+    } finally {
+      setTasksLoading(false);
+    }
+  }, []);
+
+  return { allTasks, tasksLoading, error, loadAllTasks };
+}

--- a/frontend/src/pages/CRM.tsx
+++ b/frontend/src/pages/CRM.tsx
@@ -38,68 +38,9 @@ import { crmService } from '../services/api';
 import { KanbanBoard, LeadCard, LeadModal, TaskCard, initialLeadFormData } from '../components/crm';
 import type { LeadFormData } from '../components/crm';
 import type { Lead, Task, Communication, CRMStats } from '../types';
+import { STATUS_COLORS, EMAIL_TEMPLATES } from '../features/crm/constants';
 
-// Status colors for lead details panel
-const STATUS_COLORS: Record<string, { bg: string; text: string }> = {
-  new: { bg: 'bg-blue-100', text: 'text-blue-700' },
-  contacted: { bg: 'bg-yellow-100', text: 'text-yellow-700' },
-  qualified: { bg: 'bg-purple-100', text: 'text-purple-700' },
-  proposal: { bg: 'bg-indigo-100', text: 'text-indigo-700' },
-  negotiation: { bg: 'bg-orange-100', text: 'text-orange-700' },
-  won: { bg: 'bg-green-100', text: 'text-green-700' },
-  lost: { bg: 'bg-red-100', text: 'text-red-700' },
-};
-
-// Status names now use i18n - t('crm.status.xxx')
-
-// Email templates / Plantillas de email
-const EMAIL_TEMPLATES = [
-  {
-    id: 'welcome',
-    name: { es: 'Bienvenida', en: 'Welcome' },
-    subject: { es: '¡Bienvenido a nuestra plataforma!', en: 'Welcome to our platform!' },
-    content: {
-      es: 'Hola {{name}},\n\n¡Gracias por tu interés en nuestra plataforma! Nos encantaría mostrarte cómo funciona y cómo puedes empezar a ganar comisiones.\n\n¿Tienes alguna pregunta?\n\nSaludos,\n{{myName}}',
-      en: 'Hi {{name}},\n\nThank you for your interest in our platform! We would love to show you how it works and how you can start earning commissions.\n\nDo you have any questions?\n\nBest regards,\n{{myName}}',
-    },
-  },
-  {
-    id: 'followup',
-    name: { es: 'Seguimiento', en: 'Follow-up' },
-    subject: { es: '¿Cómo va tu experiencia?', en: 'How is your experience going?' },
-    content: {
-      es: 'Hola {{name}},\n\nSolo quería hacer seguimiento para ver cómo va tu experiencia con nuestra plataforma.\n\n¿Hay algo en lo que pueda ayudarte?\n\nSaludos,\n{{myName}}',
-      en: 'Hi {{name}},\n\nJust wanted to follow up on how your experience with our platform is going.\n\nIs there anything I can help you with?\n\nBest regards,\n{{myName}}',
-    },
-  },
-  {
-    id: 'presentation',
-    name: { es: 'Presentación de producto', en: 'Product Presentation' },
-    subject: { es: 'Conoce más sobre nuestro producto', en: 'Learn more about our product' },
-    content: {
-      es: 'Hola {{name}},\n\nTe envío información sobre nuestro producto/servicio que creo que puede interesarte.\n\n[Descripción del producto]\n\n¿Te gustaría agendar una llamada para explicar más detalles?\n\nSaludos,\n{{myName}}',
-      en: "Hi {{name}},\n\nI'm sending you information about our product/service that I think might interest you.\n\n[Product description]\n\nWould you like to schedule a call to explain more details?\n\nBest regards,\n{{myName}}",
-    },
-  },
-  {
-    id: 'closing',
-    name: { es: 'Cierre de venta', en: 'Closing Sale' },
-    subject: { es: 'Último paso para unirte', en: 'Last step to join' },
-    content: {
-      es: 'Hola {{name}},\n\n¡Nos alegra que hayas decidido unirte a nuestra comunidad!\n\nPara completar tu registro, solo necesitas [acción requerida].\n\nSi tienes cualquier duda, estoy aquí para ayudarte.\n\nSaludos,\n{{myName}}',
-      en: "Hi {{name}},\n\nWe are glad you decided to join our community!\n\nTo complete your registration, you just need to [required action].\n\nIf you have any questions, I'm here to help.\n\nBest regards,\n{{myName}}",
-    },
-  },
-  {
-    id: 'support',
-    name: { es: 'Soporte técnico', en: 'Technical Support' },
-    subject: { es: 'Estoy aquí para ayudarte', en: "I'm here to help you" },
-    content: {
-      es: 'Hola {{name}},\n\nRecibí tu mensaje sobre [tema]. Estoy aquí para ayudarte.\n\n[Solución o siguiente paso]\n\n¿Necesitas algo más?\n\nSaludos,\n{{myName}}',
-      en: "Hi {{name}},\n\nI received your message about [topic]. I'm here to help you.\n\n[Solution or next step]\n\nDo you need anything else?\n\nBest regards,\n{{myName}}",
-    },
-  },
-];
+// EMAIL_TEMPLATES imported from features/crm/constants.ts
 
 type Tab = 'leads' | 'kanban' | 'tasks' | 'stats';
 


### PR DESCRIPTION
## Summary

Extract shared constants and inline business logic from CRM.tsx into dedicated hooks and a constants module. This is PR #1 of 3 in the CRM Refactoring chain.

### Changes

**New files:**
- `frontend/src/features/crm/constants.ts` — STATUS_COLORS, EMAIL_TEMPLATES, CRM_TABS, LEAD_STATUSES, LEAD_SOURCES with full bilingual (es/en) support
- `frontend/src/hooks/useCRMLeads.ts` — Lead CRUD, filter state, detail loading (tasks + communications), status changes, task completion, CSV export
- `frontend/src/hooks/useCRMTasks.ts` — All-tasks loading with loading/error state
- `frontend/src/hooks/useCRMKanban.ts` — Kanban leads, stats summary, drag-and-drop status updates
- `frontend/src/hooks/useCRMMetrics.ts` — Stats fetching (total/won/in-progress/conversion rate)
- `frontend/src/hooks/useCRMAnalytics.ts` — Analytics report with period/date-range filtering and CSV export

**Modified files:**
- `frontend/src/pages/CRM.tsx` — Remove inline STATUS_COLORS (+48 lines) and EMAIL_TEMPLATES (+44 lines); import from constants module
- `frontend/src/components/crm/LeadCard.tsx` — Remove duplicate STATUS_COLORS (+8 lines); import from constants module

### Design Decisions
- Hooks follow the same pattern as `useCRMAutomation.ts` (return result interface, typed state, callback-based actions)
- Constants file uses bilingual (es/en) objects for EMAIL_TEMPLATES, matching the original inline structure
- Each hook is self-contained with its own loading/error state — no cross-hook dependencies
- useCRMLeads auto-loads on filter change via useEffect, matching the original CRM.tsx behavior

## Chain Context

| Field | Value |
|-------|-------|
| Chain | CRM Refactoring (Sprint 11) |
| Tracker PR | feature/crm-refactoring |
| Position | 1 of 3 |
| Base | `feature/crm-refactoring` |
| Depends on | None |
| Follow-up | PR #2: Components |
| Review budget | ~280 / 400 |
| Starts at | development |
| Ends with | Hooks + constants extracted from CRM.tsx |

### Chain Overview

development
 └── feature/crm-refactoring
      └── 📍 #NNN This PR (Foundation)
           └── #NNN Next PR (Components)

### Scope
- Includes: useCRMLeads, useCRMTasks, useCRMKanban, useCRMMetrics, useCRMAnalytics, constants
- Excludes: Sub-components, CRM.tsx orchestration refactor

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit