### PR TITLE
fix(products): ProductService.delete() returns boolean to fix 404 bug

### DIFF
--- a/backend/src/__tests__/unit/ProductController.test.ts
+++ b/backend/src/__tests__/unit/ProductController.test.ts
@@ -423,7 +423,7 @@ describe('ProductWriteController - deleteProduct', () => {
   });
 
   it('returns 404 when product not found', async () => {
-    (productService.delete as jest.Mock).mockResolvedValue(null);
+    (productService.delete as jest.Mock).mockResolvedValue(false);
 
     const req = makeReq({ params: { id: VALID_UUID } });
     const res = makeRes();

--- a/backend/src/services/ProductService.ts
+++ b/backend/src/services/ProductService.ts
@@ -291,11 +291,13 @@ export class ProductService {
   /**
    * Delete a product (soft delete by deactivating)
    * @param {string} id - Product UUID
-   * @returns {Promise<void>}
+   * @returns {Promise<boolean>} true if deleted, false if not found
    */
-  async delete(id: string): Promise<void> {
+  async delete(id: string): Promise<boolean> {
     const product = await this.findById(id);
+    if (!product) return false;
     await product.update({ isActive: false });
+    return true;
   }
 
   /**


### PR DESCRIPTION
fix(products): ProductService.delete() returns boolean to fix 404 bug

Root Cause:
ProductService.delete() returned Promise<void>, but the controller
checked if (!deleted) to return 404. Since void is undefined,
!deleted was always truthy, so DELETE always returned 404.

Fix:
ProductService.delete() now returns Promise<boolean>: true on
successful soft-delete, false when product not found.

Files:
- backend/src/services/ProductService.ts: return boolean instead of void
- backend/src/__tests__/unit/ProductController.test.ts: mock false instead of null

Verification: 868 unit tests passing