### PR TITLE
feat(orders): add orders list foundation — backend fix, Pagination component, mock API handler

### DIFF
--- a/backend/src/controllers/orders/OrderReadController.ts
+++ b/backend/src/controllers/orders/OrderReadController.ts
@@ -108,6 +108,17 @@ export const getOrders: RequestHandler = asyncHandler(
         notes: order.notes,
         createdAt: order.createdAt,
         updatedAt: order.updatedAt,
+        // Include product details if available
+        ...(order.product && {
+          product: {
+            id: order.product.id,
+            name: order.product.name,
+            platform: order.product.platform,
+            price: Number(order.product.price),
+            durationDays: order.product.durationDays,
+            description: order.product.description,
+          },
+        }),
       })),
       pagination: {
         total: result.count,

--- a/frontend/e2e/mock-api.ts
+++ b/frontend/e2e/mock-api.ts
@@ -614,6 +614,96 @@ export function setupMockApi(page: Page): void {
         });
       }
 
+      // GET /api/orders — list orders (MUST come before :orderId regex)
+      if (pathname === '/api/orders' && method === 'GET') {
+        const page = parseInt(new URL(route.request().url()).searchParams.get('page') || '1');
+        const limit = parseInt(new URL(route.request().url()).searchParams.get('limit') || '20');
+        const total = 42;
+        const totalPages = Math.ceil(total / limit);
+
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            data: [
+              {
+                id: 'order-001',
+                orderNumber: 'ORD-20260619-001',
+                userId: 'user-1',
+                productId: 'prod-001',
+                purchaseId: 'purchase-001',
+                totalAmount: 15.99,
+                currency: 'USD',
+                status: 'completed',
+                paymentMethod: 'simulated',
+                notes: null,
+                createdAt: '2026-06-19T10:00:00.000Z',
+                updatedAt: '2026-06-19T10:00:00.000Z',
+                product: {
+                  id: 'prod-001',
+                  name: 'Netflix Premium',
+                  platform: 'netflix',
+                  price: 15.99,
+                  durationDays: 30,
+                  description: 'Acceso a Netflix en calidad 4K',
+                },
+              },
+              {
+                id: 'order-002',
+                orderNumber: 'ORD-20260618-001',
+                userId: 'user-1',
+                productId: 'prod-002',
+                purchaseId: 'purchase-002',
+                totalAmount: 12.99,
+                currency: 'USD',
+                status: 'completed',
+                paymentMethod: 'simulated',
+                notes: null,
+                createdAt: '2026-06-18T14:30:00.000Z',
+                updatedAt: '2026-06-18T14:30:00.000Z',
+                product: {
+                  id: 'prod-002',
+                  name: 'Spotify Family',
+                  platform: 'spotify',
+                  price: 12.99,
+                  durationDays: 30,
+                  description: 'Spotify Premium para hasta 6 cuentas',
+                },
+              },
+              {
+                id: 'order-003',
+                orderNumber: 'ORD-20260617-001',
+                userId: 'user-1',
+                productId: 'prod-003',
+                purchaseId: null,
+                totalAmount: 9.99,
+                currency: 'USD',
+                status: 'pending',
+                paymentMethod: 'simulated',
+                notes: 'Awaiting payment confirmation',
+                createdAt: '2026-06-17T09:15:00.000Z',
+                updatedAt: '2026-06-17T09:15:00.000Z',
+                product: {
+                  id: 'prod-003',
+                  name: 'HBO Max',
+                  platform: 'hbo_max',
+                  price: 9.99,
+                  durationDays: 30,
+                  description: 'Todo el contenido de HBO Max',
+                },
+              },
+            ],
+            pagination: {
+              total,
+              page,
+              limit,
+              totalPages,
+            },
+          }),
+        });
+      }
+
       // GET /api/orders/:orderId — get single order (used by OrderSuccess page)
       const getOrderIdMatch = pathname.match(/^\/api\/orders\/([a-zA-Z0-9_-]+)$/);
       if (getOrderIdMatch && method === 'GET') {

--- a/frontend/src/components/ui/Pagination.tsx
+++ b/frontend/src/components/ui/Pagination.tsx
@@ -1,0 +1,80 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface PaginationProps {
+  /** Current active page (1-indexed) */
+  page: number;
+  /** Total number of pages */
+  totalPages: number;
+  /** Callback fired when the user clicks a page button */
+  onPageChange: (page: number) => void;
+  className?: string;
+}
+
+/**
+ * Reusable pagination component built on shadcn/ui Button primitives.
+ * Renders page buttons with prev/next navigation.
+ * Returns `null` when `totalPages <= 1`.
+ */
+function Pagination({ page, totalPages, onPageChange, className }: PaginationProps) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  // Build visible page range (show at most 5 page buttons around the current page)
+  const pages: number[] = [];
+  const start = Math.max(1, page - 2);
+  const end = Math.min(totalPages, page + 2);
+  for (let i = start; i <= end; i++) {
+    pages.push(i);
+  }
+
+  return (
+    <nav
+      className={cn('flex items-center justify-center gap-1', className)}
+      aria-label="Pagination"
+    >
+      {/* Previous button */}
+      <Button
+        variant="outline"
+        size="icon"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+        aria-label="Previous page"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+
+      {/* Page number buttons */}
+      {pages.map((p) => (
+        <Button
+          key={p}
+          variant={p === page ? 'default' : 'outline'}
+          size="icon"
+          onClick={() => onPageChange(p)}
+          aria-current={p === page ? 'page' : undefined}
+          aria-label={`Page ${p}`}
+        >
+          {p}
+        </Button>
+      ))}
+
+      {/* Next button */}
+      <Button
+        variant="outline"
+        size="icon"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+        aria-label="Next page"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </nav>
+  );
+}
+
+Pagination.displayName = 'Pagination';
+
+export { Pagination };
+export default Pagination;

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -86,3 +86,4 @@ export {
 export { SonnerToaster } from './sonner';
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
 export { Progress } from './progress';
+export { Pagination } from './Pagination';

--- a/openspec/changes/order-history-page/tasks.md
+++ b/openspec/changes/order-history-page/tasks.md
@@ -26,11 +26,11 @@ Chain strategy: pending
 
 ## Phase 1: Backend Fix
 
-- [ ] 1.1 **Fix `OrderReadController.getOrders` response mapping** — add `product` field (id, name, platform, price, durationDays, description) inside each order's `.map()` callback, matching the existing pattern in `getOrderById`. Backend: `backend/src/controllers/orders/OrderReadController.ts` (~12 lines)
+- [x] 1.1 **Fix `OrderReadController.getOrders` response mapping** — add `product` field (id, name, platform, price, durationDays, description) inside each order's `.map()` callback, matching the existing pattern in `getOrderById`. Backend: `backend/src/controllers/orders/OrderReadController.ts` (~12 lines)
 
 ## Phase 2: Foundation UI
 
-- [ ] 2.1 **Create `Pagination.tsx`** — shadcn/ui-style component with props `{ page, totalPages, onPageChange }`. Renders page buttons (outline variant), prev/next with disabled states at boundaries; returns `null` when `totalPages <= 1`. Frontend: `frontend/src/components/ui/Pagination.tsx` (~65 lines)
+- [x] 2.1 **Create `Pagination.tsx`** — shadcn/ui-style component with props `{ page, totalPages, onPageChange }`. Renders page buttons (outline variant), prev/next with disabled states at boundaries; returns `null` when `totalPages <= 1`. Frontend: `frontend/src/components/ui/Pagination.tsx` (~65 lines)
 
 ## Phase 3: Core Pages
 
@@ -45,7 +45,7 @@ Chain strategy: pending
 
 ## Phase 5: Mock API + E2E Tests
 
-- [ ] 5.1 **Add `GET /api/orders` handler to `mock-api.ts`** — return paginated order list with 3 sample orders including product objects. Place handler **before** the `:orderId` regex to avoid false matches. Frontend: `frontend/e2e/mock-api.ts` (~55 lines)
+- [x] 5.1 **Add `GET /api/orders` handler to `mock-api.ts`** — return paginated order list with 3 sample orders including product objects. Place handler **before** the `:orderId` regex to avoid false matches. Frontend: `frontend/e2e/mock-api.ts` (~55 lines)
 - [ ] 5.2 **Create `OrdersListPage` POM** — extends `BasePage`. Selectors: table, pagination, status filter select, empty/error states, skeleton. Methods: `goto`, `filterByStatus`, `goToPage`, `clickOrderRow`. Frontend: `frontend/e2e/orders/orders-list-page.ts` (~50 lines)
 - [ ] 5.3 **Create `OrderDetailPage` POM** — extends `BasePage`. Selectors: order number, status badge, OrderSummary, commission card, back link. Methods: `goto(id)`, `verifyLoaded`. Frontend: `frontend/e2e/orders/order-detail-page.ts` (~40 lines)
 - [ ] 5.4 **Create `orders.spec.ts`** — E2E tests covering: load order list; filter by status; paginate; empty state; error state with retry; navigate to detail from list; verify detail fields; handle 404 on invalid ID. Frontend: `frontend/e2e/orders/orders.spec.ts` (~120 lines)


### PR DESCRIPTION
## PR 1/3 — Foundation

This PR is part of the Order History feature chain (tracker: #199).

### Changes

| File | Action | What |
|------|--------|------|
| `backend/src/controllers/orders/OrderReadController.ts` | Modified | Added `product` object spread in `getOrders()` response mapping |
| `frontend/src/components/ui/Pagination.tsx` | Created | Reusable shadcn/ui-style Pagination component |
| `frontend/src/components/ui/index.ts` | Modified | Added Pagination export |
| `frontend/e2e/mock-api.ts` | Modified | Added `GET /api/orders` handler before `:orderId` regex |
| `openspec/changes/order-history-page/tasks.md` | Modified | Marked 3 tasks complete |

### Verification

- Backend: `NODE_ENV=test jest` — 868 passed
- Frontend unit: `npx vitest run` — 654 passed
- Diff: +185 lines, well within 400-line budget

### Dependency Diagram

```
main
└── 📍 feature/order-history (tracker #199, draft)
     └── 📍 feature/order-history-p1 ← PR #1 (you are here)
         └── (next) feature/order-history-p2 → pages
             └── (next) feature/order-history-p3 → wiring + E2E
```

### Rollback

Revert the merge of PR 1 into the tracker branch. Does not affect main until the tracker merges.