### PR TITLE
fix(n8n): rename human-handoff payload fields to match n8n webhook schema

### DIFF
--- a/bot/src/__tests__/unit/n8n.service.test.ts
+++ b/bot/src/__tests__/unit/n8n.service.test.ts
@@ -24,8 +24,8 @@ const SCHEDULE_PAYLOAD: ScheduleVisitPayload = {
 const HANDOFF_PAYLOAD: HumanHandoffPayload = {
   phone: '5491122334455',
   name: 'Juan Test',
-  reason: 'quiere hablar con un asesor',
-  agent: 'sophia',
+  summary: 'quiere hablar con un asesor',
+  agentName: 'sophia',
   language: 'es',
   escalatedAt: new Date().toISOString(),
 };

--- a/bot/src/flows/handoff.flow.ts
+++ b/bot/src/flows/handoff.flow.ts
@@ -81,8 +81,8 @@ export const handoffFlow = addKeyword(HANDOFF_KEYWORDS).addAction(
       .triggerHumanHandoff({
         phone,
         name,
-        reason: (ctx.body || '').trim() || 'User requested human agent',
-        agent: aiAgent,
+        summary: (ctx.body || '').trim() || 'User requested human agent',
+        agentName: aiAgent,
         language: lang,
         escalatedAt: new Date().toISOString(),
       })

--- a/bot/src/services/n8n.service.ts
+++ b/bot/src/services/n8n.service.ts
@@ -40,9 +40,9 @@ export interface HumanHandoffPayload {
   /** User's name */
   name: string;
   /** Brief summary of why they need human attention */
-  reason: string;
+  summary: string;
   /** Last AI agent assigned (sophia | max) */
-  agent: string;
+  agentName: string;
   /** Conversation language */
   language: 'es' | 'en';
   /** Timestamp of escalation */


### PR DESCRIPTION
## Description

Corrige el payload mismatch en el webhook `human-handoff` de n8n. El bot enviaba campos `reason` y `agent`, pero n8n espera `summary` y `agentName`.

### Dependency Diagram

```
development
+-- PR #1 fix/bot-n8n-critical-pr1 (this PR)  [human-handoff rename] 
    +-- PR #2 fix/bot-n8n-critical-pr2          [schedule-visit fix]
        +-- PR #3 fix/bot-n8n-critical-pr3      [Redis persistence]
```

### Changes

| File | Change |
|------|--------|
| `bot/src/services/n8n.service.ts` | Renamed reason->summary, agent->agentName in HumanHandoffPayload |
| `bot/src/flows/handoff.flow.ts` | Updated payload construction to use new field names |
| `bot/src/__tests__/unit/n8n.service.test.ts` | Updated HANDOFF_PAYLOAD fixture |

### Test Plan

- [x] All 62 bot tests pass: pnpm --filter bot test
- [x] Payload contract now matches n8n webhook expected schema

Closes #213
