### PR TITLE
feat(ai): add Redis-backed conversation history with Map fallback

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -74,3 +74,10 @@ NOTION_DATABASE_ID_LEADS=your_notion_leads_database_id
 # Template name: "Bot Handoff — Notificación Equipo" (#1)
 # Manage at: https://app.brevo.com/email/template
 BREVO_HANDOFF_TEMPLATE_ID=1
+
+# ─── Redis (optional — AI conversation persistence) ───────────────────────────
+
+# Redis connection URL for AI conversation history persistence.
+# If not set, the bot uses in-memory storage (history lost on restart).
+# Example for Docker Compose: REDIS_URL=redis://redis:6379
+# REDIS_URL=redis://localhost:6379

--- a/bot/package.json
+++ b/bot/package.json
@@ -24,6 +24,7 @@
     "@builderbot/provider-baileys": "^1.4.2",
     "axios": "^1.16.0",
     "dotenv": "^16.6.1",
+    "ioredis": "^5.10.1",
     "openai": "^4.91.1"
   },
   "devDependencies": {

--- a/bot/src/__tests__/unit/ai.service.test.ts
+++ b/bot/src/__tests__/unit/ai.service.test.ts
@@ -28,6 +28,23 @@ vi.mock('../../services/mlm-api.service.js', () => ({
   BotTour: {},
 }));
 
+// Mock ioredis for RedisConversationStore tests
+// Uses vi.hoisted to ensure the mock object survives hoisting
+const mockRedisInstance = vi.hoisted(() => ({
+  get: vi.fn().mockResolvedValue(null),
+  setex: vi.fn().mockResolvedValue('OK'),
+  del: vi.fn().mockResolvedValue(1),
+  quit: vi.fn().mockResolvedValue('OK'),
+}));
+
+vi.mock('ioredis', () => {
+  // Must return a constructable function for `new Redis(url)`
+  function Redis(this: Record<string, unknown>, _url?: string) {
+    return mockRedisInstance;
+  }
+  return { default: Redis, Redis };
+});
+
 // ─── Imports AFTER mocks ───────────────────────────────────────────────────────
 
 import {
@@ -37,7 +54,13 @@ import {
   clearHistory,
   withRetry,
 } from '../../services/ai.service.js';
-import type { ChatMessage, AgentName } from '../../services/ai.service.js';
+import type { AgentName } from '../../services/ai.service.js';
+import type { ChatMessage } from '../../services/conversation-store.js';
+import {
+  RedisConversationStore,
+  createConversationStore,
+  MapConversationStore,
+} from '../../services/conversation-store.js';
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -78,35 +101,35 @@ describe('ai.service', () => {
   describe('getHistory / appendToHistory / clearHistory', () => {
     const phone = 'test-phone-999';
 
-    beforeEach(() => {
-      clearHistory(phone);
+    beforeEach(async () => {
+      await clearHistory(phone);
     });
 
-    it('returns an empty array for an unknown phone number', () => {
-      const history = getHistory('unknown-phone-000');
+    it('returns an empty array for an unknown phone number', async () => {
+      const history = await getHistory('unknown-phone-000');
       expect(history).toEqual([]);
     });
 
-    it('stores and retrieves messages, then clearHistory removes them', () => {
+    it('stores and retrieves messages, then clearHistory removes them', async () => {
       const msg: ChatMessage = { role: 'user', content: 'Hola' };
-      appendToHistory(phone, msg);
+      await appendToHistory(phone, msg);
 
-      const history = getHistory(phone);
+      const history = await getHistory(phone);
       expect(history).toHaveLength(1);
       expect(history[0]).toEqual(msg);
 
-      clearHistory(phone);
-      expect(getHistory(phone)).toEqual([]);
+      await clearHistory(phone);
+      expect(await getHistory(phone)).toEqual([]);
     });
 
-    it('trims history to the last 20 messages when exceeding MAX_HISTORY_MESSAGES', () => {
+    it('trims history to the last 20 messages when exceeding MAX_HISTORY_MESSAGES', async () => {
       // Push 25 messages — only the last 20 should remain
       for (let i = 1; i <= 25; i++) {
         const msg: ChatMessage = { role: 'user', content: `Message ${i}` };
-        appendToHistory(phone, msg);
+        await appendToHistory(phone, msg);
       }
 
-      const history = getHistory(phone);
+      const history = await getHistory(phone);
       expect(history).toHaveLength(20);
       // The first surviving message should be message #6 (25 - 20 + 1)
       expect(history[0].content).toBe('Message 6');
@@ -176,6 +199,125 @@ describe('ai.service', () => {
 
       expect(result).toBe('ok after rate limit');
       expect(fn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ─── RedisConversationStore ──────────────────────────────────────────────────
+
+  describe('RedisConversationStore', () => {
+    const phone = 'test-phone-redis-001';
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('stores and retrieves messages via Redis with setex', async () => {
+      const store = new RedisConversationStore({
+        url: 'redis://test:6379',
+        ttl: 86400,
+        keyPrefix: 'bot:conversation',
+      });
+      const msg: ChatMessage = { role: 'user', content: 'Hello Redis' };
+
+      await store.append(phone, msg);
+
+      // Should call setex with key, TTL, and JSON value
+      expect(mockRedisInstance.setex).toHaveBeenCalledWith(
+        `bot:conversation:${phone}`,
+        86400,
+        JSON.stringify([msg])
+      );
+    });
+
+    it('retrieves stored messages from Redis', async () => {
+      const msg: ChatMessage = { role: 'user', content: 'Hi' };
+      mockRedisInstance.get.mockResolvedValueOnce(JSON.stringify([msg]));
+
+      const store = new RedisConversationStore({
+        url: 'redis://test:6379',
+        ttl: 86400,
+        keyPrefix: 'bot:conversation',
+      });
+      const history = await store.get(phone);
+
+      expect(history).toHaveLength(1);
+      expect(history[0]).toEqual(msg);
+      expect(mockRedisInstance.get).toHaveBeenCalledWith(`bot:conversation:${phone}`);
+    });
+
+    it('returns empty array when Redis key does not exist', async () => {
+      mockRedisInstance.get.mockResolvedValueOnce(null);
+
+      const store = new RedisConversationStore({
+        url: 'redis://test:6379',
+        ttl: 86400,
+        keyPrefix: 'bot:conversation',
+      });
+      const history = await store.get(phone);
+
+      expect(history).toEqual([]);
+    });
+
+    it('clears conversation from Redis', async () => {
+      const store = new RedisConversationStore({
+        url: 'redis://test:6379',
+        ttl: 86400,
+        keyPrefix: 'bot:conversation',
+      });
+
+      await store.clear(phone);
+
+      expect(mockRedisInstance.del).toHaveBeenCalledWith(`bot:conversation:${phone}`);
+    });
+
+    it('trims history to maxMessages when exceeding limit', async () => {
+      const store = new RedisConversationStore({
+        url: 'redis://test:6379',
+        ttl: 86400,
+        keyPrefix: 'bot:conversation',
+      });
+      mockRedisInstance.get.mockResolvedValue(null); // start empty
+
+      // Append 5 messages with maxMessages=3
+      for (let i = 1; i <= 5; i++) {
+        mockRedisInstance.get.mockResolvedValueOnce(
+          i === 1
+            ? null
+            : JSON.stringify(
+                Array.from({ length: Math.min(i - 1, 3) }, (_, j) => ({
+                  role: 'user' as const,
+                  content: `Message ${i - 3 + j}`,
+                }))
+              )
+        );
+        await store.append(phone, { role: 'user', content: `Message ${i}` }, 3);
+      }
+
+      // The last setex call should contain only 3 messages
+      const lastCallArgs = mockRedisInstance.setex.mock.calls.slice(-1)[0];
+      const stored = JSON.parse(lastCallArgs[2]) as ChatMessage[];
+      expect(stored).toHaveLength(3);
+      expect(stored[0].content).toBe('Message 3');
+      expect(stored[2].content).toBe('Message 5');
+    });
+  });
+
+  // ─── createConversationStore factory ──────────────────────────────────────────
+
+  describe('createConversationStore', () => {
+    it('returns MapConversationStore when no REDIS_URL is set', () => {
+      const store = createConversationStore();
+      expect(store).toBeInstanceOf(MapConversationStore);
+    });
+
+    it('returns RedisConversationStore when REDIS_URL is provided', () => {
+      const store = createConversationStore('redis://test:6379');
+      expect(store).toBeInstanceOf(RedisConversationStore);
+    });
+
+    it('uses custom TTL and keyPrefix when provided', () => {
+      const store = createConversationStore('redis://test:6379', 3600, 'custom:prefix');
+      expect(store).toBeInstanceOf(RedisConversationStore);
     });
   });
 });

--- a/bot/src/services/ai.service.ts
+++ b/bot/src/services/ai.service.ts
@@ -14,6 +14,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { mlmApi, BotProperty, BotTour } from './mlm-api.service.js';
+import {
+  createConversationStore,
+  ChatMessage,
+  MAX_HISTORY_MESSAGES,
+} from './conversation-store.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -23,10 +28,7 @@ const __dirname = path.dirname(__filename);
 export type AgentName = 'sophia' | 'max';
 export type Language = 'es' | 'en';
 
-export interface ChatMessage {
-  role: 'user' | 'assistant' | 'system';
-  content: string;
-}
+export type { ChatMessage } from './conversation-store.js';
 
 export interface AIResponse {
   text: string;
@@ -40,9 +42,8 @@ const MODEL = process.env.OPENAI_MODEL || 'gpt-4o';
 const MAX_TOKENS = 512;
 const TEMPERATURE = 0.7;
 
-// In-memory conversation history keyed by WhatsApp phone number
-const conversationHistory = new Map<string, ChatMessage[]>();
-const MAX_HISTORY_MESSAGES = 20; // keep last 20 turns to avoid token bloat
+// Conversation history store — Redis if REDIS_URL is set, in-memory Map otherwise
+const conversationHistory = createConversationStore();
 
 // ─── Prompt Loader ────────────────────────────────────────────────────────────
 
@@ -297,22 +298,17 @@ function getClient(): OpenAI {
 
 // ─── Conversation History ─────────────────────────────────────────────────────
 
-export function getHistory(phone: string): ChatMessage[] {
-  return conversationHistory.get(phone) || [];
+export async function getHistory(phone: string): Promise<ChatMessage[]> {
+  const result = await conversationHistory.get(phone);
+  return result || [];
 }
 
-export function appendToHistory(phone: string, message: ChatMessage): void {
-  const history = conversationHistory.get(phone) || [];
-  history.push(message);
-  // Trim to last N messages to avoid excessive token usage
-  if (history.length > MAX_HISTORY_MESSAGES) {
-    history.splice(0, history.length - MAX_HISTORY_MESSAGES);
-  }
-  conversationHistory.set(phone, history);
+export async function appendToHistory(phone: string, message: ChatMessage): Promise<void> {
+  await conversationHistory.append(phone, message);
 }
 
-export function clearHistory(phone: string): void {
-  conversationHistory.delete(phone);
+export async function clearHistory(phone: string): Promise<void> {
+  await conversationHistory.clear(phone);
 }
 
 // ─── Main AI Chat Function ────────────────────────────────────────────────────
@@ -342,12 +338,13 @@ export async function chat(
   const systemPrompt = buildSystemPrompt(agent, language, liveContext);
 
   // Append user message to history
-  appendToHistory(phone, { role: 'user', content: userMsg });
+  await appendToHistory(phone, { role: 'user', content: userMsg });
 
   // Build messages array: system + history
+  const history = await getHistory(phone);
   const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
     { role: 'system', content: systemPrompt },
-    ...getHistory(phone).map((m) => ({
+    ...history.map((m) => ({
       role: m.role as 'user' | 'assistant',
       content: m.content,
     })),
@@ -370,7 +367,7 @@ export async function chat(
         : 'Lo siento, no pude procesar eso. Te conecto con un asesor humano.');
 
     // Append assistant response to history
-    appendToHistory(phone, { role: 'assistant', content: responseText });
+    await appendToHistory(phone, { role: 'assistant', content: responseText });
 
     return { text: responseText, agent };
   } catch (error) {

--- a/bot/src/services/conversation-store.ts
+++ b/bot/src/services/conversation-store.ts
@@ -1,0 +1,145 @@
+/**
+ * @fileoverview Conversation store abstraction — Strategy pattern
+ * @description Provides an interface for conversation history storage with two
+ *              implementations: Redis-backed (with TTL) and in-memory Map fallback.
+ *              The exported factory function selects the appropriate implementation
+ *              based on the REDIS_URL environment variable.
+ */
+
+import { Redis } from 'ioredis';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ChatMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+export const MAX_HISTORY_MESSAGES = 20;
+
+// ─── ConversationStore Interface ─────────────────────────────────────────────
+
+/**
+ * Strategy interface for conversation history storage.
+ * Return types use union types to allow both sync (Map) and async (Redis) implementations.
+ */
+export interface ConversationStore {
+  get(phone: string): ChatMessage[] | Promise<ChatMessage[]>;
+  append(phone: string, message: ChatMessage, maxMessages?: number): void | Promise<void>;
+  clear(phone: string): void | Promise<void>;
+}
+
+// ─── MapConversationStore (in-memory fallback) ────────────────────────────────
+
+/**
+ * In-memory Map-based conversation store.
+ * Behaves identically to the original implementation — no persistence across restarts.
+ */
+export class MapConversationStore implements ConversationStore {
+  private store = new Map<string, ChatMessage[]>();
+
+  get(phone: string): ChatMessage[] {
+    return this.store.get(phone) || [];
+  }
+
+  append(phone: string, message: ChatMessage, maxMessages = MAX_HISTORY_MESSAGES): void {
+    const history = this.store.get(phone) || [];
+    history.push(message);
+    if (history.length > maxMessages) {
+      history.splice(0, history.length - maxMessages);
+    }
+    this.store.set(phone, history);
+  }
+
+  clear(phone: string): void {
+    this.store.delete(phone);
+  }
+}
+
+// ─── Redis Conversation Store ─────────────────────────────────────────────────
+
+export interface RedisConfig {
+  url: string;
+  ttl: number;
+  keyPrefix: string;
+}
+
+/**
+ * Redis-backed conversation store.
+ * Keys follow the pattern: `bot:conversation:{phone}`
+ * Each key has a TTL of 24h (configurable) that resets on every append.
+ * Serialization uses JSON.stringify / JSON.parse.
+ *
+ * Usage: new RedisConversationStore({ url: REDIS_URL, ttl: 86400, keyPrefix: 'bot:conversation' })
+ */
+export class RedisConversationStore implements ConversationStore {
+  private redis: Redis;
+  private ttl: number;
+  private keyPrefix: string;
+
+  constructor(config: RedisConfig) {
+    this.redis = new Redis(config.url);
+    this.ttl = config.ttl;
+    this.keyPrefix = config.keyPrefix;
+  }
+
+  private key(phone: string): string {
+    return `${this.keyPrefix}:${phone}`;
+  }
+
+  async get(phone: string): Promise<ChatMessage[]> {
+    const raw = await this.redis.get(this.key(phone));
+    return raw ? (JSON.parse(raw) as ChatMessage[]) : [];
+  }
+
+  async append(
+    phone: string,
+    message: ChatMessage,
+    maxMessages = MAX_HISTORY_MESSAGES
+  ): Promise<void> {
+    const history = await this.get(phone);
+    history.push(message);
+    if (history.length > maxMessages) {
+      history.splice(0, history.length - maxMessages);
+    }
+    await this.redis.setex(this.key(phone), this.ttl, JSON.stringify(history));
+  }
+
+  async clear(phone: string): Promise<void> {
+    await this.redis.del(this.key(phone));
+  }
+
+  /** Gracefully close the Redis connection. Call during shutdown. */
+  async quit(): Promise<void> {
+    await this.redis.quit();
+  }
+
+  /** Expose the underlying Redis instance for advanced use / testing */
+  get client(): Redis {
+    return this.redis;
+  }
+}
+
+// ─── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a ConversationStore based on the REDIS_URL environment variable.
+ *
+ * - If REDIS_URL is set and non-empty → returns a RedisConversationStore
+ * - Otherwise → returns a MapConversationStore (in-memory, no persistence)
+ *
+ * @param redisUrl - Redis connection URL (defaults to process.env.REDIS_URL)
+ * @param ttl - Key TTL in seconds (default: 86400 = 24h)
+ * @param keyPrefix - Redis key prefix (default: 'bot:conversation')
+ */
+export function createConversationStore(
+  redisUrl?: string,
+  ttl = 86400,
+  keyPrefix = 'bot:conversation'
+): ConversationStore {
+  const url = redisUrl ?? process.env.REDIS_URL;
+  if (url) {
+    return new RedisConversationStore({ url, ttl, keyPrefix });
+  }
+  return new MapConversationStore();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ importers:
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
       openai:
         specifier: ^4.91.1
         version: 4.104.0(ws@8.21.0)(zod@3.25.76)


### PR DESCRIPTION
## Description

Reemplaza el almacenamiento en memoria (Map) de conversaciones AI por una implementacion con Redis, mas un fallback a Map cuando no hay Redis disponible. Esto evita que las conversaciones se pierdan al reiniciar el bot.

### Dependency

Depends on PR #220 (schedule-visit fix).

### Changes

| File | Change |
|------|--------|
| `bot/src/services/conversation-store.ts` | Created: ConversationStore interface, MapConversationStore, RedisConversationStore, factory function |
| `bot/src/services/ai.service.ts` | Refactored: replaced Map with store factory, async history functions |
| `bot/src/__tests__/unit/ai.service.test.ts` | Added ioredis mock + 8 new tests for Redis store |
| `bot/package.json` | Added ioredis dependency |
| `bot/.env.example` | Added REDIS_URL env var |

### Test Plan

- [x] All 70 bot tests pass (62 original + 8 new)
- [x] Redis store: setex called with correct key prefix, TTL, JSON serialization
- [x] Map fallback works when REDIS_URL is unset
- [x] No regressions in existing conversation tests

Closes #214
