### PR TITLE
feat(config): add platformUrl() helper and 4 env-backed constants

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -75,6 +75,20 @@ NOTION_DATABASE_ID_LEADS=your_notion_leads_database_id
 # Manage at: https://app.brevo.com/email/template
 BREVO_HANDOFF_TEMPLATE_ID=1
 
+# ─── Platform Configuration ───────────────────────────────────────────────────
+
+# Base URL for platform links in bot messages.
+# PLATFORM_URL=https://nexoreal.xyz
+
+# Contact email shown in bot responses.
+# EMAIL=contact@nexoreal.xyz
+
+# Calendly scheduling link.
+# CALENDLY_LINK=https://calendly.com/nexoreal
+
+# Physical office address shown in bot responses.
+# OFFICE_ADDRESS=Av. Always Sunny 123, Buenos Aires, Argentina
+
 # ─── Redis (optional — AI conversation persistence) ───────────────────────────
 
 # Redis connection URL for AI conversation history persistence.

--- a/bot/src/config/platform.ts
+++ b/bot/src/config/platform.ts
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Platform Configuration — env-backed constants for bot messages
+ * @description Centralized configuration for platform URLs and contact info.
+ *              Import from here instead of hardcoding URLs or placeholders in flows.
+ *              Configuración centralizada para URLs de plataforma e info de contacto.
+ *              Importar desde aquí en lugar de hardcodear URLs o placeholders en flows.
+ * @module config/platform
+ */
+
+/**
+ * Build a platform URL from the PLATFORM_URL env var and an optional path.
+ *
+ * - Removes trailing slash from base URL before appending path
+ * - Path starting with `/` → appended as-is
+ * - Path without leading `/` → `/` prepended automatically
+ * - No path → returns base URL only
+ *
+ * @param path - Optional path to append (e.g. '/register', 'properties')
+ * @returns Full platform URL
+ *
+ * @example
+ * ```ts
+ * platformUrl()              // → 'https://nexoreal.xyz'
+ * platformUrl('/register')   // → 'https://nexoreal.xyz/register'
+ * platformUrl('properties')  // → 'https://nexoreal.xyz/properties'
+ * ```
+ */
+export function platformUrl(path?: string): string {
+  const baseUrl = (process.env.PLATFORM_URL || 'https://nexoreal.xyz').replace(/\/+$/, '');
+
+  if (!path) return baseUrl;
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${baseUrl}${normalizedPath}`;
+}
+
+/**
+ * Contact email shown in bot responses.
+ * Default: empty string (the substitution layer falls back to a generic message).
+ */
+export const EMAIL: string = process.env.EMAIL || '';
+
+/**
+ * Calendly scheduling link for booking visits.
+ * Default: empty string (the substitution layer falls back to a generic message).
+ */
+export const CALENDLY_LINK: string = process.env.CALENDLY_LINK || '';
+
+/**
+ * Physical office address shown in bot responses.
+ * Default: 'Ask the agent for more information'
+ */
+export const OFFICE_ADDRESS: string =
+  process.env.OFFICE_ADDRESS || 'Ask the agent for more information';

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -151,6 +151,12 @@ services:
       DB_USER: ${DB_USER:-mlm}
       DB_PASSWORD: ${DB_PASSWORD}
 
+      # Platform configuration — bot contact info & URLs
+      PLATFORM_URL: ${PLATFORM_URL:-https://nexoreal.xyz}
+      EMAIL: ${EMAIL:-}
+      CALENDLY_LINK: ${CALENDLY_LINK:-}
+      OFFICE_ADDRESS: ${OFFICE_ADDRESS:-Ask the agent for more information}
+
       # n8n — internal webhook base URL
       N8N_WEBHOOK_URL: http://n8n:5678/webhook
     volumes:


### PR DESCRIPTION
## Description

New `bot/src/config/platform.ts` module with `platformUrl(path?)` helper and 4 env-backed constants. This is the foundation for replacing hardcoded platform URLs and KB placeholders.

### Changes

| File | Action |
|------|--------|
| `bot/src/config/platform.ts` | Created — `platformUrl()`, `EMAIL`, `CALENDLY_LINK`, `OFFICE_ADDRESS` |
| `bot/.env.example` | Modified — added Platform Configuration section |
| `docker-compose.prod.yml` | Modified — added 4 env vars to bot service |

### Test Plan

- [x] `platformUrl()` returns default URL when PLATFORM_URL not set
- [x] `platformUrl('/register')` appends path correctly
- [x] No breaking changes — this is additive only

PR 1 of 3 (feature-branch-chain). Part of `configurable-env-substitutes` change.