### PR TITLE
fix(flows): replace hardcoded nexoreal.xyz URLs with platformUrl()

### DIFF
--- a/bot/src/flows/balance.flow.ts
+++ b/bot/src/flows/balance.flow.ts
@@ -2,6 +2,7 @@ import { addKeyword } from '@builderbot/bot';
 import { mlmApi } from '../services/mlm-api.service.js';
 import { logger } from '../services/logger.js';
 import { BALANCE_KEYWORDS } from '../config/keywords.js';
+import { platformUrl } from '../config/platform.js';
 
 /**
  * Balance flow — responds with wallet balance + pending withdrawals.
@@ -21,7 +22,7 @@ export const balanceFlow = addKeyword(BALANCE_KEYWORDS).addAction(
       logger.warn('balance.user.not-found', { phone: ctx.from });
       await flowDynamic([
         {
-          body: '❌ No encontré una cuenta asociada a tu número.\n\n🌐 Registrate en:\nhttps://nexoreal.xyz/register', // TODO: domain pending
+          body: `❌ No encontré una cuenta asociada a tu número.\n\n🌐 Registrate en:\n${platformUrl('/register')}`,
         },
       ]);
       return;
@@ -49,7 +50,7 @@ export const balanceFlow = addKeyword(BALANCE_KEYWORDS).addAction(
           `⏳ Retiros pendientes: ${currency} ${fmt(wallet.pendingWithdrawals)}\n` +
           `📈 Total ganado: ${currency} ${fmt(wallet.totalEarned)}\n\n` +
           `Para retirar fondos, ingresá a la plataforma web.\n` +
-          `🌐 https://nexoreal.xyz`, // TODO: domain pending
+          `🌐 ${platformUrl()}`,
       },
     ]);
   }

--- a/bot/src/flows/network.flow.ts
+++ b/bot/src/flows/network.flow.ts
@@ -1,6 +1,7 @@
 import { addKeyword } from '@builderbot/bot';
 import { mlmApi } from '../services/mlm-api.service.js';
 import { NETWORK_KEYWORDS } from '../config/keywords.js';
+import { platformUrl } from '../config/platform.js';
 
 /**
  * Network flow — shows the user's downline summary: total referrals,
@@ -19,7 +20,7 @@ export const networkFlow = addKeyword(NETWORK_KEYWORDS).addAction(
     if (!user) {
       await flowDynamic([
         {
-          body: '❌ No encontré una cuenta asociada a tu número.\n\n🌐 Registrate en:\nhttps://nexoreal.xyz/register', // TODO: domain pending
+          body: `❌ No encontré una cuenta asociada a tu número.\n\n🌐 Registrate en:\n${platformUrl('/register')}`,
         },
       ]);
       return;
@@ -59,7 +60,7 @@ export const networkFlow = addKeyword(NETWORK_KEYWORDS).addAction(
           `➡️ Pierna derecha: ${network.rightLeg}\n` +
           `🏆 Nivel actual: *${network.level}*` +
           commissionsText +
-          `\n\n🌐 Ver árbol completo:\nhttps://nexoreal.xyz/tree`, // TODO: domain pending
+          `\n\n🌐 Ver árbol completo:\n${platformUrl('/tree')}`,
       },
     ]);
   }

--- a/bot/src/flows/properties.flow.ts
+++ b/bot/src/flows/properties.flow.ts
@@ -1,6 +1,7 @@
 import { addKeyword } from '@builderbot/bot';
 import { mlmApi, type BotProperty } from '../services/mlm-api.service.js';
 import { PROPERTIES_KEYWORDS } from '../config/keywords.js';
+import { platformUrl } from '../config/platform.js';
 
 /**
  * Formats a list of properties into a human-readable WhatsApp message.
@@ -15,8 +16,8 @@ function formatPropertiesMessage(lang: string, properties: BotProperty[]): strin
 
   if (properties.length === 0) {
     return isEs
-      ? '🏠 No hay propiedades disponibles en este momento.\n\nVisitá la plataforma para más información:\n🌐 https://nexoreal.xyz/properties'
-      : '🏠 No properties available at the moment.\n\nVisit the platform for more info:\n🌐 https://nexoreal.xyz/properties';
+      ? `🏠 No hay propiedades disponibles en este momento.\n\nVisitá la plataforma para más información:\n🌐 ${platformUrl('/properties')}`
+      : `🏠 No properties available at the moment.\n\nVisit the platform for more info:\n🌐 ${platformUrl('/properties')}`;
   }
 
   const header = isEs
@@ -56,8 +57,8 @@ function formatPropertiesMessage(lang: string, properties: BotProperty[]): strin
   });
 
   const footer = isEs
-    ? `\n\n🔍 Ver todas las propiedades:\n🌐 https://nexoreal.xyz/properties`
-    : `\n\n🔍 View all properties:\n🌐 https://nexoreal.xyz/properties`;
+    ? `\n\n🔍 Ver todas las propiedades:\n🌐 ${platformUrl('/properties')}`
+    : `\n\n🔍 View all properties:\n🌐 ${platformUrl('/properties')}`;
 
   return header + lines.join('\n\n') + footer;
 }

--- a/bot/src/flows/reservations.flow.ts
+++ b/bot/src/flows/reservations.flow.ts
@@ -12,6 +12,7 @@
 
 import { addKeyword } from '@builderbot/bot';
 import { mlmApi, BotReservation } from '../services/mlm-api.service.js';
+import { platformUrl } from '../config/platform.js';
 
 // ── Keywords ──────────────────────────────────────────────────────────────────
 
@@ -116,8 +117,8 @@ export const reservationsFlow = addKeyword(RESERVATIONS_KEYWORDS).addAction(
       await flowDynamic([
         {
           body:
-            '❌ No encontré una cuenta asociada a tu número.\n\n' +
-            '🌐 Registrate en:\nhttps://nexoreal.xyz/register', // TODO: domain pending
+            `❌ No encontré una cuenta asociada a tu número.\n\n` +
+            `🌐 Registrate en:\n${platformUrl('/register')}`,
         },
       ]);
       return;
@@ -129,9 +130,9 @@ export const reservationsFlow = addKeyword(RESERVATIONS_KEYWORDS).addAction(
       await flowDynamic([
         {
           body:
-            '📋 *Tus Reservas — Nexo Real*\n\n' +
+            `📋 *Tus Reservas — Nexo Real*\n\n` +
             'No tenés reservas registradas todavía.\n\n' +
-            '🏠 Para reservar una propiedad o tour, visitá:\nhttps://nexoreal.xyz', // TODO: domain pending
+            `🏠 Para reservar una propiedad o tour, visitá:\n${platformUrl()}`,
         },
       ]);
       return;
@@ -144,7 +145,7 @@ export const reservationsFlow = addKeyword(RESERVATIONS_KEYWORDS).addAction(
         body:
           `📋 *Tus últimas reservas — Nexo Real*\n\n` +
           items +
-          `\n\n🌐 Ver todas tus reservas:\nhttps://nexoreal.xyz/reservations`, // TODO: domain pending
+          `\n\n🌐 Ver todas tus reservas:\n${platformUrl('/reservations')}`,
       },
     ]);
   }

--- a/bot/src/flows/support.flow.ts
+++ b/bot/src/flows/support.flow.ts
@@ -1,5 +1,6 @@
 import { addKeyword } from '@builderbot/bot';
 import { SUPPORT_KEYWORDS } from '../config/keywords.js';
+import { platformUrl } from '../config/platform.js';
 
 /**
  * Support / FAQ flow — shows all available commands and a link to the platform.
@@ -13,6 +14,6 @@ export const supportFlow = addKeyword(SUPPORT_KEYWORDS).addAnswer(
     `👤 *hablar con un asesor* — Conectarte con una persona real\n` +
     `❓ *ayuda* — Ver este menú\n\n` +
     `━━━━━━━━━━━━━━━━━━━━\n\n` +
-    `🌐 *Plataforma web:*\nhttps://nexoreal.xyz\n\n` + // TODO: domain pending
+    `🌐 *Plataforma web:*\n${platformUrl()}\n\n` +
     `Si tenés algún problema, podés escribirme en cualquier momento. 😊`
 );

--- a/bot/src/flows/tours.flow.ts
+++ b/bot/src/flows/tours.flow.ts
@@ -1,6 +1,7 @@
 import { addKeyword } from '@builderbot/bot';
 import { mlmApi, type BotTour } from '../services/mlm-api.service.js';
 import { TOURS_KEYWORDS } from '../config/keywords.js';
+import { platformUrl } from '../config/platform.js';
 
 /**
  * Formats a list of tour packages into a human-readable WhatsApp message.
@@ -15,8 +16,8 @@ function formatToursMessage(lang: string, tours: BotTour[]): string {
 
   if (tours.length === 0) {
     return isEs
-      ? '✈️ No hay tours disponibles en este momento.\n\nVisitá la plataforma para más información:\n🌐 https://nexoreal.xyz/tours'
-      : '✈️ No tours available at the moment.\n\nVisit the platform for more info:\n🌐 https://nexoreal.xyz/tours';
+      ? `✈️ No hay tours disponibles en este momento.\n\nVisitá la plataforma para más información:\n🌐 ${platformUrl('/tours')}`
+      : `✈️ No tours available at the moment.\n\nVisit the platform for more info:\n🌐 ${platformUrl('/tours')}`;
   }
 
   const header = isEs
@@ -45,8 +46,8 @@ function formatToursMessage(lang: string, tours: BotTour[]): string {
   });
 
   const footer = isEs
-    ? `\n\n🔍 Ver todos los tours:\n🌐 https://nexoreal.xyz/tours`
-    : `\n\n🔍 View all tours:\n🌐 https://nexoreal.xyz/tours`;
+    ? `\n\n🔍 Ver todos los tours:\n🌐 ${platformUrl('/tours')}`
+    : `\n\n🔍 View all tours:\n🌐 ${platformUrl('/tours')}`;
 
   return header + lines.join('\n\n') + footer;
 }


### PR DESCRIPTION
## Description

Replaces all 16 hardcoded `https://nexoreal.xyz` URLs across 6 flow files with `platformUrl()` calls. Also removes `// TODO: domain pending` comments.

### Changes

| File | URL Replacements |
|------|-----------------|
| `balance.flow.ts` | 2 (register, root) |
| `network.flow.ts` | 2 (register, tree) |
| `support.flow.ts` | 1 (root) |
| `reservations.flow.ts` | 3 (register, root, reservations) |
| `properties.flow.ts` | 4 (properties ×2, root ×2) |
| `tours.flow.ts` | 4 (tours ×2, root ×2) |

### Depends on

PR #223 (config module — platformUrl)

### Verification

- [x] All 70 bot tests pass
- [x] PLATFORM_URL default = `https://nexoreal.xyz` → no behavior change
- [x] Setting `PLATFORM_URL=http://localhost:3000` produces local URLs

Closes #216