### PR TITLE
feat(ai): add substituteEnvVars() and rename KB placeholders

### DIFF
--- a/bot/src/prompt_kb/knowledge-base.md
+++ b/bot/src/prompt_kb/knowledge-base.md
@@ -476,11 +476,12 @@ Siempre intentar obtener antes de cerrar la conversación o escalar:
 ### Canales de contacto
 
 > **NOTA PARA EL BOT**: Reemplazar los placeholders con los datos reales del cliente cuando estén disponibles.
+> **NOTA**: Los placeholders `[EMAIL]`, `[PLATFORM_URL]`, `[CALENDLY_LINK]` y `[OFFICE_ADDRESS]` son reemplazados automáticamente por el sistema con los datos del cliente.
 
-- 📧 Email: `[EMAIL_NEXO_REAL]`
-- 🌐 Web: `[WEB_NEXO_REAL]`
+- 📧 Email: `[EMAIL]`
+- 🌐 Web: `[PLATFORM_URL]`
 - 📅 Agendar llamada: `[CALENDLY_LINK]`
-- 📍 Oficina: `[DIRECCION_NEXO_REAL]`
+- 📍 Oficina: `[OFFICE_ADDRESS]`
 
 ---
 
@@ -510,11 +511,12 @@ Always try to collect before closing the conversation or escalating:
 ### Contact channels
 
 > **NOTE FOR BOT**: Replace placeholders with actual client data when available.
+> **NOTE**: The placeholders `[EMAIL]`, `[PLATFORM_URL]`, `[CALENDLY_LINK]` and `[OFFICE_ADDRESS]` are automatically replaced by the system with actual client data.
 
-- 📧 Email: `[EMAIL_NEXO_REAL]`
-- 🌐 Web: `[WEB_NEXO_REAL]`
+- 📧 Email: `[EMAIL]`
+- 🌐 Web: `[PLATFORM_URL]`
 - 📅 Schedule a call: `[CALENDLY_LINK]`
-- 📍 Office: `[ADDRESS_NEXO_REAL]`
+- 📍 Office: `[OFFICE_ADDRESS]`
 
 ---
 

--- a/bot/src/services/ai.service.ts
+++ b/bot/src/services/ai.service.ts
@@ -19,6 +19,7 @@ import {
   ChatMessage,
   MAX_HISTORY_MESSAGES,
 } from './conversation-store.js';
+import { platformUrl, EMAIL, CALENDLY_LINK, OFFICE_ADDRESS } from '../config/platform.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -104,6 +105,43 @@ async function fetchLiveContext(): Promise<string> {
 }
 
 /**
+ * Substitute environment-backed placeholders in a knowledge-base string.
+ * Reemplaza los placeholders de entorno en un string de knowledge base.
+ *
+ * Replaces the following placeholders with their env-var values:
+ *   [EMAIL]          → EMAIL env var (fallback: 'Ask the agent for more information')
+ *   [PLATFORM_URL]   → platformUrl() result (default: 'https://nexoreal.xyz')
+ *   [CALENDLY_LINK]  → CALENDLY_LINK env var (fallback: 'Ask the agent for more information')
+ *   [OFFICE_ADDRESS] → OFFICE_ADDRESS env var (fallback from platform.ts)
+ *
+ * Legacy aliases (backward-compatible):
+ *   [EMAIL_NEXO_REAL]    → same as [EMAIL]
+ *   [WEB_NEXO_REAL]      → same as [PLATFORM_URL]
+ *   [DIRECCION_NEXO_REAL] → same as [OFFICE_ADDRESS]
+ *   [ADDRESS_NEXO_REAL]   → same as [OFFICE_ADDRESS]
+ *
+ * @param kb - Knowledge-base string containing placeholders
+ * @returns KB string with all placeholders replaced by env-var values
+ */
+function substituteEnvVars(kb: string): string {
+  const email = EMAIL || 'Ask the agent for more information';
+  const platform = platformUrl();
+  const calendly = CALENDLY_LINK || 'Ask the agent for more information';
+  const office = OFFICE_ADDRESS;
+
+  let result = kb;
+  result = result.replaceAll('[EMAIL]', email);
+  result = result.replaceAll('[PLATFORM_URL]', platform);
+  result = result.replaceAll('[CALENDLY_LINK]', calendly);
+  result = result.replaceAll('[OFFICE_ADDRESS]', office);
+  result = result.replaceAll('[EMAIL_NEXO_REAL]', email);
+  result = result.replaceAll('[WEB_NEXO_REAL]', platform);
+  result = result.replaceAll('[DIRECCION_NEXO_REAL]', office);
+  result = result.replaceAll('[ADDRESS_NEXO_REAL]', office);
+  return result;
+}
+
+/**
  * Build the system prompt by combining static KB files with optional live context.
  * Construye el prompt del sistema combinando archivos KB estáticos con contexto en vivo opcional.
  *
@@ -117,8 +155,11 @@ function buildSystemPrompt(agent: AgentName, language: Language, liveContext = '
   const knowledgeBase = loadFile('knowledge-base.md');
   const agentPrompt = loadFile(`${agent}.prompt.md`);
 
+  // Substitute env vars in KB before injection
+  const substitutedKB = substituteEnvVars(knowledgeBase);
+
   // Inject KB into base prompt
-  const promptWithKB = basePrompt.replace('{KNOWLEDGE_BASE}', knowledgeBase);
+  const promptWithKB = basePrompt.replace('{KNOWLEDGE_BASE}', substitutedKB);
 
   // Add language instruction
   const langInstruction =


### PR DESCRIPTION
## Description

Add `substituteEnvVars(kb)` function in `ai.service.ts` that replaces KB placeholders with env var values before injecting into the system prompt. Also renames legacy placeholders in `knowledge-base.md` to unified names.

### Placeholder mapping

| New | Old (legacy compat) | Env Var |
|-----|-----|---------|
| `[EMAIL]` | `[EMAIL_NEXO_REAL]` | `EMAIL` |
| `[PLATFORM_URL]` | `[WEB_NEXO_REAL]` | `PLATFORM_URL` |
| `[CALENDLY_LINK]` | — | `CALENDLY_LINK` |
| `[OFFICE_ADDRESS]` | `[DIRECCION_NEXO_REAL]` / `[ADDRESS_NEXO_REAL]` | `OFFICE_ADDRESS` |

### Depends on

PR #223 (config module — platformUrl, env constants)

Closes #215