### PR TITLE
fix(backend): add try/catch error handling to 3 services (13 async methods)

### DIFF
--- a/backend/src/__tests__/R2Service.test.ts
+++ b/backend/src/__tests__/R2Service.test.ts
@@ -70,8 +70,19 @@ jest.mock('crypto', () => ({
   randomUUID: jest.fn().mockReturnValue('test-uuid-1234'),
 }));
 
+// ============================================
+// Mock logger to verify error logging
+// ============================================
+
+jest.mock('../utils/logger', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
 import { R2Service } from '../services/R2Service';
 import { PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { logger } from '../utils/logger';
 
 describe('R2Service', () => {
   let r2Service: R2Service;
@@ -271,6 +282,89 @@ describe('R2Service', () => {
 
       expect(result).toEqual(expectedUrls);
       expect(result).toHaveLength(2);
+    });
+  });
+
+  // ============================================================
+  // Error handling — verify try/catch logging
+  // ============================================================
+  describe('error handling', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('uploadImage — logs error and rethrows when sharp fails', async () => {
+      const error = new Error('sharp processing failed');
+      mockSharp.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      await expect(
+        r2Service.uploadImage({
+          buffer: Buffer.from('data'),
+          mimetype: 'image/jpeg',
+          entityType: 'properties',
+          entityId: 'prop-uuid',
+          filename: 'photo.jpg',
+        })
+      ).rejects.toThrow('sharp processing failed');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        { service: 'R2Service', method: 'uploadImage', error },
+        'Operation failed'
+      );
+    });
+
+    it('uploadImage — logs error and rethrows when S3 upload fails', async () => {
+      const error = new Error('S3 upload failed');
+      mockSend.mockRejectedValueOnce(error);
+
+      await expect(
+        r2Service.uploadImage({
+          buffer: Buffer.from('data'),
+          mimetype: 'image/jpeg',
+          entityType: 'properties',
+          entityId: 'prop-uuid',
+          filename: 'photo.jpg',
+        })
+      ).rejects.toThrow('S3 upload failed');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        { service: 'R2Service', method: 'uploadImage', error },
+        'Operation failed'
+      );
+    });
+
+    it('deleteImage — logs error and rethrows when S3 delete fails', async () => {
+      const error = new Error('S3 delete failed');
+      mockSend.mockRejectedValueOnce(error);
+
+      await expect(
+        r2Service.deleteImage('https://media.nexoreal.xyz/properties/uuid/img.webp')
+      ).rejects.toThrow('S3 delete failed');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        { service: 'R2Service', method: 'deleteImage', error },
+        'Operation failed'
+      );
+    });
+
+    it('uploadImages — logs error and rethrows when uploadImage fails', async () => {
+      const error = new Error('upload failed');
+      jest.spyOn(r2Service, 'uploadImage').mockRejectedValueOnce(error);
+
+      await expect(
+        r2Service.uploadImages({
+          files: [{ buffer: Buffer.from('f1'), mimetype: 'image/jpeg', originalname: 'a.jpg' }],
+          entityType: 'properties',
+          entityId: 'prop-uuid',
+        })
+      ).rejects.toThrow('upload failed');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        { service: 'R2Service', method: 'uploadImages', error },
+        'Operation failed'
+      );
     });
   });
 });

--- a/backend/src/__tests__/unit/QRService.test.ts
+++ b/backend/src/__tests__/unit/QRService.test.ts
@@ -29,9 +29,17 @@ jest.mock('../../config/env', () => ({
   },
 }));
 
+// Mock logger to verify error logging
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
 import QRCode from 'qrcode';
 import { QRService, qrService } from '../../services/QRService';
 import { QrMapping } from '../../models';
+import { logger } from '../../utils/logger';
 
 describe('QRService — Gift Card Methods', () => {
   beforeEach(() => {
@@ -103,6 +111,84 @@ describe('QRService — Gift Card Methods', () => {
   describe('singleton export', () => {
     it('should export a singleton instance of QRService', () => {
       expect(qrService).toBeInstanceOf(QRService);
+    });
+  });
+
+  // ============================================
+  // Error handling — verify try/catch logging
+  // ============================================
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('generateQRDataUrl — logs error and rethrows when QRCode.toDataURL fails', async () => {
+      const error = new Error('QR generation failed');
+      (QRCode.toDataURL as jest.Mock).mockRejectedValueOnce(error);
+
+      await expect(qrService.generateQRDataUrl('MLM-ABCD-1234')).rejects.toThrow(
+        'QR generation failed'
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        { service: 'QRService', method: 'generateQRDataUrl', error },
+        'Operation failed'
+      );
+    });
+
+    it('generateQRBuffer — logs error and rethrows when QRCode.toBuffer fails', async () => {
+      const error = new Error('QR buffer failed');
+      (QRCode.toBuffer as jest.Mock).mockRejectedValueOnce(error);
+
+      await expect(qrService.generateQRBuffer('MLM-ABCD-1234')).rejects.toThrow('QR buffer failed');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        { service: 'QRService', method: 'generateQRBuffer', error },
+        'Operation failed'
+      );
+    });
+
+    it('generateQRFile — logs error and rethrows when QRCode.toFile fails', async () => {
+      const error = new Error('QR file write failed');
+      (QRCode.toFile as jest.Mock).mockRejectedValueOnce(error);
+
+      await expect(qrService.generateQRFile('MLM-ABCD-1234', '/tmp/qr.png')).rejects.toThrow(
+        'QR file write failed'
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        { service: 'QRService', method: 'generateQRFile', error },
+        'Operation failed'
+      );
+    });
+
+    it('generateGiftCardQR — logs error and rethrows when QRCode.toDataURL fails', async () => {
+      const error = new Error('Gift card QR failed');
+      (QRCode.toDataURL as jest.Mock).mockRejectedValueOnce(error);
+
+      await expect(qrService.generateGiftCardQR('abc123xyz')).rejects.toThrow(
+        'Gift card QR failed'
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        { service: 'QRService', method: 'generateGiftCardQR', error },
+        'Operation failed'
+      );
+    });
+
+    it('resolveShortCode — logs error and rethrows when QrMapping.findOne fails', async () => {
+      const error = new Error('Database query failed');
+      (QrMapping.findOne as jest.Mock).mockRejectedValueOnce(error);
+
+      await expect(qrService.resolveShortCode('abc123xyz')).rejects.toThrow(
+        'Database query failed'
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        { service: 'QRService', method: 'resolveShortCode', error },
+        'Operation failed'
+      );
     });
   });
 });

--- a/backend/src/services/MercadoPagoService.ts
+++ b/backend/src/services/MercadoPagoService.ts
@@ -7,6 +7,7 @@
 import { createHmac } from 'crypto';
 import { MercadoPagoConfig, Preference, Payment, PaymentRefund } from 'mercadopago';
 import { config } from '../config/env.js';
+import { logger } from '../utils/logger';
 
 // Configure MercadoPago SDK v2
 const client = new MercadoPagoConfig({
@@ -66,13 +67,21 @@ class MercadoPagoService {
    * @see https://www.mercadopago.com/developers/en/docs/checkout-api/integration-configuration
    */
   async createPreference(preference: MercadoPagoPreference): Promise<CreatePreferenceResult> {
-    const result = await this.preference.create({ body: preference });
+    try {
+      const result = await this.preference.create({ body: preference });
 
-    return {
-      id: result.id!,
-      init_point: result.init_point!,
-      sandbox_init_point: result.sandbox_init_point!,
-    };
+      return {
+        id: result.id!,
+        init_point: result.init_point!,
+        sandbox_init_point: result.sandbox_init_point!,
+      };
+    } catch (error) {
+      logger.error(
+        { service: 'MercadoPagoService', method: 'createPreference', error },
+        'Operation failed'
+      );
+      throw error;
+    }
   }
 
   /**
@@ -102,18 +111,26 @@ class MercadoPagoService {
    * Get payment status by ID
    */
   async getPayment(paymentId: string): Promise<PaymentResult> {
-    const result = await this.payment.get({ id: paymentId });
+    try {
+      const result = await this.payment.get({ id: paymentId });
 
-    return {
-      id: result.id!.toString(),
-      status: result.status as PaymentResult['status'],
-      status_detail: result.status_detail ?? undefined,
-      payment_type_id: result.payment_type_id ?? undefined,
-      transaction_amount: result.transaction_amount ?? undefined,
-      currency_id: result.currency_id ?? undefined,
-      external_reference: result.external_reference ?? undefined,
-      additional_info: result.additional_info as PaymentResult['additional_info'],
-    };
+      return {
+        id: result.id!.toString(),
+        status: result.status as PaymentResult['status'],
+        status_detail: result.status_detail ?? undefined,
+        payment_type_id: result.payment_type_id ?? undefined,
+        transaction_amount: result.transaction_amount ?? undefined,
+        currency_id: result.currency_id ?? undefined,
+        external_reference: result.external_reference ?? undefined,
+        additional_info: result.additional_info as PaymentResult['additional_info'],
+      };
+    } catch (error) {
+      logger.error(
+        { service: 'MercadoPagoService', method: 'getPayment', error },
+        'Operation failed'
+      );
+      throw error;
+    }
   }
 
   /**
@@ -135,39 +152,55 @@ class MercadoPagoService {
       };
     };
   }): Promise<PaymentResult> {
-    const result = await this.payment.create({
-      body: {
-        token: paymentData.token,
-        issuer_id: paymentData.issuerId ? parseInt(paymentData.issuerId) : undefined,
-        payment_method_id: paymentData.paymentMethodId,
-        transaction_amount: paymentData.transactionAmount,
-        installments: paymentData.installments,
-        description: paymentData.description,
-        external_reference: paymentData.externalReference,
-        payer: paymentData.payer,
-      },
-    });
+    try {
+      const result = await this.payment.create({
+        body: {
+          token: paymentData.token,
+          issuer_id: paymentData.issuerId ? parseInt(paymentData.issuerId) : undefined,
+          payment_method_id: paymentData.paymentMethodId,
+          transaction_amount: paymentData.transactionAmount,
+          installments: paymentData.installments,
+          description: paymentData.description,
+          external_reference: paymentData.externalReference,
+          payer: paymentData.payer,
+        },
+      });
 
-    return {
-      id: result.id!.toString(),
-      status: result.status as PaymentResult['status'],
-      status_detail: result.status_detail ?? undefined,
-      payment_type_id: result.payment_type_id ?? undefined,
-      transaction_amount: result.transaction_amount ?? undefined,
-      currency_id: result.currency_id ?? undefined,
-      external_reference: result.external_reference ?? undefined,
-    };
+      return {
+        id: result.id!.toString(),
+        status: result.status as PaymentResult['status'],
+        status_detail: result.status_detail ?? undefined,
+        payment_type_id: result.payment_type_id ?? undefined,
+        transaction_amount: result.transaction_amount ?? undefined,
+        currency_id: result.currency_id ?? undefined,
+        external_reference: result.external_reference ?? undefined,
+      };
+    } catch (error) {
+      logger.error(
+        { service: 'MercadoPagoService', method: 'processPayment', error },
+        'Operation failed'
+      );
+      throw error;
+    }
   }
 
   /**
    * Refund a payment
    */
   async refundPayment(paymentId: string): Promise<{ status: string }> {
-    const result = await this.paymentRefund.create({ payment_id: parseInt(paymentId) });
+    try {
+      const result = await this.paymentRefund.create({ payment_id: parseInt(paymentId) });
 
-    return {
-      status: result.status ?? 'approved',
-    };
+      return {
+        status: result.status ?? 'approved',
+      };
+    } catch (error) {
+      logger.error(
+        { service: 'MercadoPagoService', method: 'refundPayment', error },
+        'Operation failed'
+      );
+      throw error;
+    }
   }
 
   /**
@@ -176,15 +209,23 @@ class MercadoPagoService {
    * Use the REST API directly or return a static list of common methods.
    */
   async getPaymentMethods(): Promise<Array<{ id: string; name: string; payment_type_id: string }>> {
-    // SDK v2 PaymentMethod only supports get(id), not list().
-    // Return common payment methods — extend as needed.
-    return [
-      { id: 'visa', name: 'Visa', payment_type_id: 'credit_card' },
-      { id: 'master', name: 'Mastercard', payment_type_id: 'credit_card' },
-      { id: 'amex', name: 'American Express', payment_type_id: 'credit_card' },
-      { id: 'pse', name: 'PSE', payment_type_id: 'bank_transfer' },
-      { id: 'efecty', name: 'Efecty', payment_type_id: 'ticket' },
-    ];
+    try {
+      // SDK v2 PaymentMethod only supports get(id), not list().
+      // Return common payment methods — extend as needed.
+      return [
+        { id: 'visa', name: 'Visa', payment_type_id: 'credit_card' },
+        { id: 'master', name: 'Mastercard', payment_type_id: 'credit_card' },
+        { id: 'amex', name: 'American Express', payment_type_id: 'credit_card' },
+        { id: 'pse', name: 'PSE', payment_type_id: 'bank_transfer' },
+        { id: 'efecty', name: 'Efecty', payment_type_id: 'ticket' },
+      ];
+    } catch (error) {
+      logger.error(
+        { service: 'MercadoPagoService', method: 'getPaymentMethods', error },
+        'Operation failed'
+      );
+      throw error;
+    }
   }
 }
 

--- a/backend/src/services/QRService.ts
+++ b/backend/src/services/QRService.ts
@@ -9,6 +9,7 @@
 import QRCode from 'qrcode';
 import { config } from '../config/env';
 import { QrMapping } from '../models';
+import { logger } from '../utils/logger';
 
 /**
  * QR Code Service - Generates QR codes for referral links and gift cards
@@ -52,18 +53,26 @@ export class QRService {
    * const dataUrl = await qrService.generateQRDataUrl('MLM-ABCD-1234');
    */
   async generateQRDataUrl(referralCode: string): Promise<string> {
-    const link = this.getReferralLink(referralCode);
+    try {
+      const link = this.getReferralLink(referralCode);
 
-    return QRCode.toDataURL(link, {
-      errorCorrectionLevel: 'H',
-      type: 'image/png',
-      margin: 2,
-      width: 300,
-      color: {
-        dark: '#000000',
-        light: '#ffffff',
-      },
-    });
+      return await QRCode.toDataURL(link, {
+        errorCorrectionLevel: 'H',
+        type: 'image/png',
+        margin: 2,
+        width: 300,
+        color: {
+          dark: '#000000',
+          light: '#ffffff',
+        },
+      });
+    } catch (error) {
+      logger.error(
+        { service: 'QRService', method: 'generateQRDataUrl', error },
+        'Operation failed'
+      );
+      throw error;
+    }
   }
 
   /**
@@ -81,18 +90,23 @@ export class QRService {
    * const buffer = await qrService.generateQRBuffer('MLM-ABCD-1234');
    */
   async generateQRBuffer(referralCode: string): Promise<Buffer> {
-    const link = this.getReferralLink(referralCode);
+    try {
+      const link = this.getReferralLink(referralCode);
 
-    return QRCode.toBuffer(link, {
-      errorCorrectionLevel: 'H',
-      type: 'png',
-      margin: 2,
-      width: 300,
-      color: {
-        dark: '#000000',
-        light: '#ffffff',
-      },
-    });
+      return await QRCode.toBuffer(link, {
+        errorCorrectionLevel: 'H',
+        type: 'png',
+        margin: 2,
+        width: 300,
+        color: {
+          dark: '#000000',
+          light: '#ffffff',
+        },
+      });
+    } catch (error) {
+      logger.error({ service: 'QRService', method: 'generateQRBuffer', error }, 'Operation failed');
+      throw error;
+    }
   }
 
   /**
@@ -109,14 +123,19 @@ export class QRService {
    * await qrService.generateQRFile('MLM-ABCD-1234', './qrcodes/qr-usuario.png');
    */
   async generateQRFile(referralCode: string, filePath: string): Promise<void> {
-    const link = this.getReferralLink(referralCode);
+    try {
+      const link = this.getReferralLink(referralCode);
 
-    await QRCode.toFile(filePath, link, {
-      errorCorrectionLevel: 'H',
-      type: 'png',
-      margin: 2,
-      width: 300,
-    });
+      await QRCode.toFile(filePath, link, {
+        errorCorrectionLevel: 'H',
+        type: 'png',
+        margin: 2,
+        width: 300,
+      });
+    } catch (error) {
+      logger.error({ service: 'QRService', method: 'generateQRFile', error }, 'Operation failed');
+      throw error;
+    }
   }
 
   // ============================================
@@ -138,18 +157,26 @@ export class QRService {
    * const dataUrl = await qrService.generateGiftCardQR('abc123xyz');
    */
   async generateGiftCardQR(shortCode: string): Promise<string> {
-    const qrUrl = `${this.baseUrl}/q/${shortCode}`;
+    try {
+      const qrUrl = `${this.baseUrl}/q/${shortCode}`;
 
-    return QRCode.toDataURL(qrUrl, {
-      errorCorrectionLevel: 'H',
-      type: 'image/png',
-      margin: 2,
-      width: 300,
-      color: {
-        dark: '#000000',
-        light: '#ffffff',
-      },
-    });
+      return await QRCode.toDataURL(qrUrl, {
+        errorCorrectionLevel: 'H',
+        type: 'image/png',
+        margin: 2,
+        width: 300,
+        color: {
+          dark: '#000000',
+          light: '#ffffff',
+        },
+      });
+    } catch (error) {
+      logger.error(
+        { service: 'QRService', method: 'generateGiftCardQR', error },
+        'Operation failed'
+      );
+      throw error;
+    }
   }
 
   /**
@@ -167,19 +194,24 @@ export class QRService {
    * const giftCardId = await qrService.resolveShortCode('abc123xyz');
    */
   async resolveShortCode(shortCode: string): Promise<string | null> {
-    const mapping = await QrMapping.findOne({ where: { shortCode } });
+    try {
+      const mapping = await QrMapping.findOne({ where: { shortCode } });
 
-    if (!mapping) {
-      return null;
+      if (!mapping) {
+        return null;
+      }
+
+      // Increment scan count and update last scanned timestamp
+      await mapping.update({
+        scanCount: mapping.scanCount + 1,
+        lastScannedAt: new Date(),
+      });
+
+      return mapping.giftCardId;
+    } catch (error) {
+      logger.error({ service: 'QRService', method: 'resolveShortCode', error }, 'Operation failed');
+      throw error;
     }
-
-    // Increment scan count and update last scanned timestamp
-    await mapping.update({
-      scanCount: mapping.scanCount + 1,
-      lastScannedAt: new Date(),
-    });
-
-    return mapping.giftCardId;
   }
 }
 

--- a/backend/src/services/R2Service.ts
+++ b/backend/src/services/R2Service.ts
@@ -20,6 +20,7 @@ import { PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { randomUUID } from 'crypto';
 import sharp from 'sharp';
 import { r2Client, R2_BUCKET, R2_PUBLIC_URL } from '../config/r2';
+import { logger } from '../utils/logger';
 
 // ============================================
 // TYPES
@@ -87,29 +88,34 @@ export class R2Service {
    * // returns 'https://media.<PLATFORM_DOMAIN>/properties/prop-uuid/550e8400.webp'
    */
   async uploadImage(params: UploadImageParams): Promise<string> {
-    const { buffer, entityType, entityId } = params;
+    try {
+      const { buffer, entityType, entityId } = params;
 
-    // Resize to max 1920px, convert to webp quality 85
-    // Redimensionar a máx 1920px, convertir a webp calidad 85
-    const processedBuffer = await sharp(buffer)
-      .resize({ width: 1920, withoutEnlargement: true })
-      .webp({ quality: 85 })
-      .toBuffer();
+      // Resize to max 1920px, convert to webp quality 85
+      // Redimensionar a máx 1920px, convertir a webp calidad 85
+      const processedBuffer = await sharp(buffer)
+        .resize({ width: 1920, withoutEnlargement: true })
+        .webp({ quality: 85 })
+        .toBuffer();
 
-    // Generate unique storage key: {entityType}/{entityId}/{uuid}.webp
-    // Generar clave única de almacenamiento: {entityType}/{entityId}/{uuid}.webp
-    const key = `${entityType}/${entityId}/${randomUUID()}.webp`;
+      // Generate unique storage key: {entityType}/{entityId}/{uuid}.webp
+      // Generar clave única de almacenamiento: {entityType}/{entityId}/{uuid}.webp
+      const key = `${entityType}/${entityId}/${randomUUID()}.webp`;
 
-    await r2Client.send(
-      new PutObjectCommand({
-        Bucket: R2_BUCKET,
-        Key: key,
-        Body: processedBuffer,
-        ContentType: 'image/webp',
-      })
-    );
+      await r2Client.send(
+        new PutObjectCommand({
+          Bucket: R2_BUCKET,
+          Key: key,
+          Body: processedBuffer,
+          ContentType: 'image/webp',
+        })
+      );
 
-    return `${R2_PUBLIC_URL}/${key}`;
+      return `${R2_PUBLIC_URL}/${key}`;
+    } catch (error) {
+      logger.error({ service: 'R2Service', method: 'uploadImage', error }, 'Operation failed');
+      throw error;
+    }
   }
 
   /**
@@ -126,16 +132,21 @@ export class R2Service {
    * await r2Service.deleteImage('https://media.<PLATFORM_DOMAIN>/properties/uuid/550e8400.webp');
    */
   async deleteImage(imageUrl: string): Promise<void> {
-    // Extract key by removing the base URL prefix
-    // Extraer la clave eliminando el prefijo de la URL base
-    const key = imageUrl.replace(`${R2_PUBLIC_URL}/`, '');
+    try {
+      // Extract key by removing the base URL prefix
+      // Extraer la clave eliminando el prefijo de la URL base
+      const key = imageUrl.replace(`${R2_PUBLIC_URL}/`, '');
 
-    await r2Client.send(
-      new DeleteObjectCommand({
-        Bucket: R2_BUCKET,
-        Key: key,
-      })
-    );
+      await r2Client.send(
+        new DeleteObjectCommand({
+          Bucket: R2_BUCKET,
+          Key: key,
+        })
+      );
+    } catch (error) {
+      logger.error({ service: 'R2Service', method: 'deleteImage', error }, 'Operation failed');
+      throw error;
+    }
   }
 
   /**
@@ -157,20 +168,25 @@ export class R2Service {
    * // returns ['https://media.<PLATFORM_DOMAIN>/properties/uuid/a.webp', ...]
    */
   async uploadImages(params: UploadImagesParams): Promise<string[]> {
-    const { files, entityType, entityId } = params;
-    const urls: string[] = [];
+    try {
+      const { files, entityType, entityId } = params;
+      const urls: string[] = [];
 
-    for (const file of files) {
-      const url = await this.uploadImage({
-        buffer: file.buffer,
-        mimetype: file.mimetype as 'image/jpeg' | 'image/png' | 'image/webp',
-        entityType,
-        entityId,
-        filename: file.originalname,
-      });
-      urls.push(url);
+      for (const file of files) {
+        const url = await this.uploadImage({
+          buffer: file.buffer,
+          mimetype: file.mimetype as 'image/jpeg' | 'image/png' | 'image/webp',
+          entityType,
+          entityId,
+          filename: file.originalname,
+        });
+        urls.push(url);
+      }
+
+      return urls;
+    } catch (error) {
+      logger.error({ service: 'R2Service', method: 'uploadImages', error }, 'Operation failed');
+      throw error;
     }
-
-    return urls;
   }
 }


### PR DESCRIPTION
Closes #230

## Summary
- Add try/catch with Pino logger.error to all async methods in R2Service (3), QRService (5), MercadoPagoService (5)
- Critical fix: added await to return statements in QRService to ensure promise rejections are caught
- New error path tests for R2Service and QRService

## Why
These services had zero try/catch, causing unhandled exceptions to leak stack traces in production.

## Changes
| File | Change |
|------|--------|
| backend/src/services/R2Service.ts | +3 try/catch blocks |
| backend/src/services/QRService.ts | +5 try/catch + return await fix |
| backend/src/services/MercadoPagoService.ts | +import logger + 5 try/catch |
| backend/src/__tests__/R2Service.test.ts | New: error path tests |
| backend/src/__tests__/unit/QRService.test.ts | +5 error handling tests |

## Test Plan
- [x] All 877 tests pass, 0 failures
- [x] New error path tests verify logging and rethrowing
- [x] try/catch coverage verified: R2Service=3, QRService=5, MercadoPagoService=5