### PR TITLE
docs: sync PROJECT_STATE, ROADMAP, PRD to current state

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -4,7 +4,7 @@
 
 **Version**: 3.2.0  
 **Status**: ✅ v3.2.0 Released  
-**Last Updated**: 2026-06-25  
+**Last Updated**: 2026-07-17  
 **Document Owner**: Nexo Real Development Team  
 **Tagline**: _"Conectamos tu negocio con el mundo."_
 
@@ -335,7 +335,7 @@ ORM:        Sequelize 6
 Email:      Brevo (SMTP + API)
 SMS:        Brevo SMS
 Payments:   PayPal SDK + MercadoPago SDK
-Testing:    Jest (90+ suites) + Bot Vitest (62 tests)
+Testing:    Jest (66 suites / 887 tests) + Bot Vitest (18 files / 115 tests)
 ```
 
 ## Frontend
@@ -527,6 +527,7 @@ PATCH  /api/admin/vendors/:id/commission-rate
 
 | Version | Date       | Author         | Changes                                                                                                                                                                                                                                                                          |
 | ------- | ---------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.3.0   | 2026-07-17 | Nexo Real Team | Sprint 9 completion: error handling fix (R2Service, QRService, MercadoPagoService try/catch), bot CI/CD (GitHub Actions ci-bot.yml), MercadoPagoService test coverage, ROADMAP corrections. 887+115 tests, PRs #231-234.                                                         |
 | 3.2.0   | 2026-06-25 | Nexo Real Team | Sprint 12-13: Order History, Frontend API modularization, CRM refactoring (7 sub-componentes), Test Coverage 89%, CI/CD fixes, E2E fixes, security deps. Total ~1,600 tests.                                                                                                     |
 | 3.0.0   | 2026-04-13 | Nexo Real Team | Sprint 10: Payment webhooks, Invoices, Commission model migration, 2FA frontend, admin CRUD, UX Polish, Feature Guard. 154 files changed, ~12,110 insertions. v3.0.0 released.                                                                                                   |
 | 2.4.0   | 2026-04-10 | Nexo Real Team | Sprint 8 RBAC completo: 9 roles (super_admin, admin, finance, sales, advisor, vendor, user, guest, bot), endpoints register/guest y updateUserRole. Seed Nexo Real colombiano (Unilevel). Tests ~1,236.                                                                          |
@@ -553,16 +554,16 @@ _Nexo Real — "Conectamos tu negocio con el mundo."_
 
 ## Sprint Status
 
-| Sprint     | Versión | Descripción                                                                                                                         | Estado        | Fecha      |
-| ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------- | ---------- |
-| Sprint 1-3 | v1.11.0 | Auth, MLM, CRM, E-commerce, Security, Marketplace                                                                                   | ✅ Completado | 2026-04-04 |
-| Sprint 4   | v2.0.0  | Nexo Bot WhatsApp, n8n Automation, Gamificación                                                                                     | ✅ Completado | 2026-04-06 |
-| Sprint 5   | v2.1.0  | Real Estate Frontend, Tourism Frontend, Reservation Wizard                                                                          | ✅ Completado | 2026-04-07 |
-| Sprint 6   | v2.2.0  | Admin Dashboard CRUD, Nexo Bot Flows (properties+tours), SEO Frontend, Build Hardening, i18n cleanup, CodeQL fixes                  | ✅ Completado | 2026-04-07 |
-| Sprint 7   | v2.3.5  | UI/UX Rebranding completo (landing Nexo Real, auth skin, AppLayout), Vitest 90%+ coverage, E2E Playwright, PWA                      | ✅ Completado | 2026-04-09 |
-| Sprint 8   | v2.4.0  | Bot Production-Ready, RBAC 9 roles, PostgreSQL adapter, Docker Hub, n8n workflows, seed Nexo Real                                   | ✅ Completado | 2026-04-10 |
-| Sprint 9   | v2.6.1  | Technical Debt — Pino logger, eliminate `any` types, bot Vitest (62 tests), PLATFORM_DOMAIN, controller tests (667), pitch deck     | ✅ Completado | 2026-04-12 |
-| Sprint 10  | v3.0.0  | Stabilization — Payment webhooks, invoices DB migration, disable crypto wallet, admin CRUD, 2FA testing, commission model migration | ✅ Completado | 2026-04-13 |
-| Sprint 11  | v3.0.1  | Quick Wins — Push notification tests habilitados, centralized logger fix                                                            | ✅ Completado | 2026-06-16 |
-| Sprint 12  | v3.1.0  | CRM Refactoring + Security Hardening — 7 sub-componentes, 50 vulns resueltas                                                        | ✅ Completado | 2026-06-17 |
-| Sprint 13  | v3.2.0  | Order History, Frontend API Modularization, Test Coverage Expansion, CI/CD Fixes, E2E Fixes                                         | ✅ Completado | 2026-06-25 |
+| Sprint     | Versión | Descripción                                                                                                                                                         | Estado        | Fecha      |
+| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ---------- |
+| Sprint 1-3 | v1.11.0 | Auth, MLM, CRM, E-commerce, Security, Marketplace                                                                                                                   | ✅ Completado | 2026-04-04 |
+| Sprint 4   | v2.0.0  | Nexo Bot WhatsApp, n8n Automation, Gamificación                                                                                                                     | ✅ Completado | 2026-04-06 |
+| Sprint 5   | v2.1.0  | Real Estate Frontend, Tourism Frontend, Reservation Wizard                                                                                                          | ✅ Completado | 2026-04-07 |
+| Sprint 6   | v2.2.0  | Admin Dashboard CRUD, Nexo Bot Flows (properties+tours), SEO Frontend, Build Hardening, i18n cleanup, CodeQL fixes                                                  | ✅ Completado | 2026-04-07 |
+| Sprint 7   | v2.3.5  | UI/UX Rebranding completo (landing Nexo Real, auth skin, AppLayout), Vitest 90%+ coverage, E2E Playwright, PWA                                                      | ✅ Completado | 2026-04-09 |
+| Sprint 8   | v2.4.0  | Bot Production-Ready, RBAC 9 roles, PostgreSQL adapter, Docker Hub, n8n workflows, seed Nexo Real                                                                   | ✅ Completado | 2026-04-10 |
+| Sprint 9   | v2.6.1  | Technical Debt — Pino logger, eliminate `any` types, bot Vitest (115 tests), PLATFORM_DOMAIN, controller tests (887), error handling (R2/QR/MercadoPago), bot CI/CD | ✅ Completado | 2026-04-12 |
+| Sprint 10  | v3.0.0  | Stabilization — Payment webhooks, invoices DB migration, disable crypto wallet, admin CRUD, 2FA testing, commission model migration                                 | ✅ Completado | 2026-04-13 |
+| Sprint 11  | v3.0.1  | Quick Wins — Push notification tests habilitados, centralized logger fix                                                                                            | ✅ Completado | 2026-06-16 |
+| Sprint 12  | v3.1.0  | CRM Refactoring + Security Hardening — 7 sub-componentes, 50 vulns resueltas                                                                                        | ✅ Completado | 2026-06-17 |
+| Sprint 13  | v3.2.0  | Order History, Frontend API Modularization, Test Coverage Expansion, CI/CD Fixes, E2E Fixes                                                                         | ✅ Completado | 2026-06-25 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,7 @@
 > _"Conectamos tu negocio con el mundo."_
 
 **Versión actual**: v3.2.0 — Sprint 10+ Completado ✅  
-**Última actualización**: 2026-06-25  
+**Última actualización**: 2026-07-17  
 **Estado**: Activo - Producción  
 **Meta**: v3.3.0 — próxima expansión
 
@@ -14,50 +14,50 @@
 
 ### ✅ Lo que YA está implementado (v3.2.0)
 
-| Área                     | Funcionalidad                                                                        | Estado |
-| ------------------------ | ------------------------------------------------------------------------------------ | ------ |
-| **Auth**                 | JWT, 2FA, Roles                                                                      | ✅     |
-| **MLM**                  | Unilevel con Closure Table                                                           | ✅     |
-| **Comisiones**           | 5 niveles configurables                                                              | ✅     |
-| **E-commerce**           | Productos streaming (MVP ejemplo)                                                    | ✅     |
-| **Wallet**               | Balance, transacciones, retiros                                                      | ✅     |
-| **CRM**                  | Leads, Tasks, Communications                                                         | ✅     |
-| **Notificaciones**       | Email (Brevo), Push (Web)                                                            | ✅     |
-| **PWA**                  | Offline, instalable, shortcuts                                                       | ✅     |
-| **Landing Pages**        | Productos con SEO                                                                    | ✅     |
-| **Dashboard**            | Stats, tree view, perfil                                                             | ✅     |
-| **i18n**                 | Español + Inglés (sin claves huérfanas)                                              | ✅     |
-| **Pagos**                | PayPal + MercadoPago                                                                 | ✅     |
-| **Gamificación**         | Leaderboards + Achievements                                                          | ✅     |
-| **Gift Cards**           | CRUD, redeem, balance, admin                                                         | ✅     |
-| **Cart Recovery**        | Persistence, tokens, emails                                                          | ✅     |
-| **Email Auto**           | Templates, campaigns, scheduling                                                     | ✅     |
-| **Security**             | SSRF, XSS, pino-http, Docker hardening, CodeQL fixes                                 | ✅     |
-| **Products**             | Generic products + inventory + categories                                            | ✅     |
-| **Marketplace**          | Multi-vendor, commission split 3-way                                                 | ✅     |
-| **Delivery**             | Shipping addresses, providers, tracking                                              | ✅     |
-| **Contracts**            | Affiliate contracts MVP con hash/IP                                                  | ✅     |
-| **Real Estate Frontend** | PropertiesPage, PropertyDetailPage, filtros, galería                                 | ✅     |
-| **Tourism Frontend**     | ToursPage, TourDetailPage, itinerario, disponibilidad                                | ✅     |
-| **Reservation Wizard**   | Wizard 3 pasos + MisReservasPage + reservationStore                                  | ✅     |
-| **Admin Dashboard CRUD** | AdminPropertiesPage + AdminToursPage + AdminReservationsPage                         | ✅     |
-| **Nexo Bot Flows**       | propertiesFlow + toursFlow (ES/EN, limit 5)                                          | ✅     |
-| **network_balance**      | Migración `binary_balance` → `network_balance`                                       | ✅     |
-| **Build Hardening**      | Sin `.map` en producción, logs de tamaño                                             | ✅     |
-| **SEO Frontend**         | Helmet dinámico + OG tags + JSON-LD (Property + Tour) + social proof badges          | ✅     |
-| **Tests**                | Backend: 49 suites, 667 tests (Jest) · Bot: 8 files, 62 tests (Vitest) · Total: ~729 | ✅     |
-| **RBAC 9 Roles**         | super_admin, admin, finance, sales, advisor, vendor, user, guest, bot                | ✅     |
-| **Register Guest**       | `POST /api/auth/register/guest` — registro público sin sponsor                       | ✅     |
-| **Update User Role**     | `PATCH /api/admin/users/:id/role` — solo super_admin/admin                           | ✅     |
-| **Seed Nexo Real**       | Datos colombianos (Medellín, Bogotá, Cartagena), árbol Unilevel completo             | ✅     |
-| **Payment Webhooks**     | WebhookEvent model + MercadoPago + PayPal webhook handlers                           | ✅     |
-| **Invoice System**       | Invoice model + InvoiceService + PDF generation + CRUD routes                        | ✅     |
-| **Commission Unilevel**  | Migración Binary→Unilevel, 10 niveles configurables, Closure Table                   | ✅     |
-| **n8n CRM Integration**  | WorkflowService + WorkflowExecution + N8nWebhookController + Automation routes       | ✅     |
-| **2FA Frontend**         | TwoFactorLoginPage + twoFactorService + códigos de recuperación                      | ✅     |
-| **UX Polish**            | EmptyState 6 tipos + Skeleton loaders + Mobile responsive + Sonner toast             | ✅     |
-| **Feature Guard**        | Middleware para feature flags (FEATURE_CRYPTO_ENABLED=false por defecto)             | ✅     |
-| **Tests**                | Backend: 65+ suites, 600+ tests · Frontend: 35+ suites, 600+ tests · Total: 1,200+   | ✅     |
+| Área                     | Funcionalidad                                                                                            | Estado |
+| ------------------------ | -------------------------------------------------------------------------------------------------------- | ------ |
+| **Auth**                 | JWT, 2FA, Roles                                                                                          | ✅     |
+| **MLM**                  | Unilevel con Closure Table                                                                               | ✅     |
+| **Comisiones**           | 5 niveles configurables                                                                                  | ✅     |
+| **E-commerce**           | Productos streaming (MVP ejemplo)                                                                        | ✅     |
+| **Wallet**               | Balance, transacciones, retiros                                                                          | ✅     |
+| **CRM**                  | Leads, Tasks, Communications                                                                             | ✅     |
+| **Notificaciones**       | Email (Brevo), Push (Web)                                                                                | ✅     |
+| **PWA**                  | Offline, instalable, shortcuts                                                                           | ✅     |
+| **Landing Pages**        | Productos con SEO                                                                                        | ✅     |
+| **Dashboard**            | Stats, tree view, perfil                                                                                 | ✅     |
+| **i18n**                 | Español + Inglés (sin claves huérfanas)                                                                  | ✅     |
+| **Pagos**                | PayPal + MercadoPago                                                                                     | ✅     |
+| **Gamificación**         | Leaderboards + Achievements                                                                              | ✅     |
+| **Gift Cards**           | CRUD, redeem, balance, admin                                                                             | ✅     |
+| **Cart Recovery**        | Persistence, tokens, emails                                                                              | ✅     |
+| **Email Auto**           | Templates, campaigns, scheduling                                                                         | ✅     |
+| **Security**             | SSRF, XSS, pino-http, Docker hardening, CodeQL fixes                                                     | ✅     |
+| **Products**             | Generic products + inventory + categories                                                                | ✅     |
+| **Marketplace**          | Multi-vendor, commission split 3-way                                                                     | ✅     |
+| **Delivery**             | Shipping addresses, providers, tracking                                                                  | ✅     |
+| **Contracts**            | Affiliate contracts MVP con hash/IP                                                                      | ✅     |
+| **Real Estate Frontend** | PropertiesPage, PropertyDetailPage, filtros, galería                                                     | ✅     |
+| **Tourism Frontend**     | ToursPage, TourDetailPage, itinerario, disponibilidad                                                    | ✅     |
+| **Reservation Wizard**   | Wizard 3 pasos + MisReservasPage + reservationStore                                                      | ✅     |
+| **Admin Dashboard CRUD** | AdminPropertiesPage + AdminToursPage + AdminReservationsPage                                             | ✅     |
+| **Nexo Bot Flows**       | propertiesFlow + toursFlow (ES/EN, limit 5)                                                              | ✅     |
+| **network_balance**      | Migración `binary_balance` → `network_balance`                                                           | ✅     |
+| **Build Hardening**      | Sin `.map` en producción, logs de tamaño                                                                 | ✅     |
+| **SEO Frontend**         | Helmet dinámico + OG tags + JSON-LD (Property + Tour) + social proof badges                              | ✅     |
+| **Tests**                | Backend: 66 suites, 887 tests (Jest) · Bot: 18 files, 115 tests (Vitest) · Total: ~1,002                 | ✅     |
+| **RBAC 9 Roles**         | super_admin, admin, finance, sales, advisor, vendor, user, guest, bot                                    | ✅     |
+| **Register Guest**       | `POST /api/auth/register/guest` — registro público sin sponsor                                           | ✅     |
+| **Update User Role**     | `PATCH /api/admin/users/:id/role` — solo super_admin/admin                                               | ✅     |
+| **Seed Nexo Real**       | Datos colombianos (Medellín, Bogotá, Cartagena), árbol Unilevel completo                                 | ✅     |
+| **Payment Webhooks**     | WebhookEvent model + MercadoPago + PayPal webhook handlers                                               | ✅     |
+| **Invoice System**       | Invoice model + InvoiceService + PDF generation + CRUD routes                                            | ✅     |
+| **Commission Unilevel**  | Migración Binary→Unilevel, 10 niveles configurables, Closure Table                                       | ✅     |
+| **n8n CRM Integration**  | WorkflowService + WorkflowExecution + N8nWebhookController + Automation routes                           | ✅     |
+| **2FA Frontend**         | TwoFactorLoginPage + twoFactorService + códigos de recuperación                                          | ✅     |
+| **UX Polish**            | EmptyState 6 tipos + Skeleton loaders + Mobile responsive + Sonner toast                                 | ✅     |
+| **Feature Guard**        | Middleware para feature flags (FEATURE_CRYPTO_ENABLED=false por defecto)                                 | ✅     |
+| **Tests**                | Backend: 66 suites, 887 tests · Frontend: 34 files, 446 tests · Bot: 18 files, 115 tests · Total: ~1,448 | ✅     |
 
 ---
 
@@ -527,13 +527,19 @@ Issue #132 [S9/9.7] — Controller Test Coverage Expansion:
 Issue #150 — Documentation Update:
   ✅ All project documentation updated to reflect Sprint 9 completion
 
-⚠️ Known gap: R2Service, QRService, MercadoPagoService lack try/catch error handling
-   → Tracked in separate change: fix-service-error-handling
+✅ Error handling resolved: R2Service, QRService, MercadoPagoService — PR #232
+
+PRs additions (Sprint 9 late cycle):
+  PR #231: docs/update-sprint9-roadmap
+  PR #232: fix/service-error-handling (R2Service, QRService, MercadoPagoService)
+  PR #233: test/mercadopago-service-coverage
+  PR #234: ci/bot-github-actions (GitHub Actions workflow for bot tests)
+  Issue #218: Bot CI/CD — CLOSED
 
 Tests (post-Sprint 9):
-  Backend: 49 suites / 667 tests (Jest) ✅
+  Backend: 66 suites / 887 tests (Jest) ✅
   Bot: 18 files / 115 tests (Vitest) ✅
-  Total platform: ~782 backend+bot tests
+  Total platform: ~1,002 backend+bot tests
 ```
 
 #### Sprint 10 — v3.2.0 — Stabilization & Commission Migration ✅
@@ -589,7 +595,7 @@ Email: Brevo (SMTP + API)
 SMS: Brevo SMS
 Pagos: PayPal + MercadoPago
 Delivery: Providers via webhooks
-Testing: Jest (49 suites / 667 tests) + Bot Vitest (8 files / 62 tests)
+Testing: Jest (66 suites / 887 tests) + Bot Vitest (18 files / 115 tests)
 ```
 
 ### Frontend Stack
@@ -647,6 +653,6 @@ sprint:9             - Sprint 9 — v2.5.0 → v2.6.1
 
 ---
 
-**Última actualización**: 2026-06-25  
+**Última actualización**: 2026-07-17  
 **Proyecto**: https://github.com/users/ipproyectosysoluciones/projects/4  
 **Producto**: Nexo Real — _"Conectamos tu negocio con el mundo."_

--- a/openspec/PROJECT_STATE.md
+++ b/openspec/PROJECT_STATE.md
@@ -1,20 +1,20 @@
 # Nexo Real — Estado del Proyecto
 
-> **Archivo de referencia rápida para nuevas sesiones.** Refleja el estado real al 2026-04-11.
+> **Archivo de referencia rápida para nuevas sesiones.** Refleja el estado real al 2026-07-17.
 
 ---
 
-## Versión actual: v2.4.0
+## Versión actual: v3.2.0
 
 | Campo | Valor |
 |-------|-------|
-| Versión | **v2.4.0** (Sprint 8 — Bot production-ready) |
-| Branch main | `main` — producción (synced 2026-04-10) |
+| Versión | **v3.2.0** (Sprint 13 — Order History + Frontend API Modularization + Test Coverage) |
+| Branch main | `main` — producción (synced 2026-06-25) |
 | Branch activo | `development` |
-| Sprint completado | Sprint 8 — Bot Completo + n8n Workflows |
-| Próximo sprint | **Sprint 9** — Planeado |
+| Sprint completado | Sprint 13 — Order History, CRM Refactoring, Test Coverage Expansion |
+| Próximo sprint | **Sprint 14** — Planeado |
 | Repositorio | `ipproyectosysoluciones/mlm-platform` |
-| Root local | `/media/bladimir/Datos1/Datos/MLM` |
+| Root local | `/media/bladimir/Datos2/Datos/MLM` |
 
 ---
 
@@ -25,20 +25,21 @@
 | Backend | ✅ Activo | `api.nexoreal.xyz` (Cloudflare Tunnel) |
 | Frontend | ✅ Activo | `nexoreal.xyz` + `www.nexoreal.xyz` (Vercel) |
 | Bot WhatsApp | ✅ Activo | Puerto 3002 (local) |
+| Bot CI/CD | ✅ GitHub Actions | `ci-bot.yml` — Vitest en PRs |
 | n8n | 🔧 Docker local | Pendiente migrar a cloud |
 | DB | ✅ PostgreSQL | `DB_NAME=mlm_platform` (nombre legacy, **NO cambiar**) |
 
 ---
 
-## Tests al cierre v2.4.0
+## Tests al cierre v3.2.0
 
 | Suite | Tests | Estado |
 |-------|-------|--------|
-| Backend (Jest) | 528 (39 suites) | ✅ 527 passed, 1 skipped |
+| Backend (Jest) | 887 (66 suites) | ✅ 886 passed, 1 skipped |
 | Frontend Unit (Vitest) | ~446 (34 files) | ✅ Pasan |
 | E2E (Playwright) | ~262 (22 specs) | ✅ Pasan |
-| Bot | 0 | ⚠️ Sin tests |
-| **Total** | **~1,236** | ✅ |
+| Bot (Vitest) | 115 (18 files) | ✅ Pasan |
+| **Total** | **~1,298** | ✅ |
 
 **Histórico v2.3.5**: Backend 535 / Frontend 432 / Total 967
 
@@ -50,7 +51,8 @@
 
 | PR | Branch | Target | Estado |
 |----|--------|--------|--------|
-| #105 | `feature/sprint7-testing` | `development` | ⚠️ **OPEN — pendiente merge manual** |
+
+*(Ninguno pendiente)*
 
 ---
 
@@ -69,6 +71,40 @@
 
 **Additional PRs (scope expansion)**: #112, #117–#125 (env examples, bug fixes, RBAC, seed, docs, Docker)
 **Total PRs merged**: 19 (#107–#125)
+
+---
+
+## Sprint 9 — Estado COMPLETADO ✅
+
+**Change**: `sprint9-tech-debt` | **Status**: ARCHIVED
+**Completed**: 2026-04-12
+
+| # | Issue | Descripción | PR |
+|---|-------|-------------|-----|
+| 1 | #126 | Mount 6 orphaned routes + relocate commission-config | #133 |
+| 2 | #127 | JWT/2FA fail-fast on missing secrets | #134 |
+| 3 | #128 | Pino Logger Migration (Winston → Pino) | #145 |
+| 4 | #129 | PLATFORM_DOMAIN env var (remove hardcoded) | #148 |
+| 5 | #130 | Eliminate all explicit `any` types (39 files) | #146 |
+| 6 | #131 | Bot Vitest Test Infrastructure (18 files, 115 tests) | #227–#229 |
+| 7 | #132 | Controller Test Coverage Expansion (9 new test files) | #149 |
+| 8 | #218 | Bot CI/CD GitHub Actions (`ci-bot.yml`) | #234 |
+| 9 | — | fix-service-error-handling: R2Service, QRService, MercadoPagoService try/catch | #232 |
+| 10 | — | docs: Sprint 9 roadmap corrections | #231 |
+| 11 | — | MercadoPagoService test coverage | #233 |
+
+**Total PRs merged**: 12 (#133, #134, #145, #146, #148, #149, #227–#229, #231–#234)
+
+---
+
+## Sprints 10–13 — Estado COMPLETADO ✅
+
+| Sprint | Versión | Foco principal | Fecha |
+|--------|---------|---------------|-------|
+| Sprint 10 | v3.0.0 | Payment webhooks, Invoices DB, Commission Unilevel, 2FA frontend, Admin CRUD, UX Polish, n8n CRM | 2026-04-13 |
+| Sprint 11 | v3.0.1 | Push notification tests habilitados, centralized logger fix | 2026-06-16 |
+| Sprint 12 | v3.1.0 | CRM Refactoring (7 sub-componentes), Security Hardening (50 vulns resueltas) | 2026-06-17 |
+| Sprint 13 | v3.2.0 | Order History, Frontend API Modularization, Test Coverage Expansion, CI/CD Fixes, E2E Fixes | 2026-06-25 |
 
 ---
 
@@ -118,20 +154,19 @@ Login:  admin@mlm.com / admin123
 |-------|-------|
 | Artifact store | `engram` (proyecto: `bladimir`) |
 | Sprint 8 change | `sprint8-bot-complete` — ✅ ARCHIVED (archive report: obs #711) |
+| Sprint 9 change | `sprint9-tech-debt` — ✅ ARCHIVED |
+| Sprint 9 fix | `fix-service-error-handling` — ✅ ARCHIVED |
+| Sprint 10 change | `sprint10-stabilization` — ✅ ARCHIVED |
 | Archived to | `openspec/changes/archive/2026-04-11-sprint8-bot-complete/` |
-| Next sprint | Sprint 9 — planeado (SDD contexto a actualizar) |
-| sdd-init | Reejecutar si se inicia Sprint 9 |
+| Next sprint | Sprint 14 — planeado (SDD contexto a actualizar) |
+| sdd-init | Reejecutar si se inicia Sprint 14 |
 
 ---
 
 ## Deuda técnica conocida
 
-1. PR #105 pendiente merge (`feature/sprint7-testing` → `development`)
-2. Coverage real no medida — puede no llegar al 90% gate
-3. `api/services/api.ts` — 7.56% coverage (difícil de cubrir, bajo en prioritario)
-4. `components/tree/*` — 0.92% (legacy MLM, excluir de coverage)
-5. `pages/Profile.tsx` — 21.66% coverage
+*(Sin items críticos pendientes)*
 
 ---
 
-*Actualizado: 2026-04-11 | Post-auditoría v2.4.0*
+*Actualizado: 2026-07-17 | Post-auditoría v3.2.0*


### PR DESCRIPTION
## What
Synchronize 3 stale documentation files with current project state (v3.2.0+, 1002+ tests, Sprint 13 complete).

## Changes
- **PROJECT_STATE.md**: v2.4.0 → v3.2.0, Sprints 9-13 added, 887+115 tests, root path fixed, PR #105 removed, deuda técnica cleared
- **ROADMAP.md**: Test counts → 887+115, error handling gap resolved (was ⚠️), PRs #231-234 added, architecture section updated
- **PRD.md**: Tech stack → 66 suites/887 tests + 18 files/115 bot tests, Sprint 9 description updated with error handling + bot CI/CD, v3.3.0 history entry

## Closes
No specific issue — proactive documentation sync.

## Verification
All 3 files reviewed against actual repo state (git log, test runs).