### PR TITLE
ci: optimize backend CI — pnpm cache + path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,30 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'frontend/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/ci.yml'
+
   backend:
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.backend == 'true'
     services:
       postgres:
         image: postgres:16-alpine
@@ -31,7 +53,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '24' }
+        with:
+          node-version: '24'
+          cache: 'pnpm'
       - run: corepack enable && corepack prepare pnpm@latest --activate
 
       - name: Install dependencies
@@ -78,10 +102,14 @@ jobs:
 
   frontend:
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '24' }
+        with:
+          node-version: '24'
+          cache: 'pnpm'
       - run: corepack enable && corepack prepare pnpm@latest --activate
 
       - name: Install dependencies
@@ -106,11 +134,13 @@ jobs:
   playwright:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/development'
-    needs: [frontend]
+    needs: [frontend, changes]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '24' }
+        with:
+          node-version: '24'
+          cache: 'pnpm'
       - run: corepack enable && corepack prepare pnpm@latest --activate
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'pnpm'
-      - run: corepack enable && corepack prepare pnpm@latest --activate
+      - run: corepack prepare pnpm@latest --activate
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
@@ -106,11 +107,12 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'
     steps:
       - uses: actions/checkout@v4
+      - run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'pnpm'
-      - run: corepack enable && corepack prepare pnpm@latest --activate
+      - run: corepack prepare pnpm@latest --activate
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
@@ -137,11 +139,12 @@ jobs:
     needs: [frontend, changes]
     steps:
       - uses: actions/checkout@v4
+      - run: corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'pnpm'
-      - run: corepack enable && corepack prepare pnpm@latest --activate
+      - run: corepack prepare pnpm@latest --activate
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile


### PR DESCRIPTION
## Summary

Optimizes CI pipeline to reduce wait times. Backend CI currently takes ~8m55s per PR.

## Changes

### 1. pnpm dependency cache
Added `cache: 'pnpm'` to `actions/setup-node@v4` in all jobs. GitHub Actions caches the pnpm store between runs, avoiding full reinstalls.

### 2. Path-based job filtering
Added `dorny/paths-filter@v3` detection job that checks which areas changed:
- **backend job**: skips on PRs that only touch `frontend/`
- **frontend job**: skips on PRs that only touch `backend/`
- On push to main/development: always runs all jobs (safety net)

## Expected Impact

| Scenario | Before | After |
|----------|--------|-------|
| Bot-only PR | ~9min backend + ~44s frontend | ~44s (frontend only) |
| Frontend-only PR | ~9min backend + ~44s frontend | ~44s (frontend only) |
| Backend PR | ~9min | ~7min (cached) |
| Mixed PR | ~9min | ~7min (cached) |

Closes #239