### PR TITLE
fix(backend): resolve payment controller type errors (Phase D1)

### DIFF
--- a/backend/src/controllers/PaymentMercadoPagoController.ts
+++ b/backend/src/controllers/PaymentMercadoPagoController.ts
@@ -9,7 +9,7 @@ import { asyncHandler } from '../middleware/asyncHandler.js';
 import { mercadoPagoService } from '../services/MercadoPagoService.js';
 import { ResponseUtil } from '../utils/response.util.js';
 import { config } from '../config/env.js';
-import { logger } from '../utils/logger';
+import { logger } from '../utils/logger.js';
 import { Purchase, Order, Product } from '../models/index.js';
 import { WebhookEvent } from '../models/WebhookEvent.js';
 import { CommissionService } from '../services/CommissionService.js';
@@ -55,12 +55,12 @@ export class PaymentMercadoPagoController {
 
     const preference = await mercadoPagoService.createPreference({
       items: items.map((item: PreferenceItemInput) => ({
-        id: item.id || item.productId,
-        title: item.title || item.name,
+        id: item.id || item.productId || '',
+        title: item.title || item.name || '',
         description: item.description || description || 'Nexo Real - Compra',
         quantity: item.quantity || 1,
         currency_id: item.currency_id || 'COP',
-        unit_price: parseFloat(item.unit_price || item.price),
+        unit_price: parseFloat(String(item.unit_price || item.price || '0')),
       })),
       payer: {
         email: userEmail,
@@ -295,7 +295,7 @@ export class PaymentMercadoPagoController {
                   orderNumber,
                   userId,
                   productId,
-                  purchaseId: purchase.id,
+                  purchaseId: purchase.id ?? null,
                   totalAmount: amount,
                   currency,
                   status: 'completed',

--- a/backend/src/controllers/PaymentPayPalController.ts
+++ b/backend/src/controllers/PaymentPayPalController.ts
@@ -4,11 +4,11 @@
  * @module controllers/PaymentPayPalController
  */
 
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { asyncHandler } from '../middleware/asyncHandler.js';
 import { paypalService } from '../services/PayPalService.js';
 import { ResponseUtil } from '../utils/response.util.js';
-import { logger } from '../utils/logger';
+import { logger } from '../utils/logger.js';
 import { Purchase, Order, Product } from '../models/index.js';
 import { CommissionService } from '../services/CommissionService.js';
 import type { AuthenticatedRequest } from '../middleware/auth.middleware.js';
@@ -39,7 +39,7 @@ export class PaymentPayPalController {
       currency,
       description: description || 'Nexo Real - Compra',
       orderId,
-      userId,
+      userId: userId ?? '',
     });
 
     // Find approval URL
@@ -242,7 +242,7 @@ export class PaymentPayPalController {
             orderNumber,
             userId,
             productId,
-            purchaseId: purchase.id,
+            purchaseId: purchase.id ?? null,
             totalAmount: amount,
             currency,
             status: 'completed',

--- a/backend/src/middleware/asyncHandler.ts
+++ b/backend/src/middleware/asyncHandler.ts
@@ -1,7 +1,11 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
 import { logger } from '../utils/logger';
 
-type AsyncRequestHandler = (req: Request, res: Response, next: NextFunction) => Promise<void>;
+type AsyncRequestHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => Promise<void | Response>;
 
 export function asyncHandler(fn: AsyncRequestHandler): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {


### PR DESCRIPTION
## Phase D1 — Payment Controller Types

Resolves ~43 type errors in PaymentPayPalController and PaymentMercadoPagoController.

### Changes
- **asyncHandler.ts**: Widened `AsyncRequestHandler` return type from `Promise<void>` to `Promise<void | Response>` — handlers that return `res.json()` were incorrectly failing type checks
- **PaymentPayPalController.ts**: Added `import { Request }` from Express (was using Fetch API `Request` causing ReadableStream errors on `req.body`, `req.headers`, `req.params`), fixed `userId` null coalesce, fixed `Order.create` purchaseId type
- **PaymentMercadoPagoController.ts**: Added `.js` extension to logger import, fixed item `id`/`title` to string defaults, fixed `parseFloat` type coercion with `String()`

### Verification
- `pnpm build` passes (dist/server.mjs 787kb)
- `pnpm test` passes (66 suites, 888 tests, 0 failures)
- Zero `tsc` errors in both payment controller files

### Branch
`fix/sprint15-phase-d1-payment-types` → `development`

Sprint 15 TypeScript Strict Error Elimination
