### PR TITLE
feat(sprint15): tsc --noEmit CI gate + docs update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Build backend
         run: cd backend && pnpm build
 
+      - name: Type check backend
+        run: cd backend && pnpm tsc --noEmit
+
       - name: Unit tests
         run: cd backend && pnpm test
         env:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,7 @@
 > Hoja de ruta completa para la plataforma **Nexo Real** — Servicios Inmobiliarios, Turismo/Hospitalidad y Afiliaciones.  
 > _"Conectamos tu negocio con el mundo."_
 
-**Versión actual**: v3.2.0 — Sprint 14 Completado ✅  
+**Versión actual**: v3.3.0 — Sprint 15 Completado ✅  
 **Última actualización**: 2026-07-18  
 **Estado**: Activo - Producción  
 **Meta**: v3.3.0 — próxima expansión
@@ -589,6 +589,39 @@ Impact:
   CI total: ~9min → ~6min (33% reduction)
   Integration tests: ~6-7min → ~4min (3 shards parallel)
   Security: 7 secrets extracted from YAML to GitHub Actions secrets
+```
+
+#### Sprint 15 — TypeScript Strict Error Elimination ✅
+
+```
+Branch:    fix/sprint15-*
+Estado:    Completado 2026-07-18
+PRs:       #248–#252
+
+PR #248 — Backend TS Errors Batch 1:
+  ✅ Strict TS errors eliminated: auth, config, middleware modules
+  ✅ Proper type annotations for all route handlers
+
+PR #249 — Backend TS Errors Batch 2:
+  ✅ Strict TS errors eliminated: services, controllers
+  ✅ Removed all unjustified `any` casts in business logic
+
+PR #250 — Backend TS Errors Batch 3:
+  ✅ Strict TS errors eliminated: routes, utils
+  ✅ Type-safe route parameter handling
+
+PR #251 — Backend TS Errors Batch 4:
+  ✅ Remaining modules: models, validators, types
+  ✅ Zero compilation errors across entire backend
+
+PR #252 — CI Type Check Gate:
+  ✅ tsc --noEmit blocking step in CI pipeline
+  ✅ Runs after build — catches type regressions before merge
+
+Impact:
+  979+ TypeScript strict errors eliminated
+  CI gate prevents type error regressions
+  Zero compilation errors — clean type checking pass
 ```
 
 ### Fase 2 — Multi-Tenant (1–2 meses post v2.0.0)

--- a/openspec/PROJECT_STATE.md
+++ b/openspec/PROJECT_STATE.md
@@ -4,15 +4,15 @@
 
 ---
 
-## Versión actual: v3.2.0
+## Versión actual: v3.3.0
 
 | Campo | Valor |
 |-------|-------|
-| Versión | **v3.2.0** (Sprint 14 — CI Pipeline Optimization + Security Hardening) |
+| Versión | **v3.3.0** (Sprint 15 — TypeScript Strict Error Elimination) |
 | Branch main | `main` — producción (synced 2026-06-25) |
 | Branch activo | `development` |
-| Sprint completado | Sprint 14 — CI optimization, Jest sharding, secrets extraction |
-| Próximo sprint | **Sprint 15** — Pendiente |
+| Sprint completado | Sprint 15 — TypeScript strict errors eliminated, CI gate added |
+| Próximo sprint | **Sprint 16** — Pendiente |
 | Repositorio | `ipproyectosysoluciones/mlm-platform` |
 | Root local | `/media/bladimir/Datos2/Datos/MLM` |
 
@@ -55,6 +55,27 @@
 |----|--------|--------|--------|
 
 *(Ninguno pendiente)*
+
+---
+
+## Sprint 15 — Estado COMPLETADO ✅
+
+**Fecha**: 2026-07-18 | **Foco**: TypeScript Strict Error Elimination
+
+| PR | Título | Cambio | Estado |
+|----|--------|--------|--------|
+| #248 | fix/backend-ts-errors-batch1 | Strict TS errors: auth, config, middleware | ✅ Merged |
+| #249 | fix/backend-ts-errors-batch2 | Strict TS errors: services, controllers | ✅ Merged |
+| #250 | fix/backend-ts-errors-batch3 | Strict TS errors: routes, utils | ✅ Merged |
+| #251 | fix/backend-ts-errors-batch4 | Strict TS errors: remaining modules | ✅ Merged |
+| #252 | ci/backend-ts-check-gate | tsc --noEmit blocking CI gate | ✅ Merged |
+
+**Impacto**:
+- 979+ TypeScript strict errors eliminated across backend
+- `tsc --noEmit` blocking CI gate prevents regressions
+- Zero compilation errors — clean type checking pass
+
+**GitHub Actions**: `tsc --noEmit` step runs after "Build backend" in CI pipeline
 
 ---
 
@@ -188,9 +209,9 @@ Login:  admin@mlm.com / admin123
 | Sprint 9 change | `sprint9-tech-debt` — ✅ ARCHIVED |
 | Sprint 9 fix | `fix-service-error-handling` — ✅ ARCHIVED |
 | Sprint 10 change | `sprint10-stabilization` — ✅ ARCHIVED |
+| Sprint 15 change | `sprint15-typescript-strict-errors` — ✅ ARCHIVED |
 | Archived to | `openspec/changes/archive/2026-04-11-sprint8-bot-complete/` |
-| Next sprint | Sprint 15 — pendiente |
-| sdd-init | Reejecutar si se inicia Sprint 15 |
+| Next sprint | Sprint 16 — pendiente |
 
 ---
 
@@ -200,4 +221,4 @@ Login:  admin@mlm.com / admin123
 
 ---
 
-*Actualizado: 2026-07-18 | Post-Sprint 14 CI optimization*
+*Actualizado: 2026-07-18 | Post-Sprint 15 TypeScript strict error elimination*


### PR DESCRIPTION
## Summary

PR7: Add `tsc --noEmit` blocking type check step in CI pipeline (after Build backend).

PR8: Update PROJECT_STATE.md and ROADMAP.md for Sprint 15 completion.

## Changes

### PR7 — CI Type Check Gate
- Added `Type check backend` step to `.github/workflows/ci.yml`
- Runs `cd backend && pnpm tsc --noEmit` after build
- Uses same Node/pnpm setup as existing build step
- Prevents type error regressions from merging

### PR8 — Docs Update
- Updated `openspec/PROJECT_STATE.md`: Sprint 15 section, v3.3.0
- Updated `docs/ROADMAP.md`: Sprint 15 details, PRs #248–#252

## Sprint 15 Impact
- 979+ TypeScript strict errors eliminated across backend
- CI gate ensures clean type checking before merge
- Zero compilation errors

## Files Changed
| File | Action | What |
|------|--------|------|
| `.github/workflows/ci.yml` | Modified | Added tsc --noEmit step |
| `openspec/PROJECT_STATE.md` | Modified | Sprint 15 status |
| `docs/ROADMAP.md` | Modified | Sprint 15 details |