### PR TITLE
chore: fix misleading JSDoc, add Sprint 18 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ Todos los cambios notables de este proyecto serán documentados en este archivo.
 
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/).
 
+## [3.3.0] - 2026-07-21
+
+### Added — Sprint 18: Quick Wins
+
+- **Postman Collection Sync** — Collection actualizada de 126 → 255 endpoints para cubrir toda la API
+- **CI/CD Auto-deploy** — Deploy automático habilitado en branch `development`
+
+### Fixed
+
+- **JSDoc `/v1/` misleading paths** — Corregidos comentarios `@route` en `CartController.ts` y `EmailCampaignController.ts` que referenciaban paths `/api/v1/` inexistentes; rutas reales usan prefijo `/api`
+
+---
+
 ## [3.2.0] - 2026-06-25
 
 ### Added — Sprint 12: Order History & Quality

--- a/backend/src/controllers/CartController.ts
+++ b/backend/src/controllers/CartController.ts
@@ -19,7 +19,7 @@ import type { AuthenticatedRequest } from '../middleware/auth.middleware.js';
  * Get the current user's active cart (creates one if none exists)
  * Obtener el carrito activo del usuario (crea uno si no existe)
  *
- * @route GET /api/v1/carts/me
+ * @route GET /api/carts/me
  * @param req - Authenticated request / Request autenticada
  * @param res - Response with cart data / Respuesta con datos del carrito
  */
@@ -52,7 +52,7 @@ export async function getMyCart(req: AuthenticatedRequest, res: Response): Promi
  * Add an item to the user's cart
  * Agregar un item al carrito del usuario
  *
- * @route POST /api/v1/carts/me/items
+ * @route POST /api/carts/me/items
  * @param req - Body: productId, quantity / Body: productId, quantity
  * @param res - Response with updated cart / Respuesta con carrito actualizado
  */
@@ -95,7 +95,7 @@ export async function addItemToCart(req: AuthenticatedRequest, res: Response): P
  * Remove an item from the user's cart
  * Eliminar un item del carrito del usuario
  *
- * @route DELETE /api/v1/carts/me/items/:cartItemId
+ * @route DELETE /api/carts/me/items/:cartItemId
  * @param req - Params: cartItemId / Params: cartItemId
  * @param res - Response with updated cart / Respuesta con carrito actualizado
  */
@@ -138,7 +138,7 @@ export async function removeItemFromCart(req: AuthenticatedRequest, res: Respons
  * Update quantity of a cart item
  * Actualizar cantidad de un item del carrito
  *
- * @route PATCH /api/v1/carts/me/items/:cartItemId
+ * @route PATCH /api/carts/me/items/:cartItemId
  * @param req - Params: cartItemId, Body: quantity / Params: cartItemId, Body: quantity
  * @param res - Response with updated cart / Respuesta con carrito actualizado
  */
@@ -190,7 +190,7 @@ export async function updateCartItemQuantity(
  * Get cart data by recovery token (preview before recovery)
  * Obtener datos del carrito por token de recuperación (preview antes de recuperar)
  *
- * @route GET /api/v1/carts/recover/:token
+ * @route GET /api/carts/recover/:token
  * @param req - Params: token (plaintext UUID)
  * @param res - Response with cart data or error
  */
@@ -238,7 +238,7 @@ export async function getCartByRecoveryToken(
  * Complete cart recovery (mark token as used, restore cart)
  * Completar recuperación del carrito (marcar token como usado, restaurar carrito)
  *
- * @route POST /api/v1/carts/recover/:token
+ * @route POST /api/carts/recover/:token
  * @param req - Params: token (plaintext UUID)
  * @param res - Response with recovered cart
  */
@@ -294,7 +294,7 @@ export async function recoverCartByToken(req: AuthenticatedRequest, res: Respons
  * List abandoned carts with stats (admin only)
  * Listar carritos abandonados con estadísticas (solo admin)
  *
- * @route GET /api/v1/carts/abandoned
+ * @route GET /api/carts/abandoned
  * @param req - Query: limit, offset, days / Query: limit, offset, days
  * @param res - Response with abandoned carts, pagination, and stats
  */

--- a/backend/src/controllers/EmailCampaignController.ts
+++ b/backend/src/controllers/EmailCampaignController.ts
@@ -8,10 +8,10 @@
  *
  * @example
  * // EN: Create a template
- * POST /api/v1/email-templates { name, subjectLine, htmlContent }
+ * POST /api/email-templates { name, subjectLine, htmlContent }
  *
  * // ES: Crear un template
- * POST /api/v1/email-templates { name, subjectLine, htmlContent }
+ * POST /api/email-templates { name, subjectLine, htmlContent }
  */
 import { Response } from 'express';
 import { emailCampaignService } from '../services/EmailCampaignService.js';


### PR DESCRIPTION
## Sprint 18 — PR #3: Quick Wins

### Changes
1. **CartController.ts**: Fixed 7 `@route` JSDoc: `/api/v1/carts/` → `/api/carts/`
2. **EmailCampaignController.ts**: Fixed 2 `@example` paths: `/api/v1/email-templates` → `/api/email-templates`
3. **CHANGELOG.md**: Added new `[3.3.0] - 2026-07-21` section for Sprint 18

### Verification
- [x] Only JSDoc comments changed, no logic
- [x] No tests affected
- [x] CHANGELOG format consistent

Closes #268