### PR TITLE
fix(test): lazy-load swaggerSpec to fix Jest/CI Symbol error

### DIFF
--- a/backend/scripts/export-swagger.mjs
+++ b/backend/scripts/export-swagger.mjs
@@ -13,7 +13,8 @@ const root = resolve(__dirname, '..');
 
 try {
   // Import the full swagger spec (includes all components, security schemes, tags)
-  const { swaggerSpec } = await import(resolve(root, 'src/config/swagger.ts'));
+  const { getSwaggerSpec } = await import(resolve(root, 'src/config/swagger.ts'));
+  const swaggerSpec = getSwaggerSpec();
   const outPath = resolve(root, 'swagger.json');
   writeFileSync(outPath, JSON.stringify(swaggerSpec, null, 2) + '\n');
   console.log(`✓ swagger.json exported → ${outPath}`);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,7 +7,7 @@ import rateLimit from 'express-rate-limit';
 import swaggerUi from 'swagger-ui-express';
 import * as Sentry from '@sentry/node';
 import { config } from './config/env.js';
-import { swaggerSpec } from './config/swagger.js';
+import { getSwaggerSpec } from './config/swagger.js';
 import routes from './routes/index.js';
 import adminRoutes from './routes/admin.routes.js';
 import crmRoutes from './routes/crm.routes.js';
@@ -200,15 +200,22 @@ if (!isTest) {
   app.use('/api/auth/2fa/verify-setup', twoFALimiter);
 }
 
-// Swagger UI
-app.use(
-  '/api-docs',
-  swaggerUi.serve,
-  swaggerUi.setup(swaggerSpec, {
-    customCss: '.swagger-ui .topbar { display: none }',
-    customSiteTitle: 'MLM API Documentation',
-  })
-);
+// Swagger UI — lazy spec generation avoids glob Symbol error in Jest/CI
+let _swaggerSetup: ReturnType<typeof swaggerUi.setup> | null = null;
+app.use('/api-docs', swaggerUi.serve, (req: Request, res: Response, next: NextFunction) => {
+  if (!_swaggerSetup) {
+    try {
+      _swaggerSetup = swaggerUi.setup(getSwaggerSpec(), {
+        customCss: '.swagger-ui .topbar { display: none }',
+        customSiteTitle: 'MLM API Documentation',
+      });
+    } catch (err) {
+      logger.error({ err }, 'Failed to initialize Swagger UI');
+      return res.status(503).json({ error: 'Swagger UI unavailable' });
+    }
+  }
+  _swaggerSetup(req, res, next);
+});
 
 // API Routes
 app.use('/api', routes);

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -2541,4 +2541,16 @@ Esta API usa JWT Bearer tokens. Incluye el token en el header:
   apis: ['./src/routes/*.ts', './src/controllers/**/*.ts'],
 };
 
-export const swaggerSpec = swaggerJsdoc(options);
+/**
+ * Lazy-loaded Swagger spec — avoids Symbol-to-string error in Jest/CI
+ * when glob@7.x encounters the apis patterns during module import.
+ * The spec is generated once on first access, then cached.
+ */
+let _swaggerSpec: ReturnType<typeof swaggerJsdoc> | null = null;
+
+export function getSwaggerSpec() {
+  if (!_swaggerSpec) {
+    _swaggerSpec = swaggerJsdoc(options);
+  }
+  return _swaggerSpec;
+}


### PR DESCRIPTION
## Problem
All backend integration tests fail on EVERY branch in CI:
```
TypeError: Cannot convert a Symbol value to a string
    at GlobSync._process (glob@7.1.6/sync.js:115:53)
    at convertGlobPaths (swagger-jsdoc@6.2.8/src/utils.js:13:31)
    at swaggerJsdoc (swagger-jsdoc@6.2.8/src/lib.js:32:10)
```

## Root Cause
`swaggerJsdoc(options)` was called eagerly at module import time in `swagger.ts:2544`. When Jest loads `app.ts` → `swagger.ts`, the library tries to resolve glob patterns (`./src/routes/*.ts`, `./src/controllers/**/*.ts`) and encounters a Symbol value instead of a string in the CI environment.

## Solution
Changed to lazy-load pattern:
- **swagger.ts**: Export `getSwaggerSpec()` — generates spec once on first access, then caches
- **app.ts**: Import `getSwaggerSpec`, call at middleware setup (not at import)
- **export-swagger.mjs**: Use `getSwaggerSpec()` for static export

## Verification
- [x] TypeScript compiles (0 errors)
- [x] No eager `swaggerJsdoc()` call at import time
- [x] Swagger UI still works (spec generated on first request to `/api-docs`)
- [x] Export script still works (calls `getSwaggerSpec()` explicitly)

Closes #273