### PR TITLE
fix(ci): run corepack enable before setup-node@v7 in auto-version

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -16,12 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - run: corepack enable
+
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
 
-      - run: corepack enable && corepack prepare pnpm@latest --activate
+      - run: corepack prepare pnpm@latest --activate
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
@@ -64,12 +66,14 @@ jobs:
         with:
           fetch-depth: 0  # Full history needed for conventional-changelog
 
+      - run: corepack enable
+
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
 
-      - run: corepack enable && corepack prepare pnpm@latest --activate
+      - run: corepack prepare pnpm@latest --activate
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile


### PR DESCRIPTION
Fix the auto-version pipeline: `setup-node@v7` with `cache: pnpm` needs `corepack enable` first (same pattern as ci.yml).