### PR TITLE
fix(ci): remove path filter from cd-backend tag trigger

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -16,12 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - run: corepack enable
+
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
 
-      - run: corepack enable && corepack prepare pnpm@latest --activate
+      - run: corepack prepare pnpm@latest --activate
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
@@ -64,12 +66,14 @@ jobs:
         with:
           fetch-depth: 0  # Full history needed for conventional-changelog
 
+      - run: corepack enable
+
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
 
-      - run: corepack enable && corepack prepare pnpm@latest --activate
+      - run: corepack prepare pnpm@latest --activate
 
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [release]
     tags: ['v*']
-    paths:
-      - 'backend/**'
-      - 'pnpm-lock.yaml'
 
 # ── Required Secrets ─────────────────────────────────────────────────
 # DOCKERHUB_USERNAME  — Docker Hub username (used as image namespace)


### PR DESCRIPTION
Tags like v1.0.1 from auto-version don't trigger cd-backend because path filter requires backend/** or pnpm-lock.yaml changes. Removing the path filter so all tag pushes trigger Docker deploy.