### PR TITLE
chore(release): v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## [1.0.1] - 2026-07-29(https://github.com/ipproyectosysoluciones/mlm-platform/compare/v3.4.1...v1.0.1) (2026-07-29)
+
+### Bug Fixes
+
+- **backend:** resolve 114 TS2742 type declaration portability errors ([3c7c114](https://github.com/ipproyectosysoluciones/mlm-platform/commit/3c7c11453f9fb57bcb9a76f597a87dc9fa5790f8))
+- **backend:** resolve 26 lint errors (unused vars + require imports) ([e5e7cb2](https://github.com/ipproyectosysoluciones/mlm-platform/commit/e5e7cb2a280752a7d85ab1833fe931eb55388197))
+- **ci:** add concurrency groups to cancel duplicate push+PR runs ([b56f5df](https://github.com/ipproyectosysoluciones/mlm-platform/commit/b56f5df2b5172b1b30ac14694f4294de02d5f978))
+- **ci:** remove broken deploy-development job (no server configured) ([f577e94](https://github.com/ipproyectosysoluciones/mlm-platform/commit/f577e94eb3f0122ca6073332f088cc9e69841a77))
+- **ci:** remove development from PR branches to prevent duplicate runs ([6357eeb](https://github.com/ipproyectosysoluciones/mlm-platform/commit/6357eebb257176cf6f69d70b4802c1108ad9332d))
+- **ci:** run corepack enable before setup-node@v7 in auto-version ([945df5b](https://github.com/ipproyectosysoluciones/mlm-platform/commit/945df5b43e081a67c9e9e5a53ae40b13eae3dffe))
+- **e2e:** use CI-aware baseURL instead of hardcoded localhost:5173 ([e16c3dc](https://github.com/ipproyectosysoluciones/mlm-platform/commit/e16c3dca105df124e12e2b33520a6b8f41781205))
+- **security:** override @conventional-changelog/git-client >= 2.0.0 (Dependabot [#184](https://github.com/ipproyectosysoluciones/mlm-platform/issues/184)) ([1524fd5](https://github.com/ipproyectosysoluciones/mlm-platform/commit/1524fd53a5ff27a538bf61a8da38626173c9d509))
+- **test:** update empty state assertions to match new search.noResults key ([0043ac0](https://github.com/ipproyectosysoluciones/mlm-platform/commit/0043ac0b120ba279d94a82e80980f303f7304ab7))
+
+### Performance Improvements
+
+- **ci:** optimize Playwright — 4 workers, retries 1, artifact reuse ([7274122](https://github.com/ipproyectosysoluciones/mlm-platform/commit/7274122ae8cd445a414a85a63a7d07f467052c98))
+
 # Changelog
 
 Todos los cambios notables de este proyecto serán documentados en este archivo.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexo-real",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Nexo Real - Plataforma de Afiliaciones",
   "scripts": {
     "prepare": "husky",


### PR DESCRIPTION
## Release v1.0.1

- Auto-version bump from conventional commits
- Triggers Docker deploy via cd-backend.yml

**WARNING**: Do NOT squash — we need the merge commit to trigger cd-backend via branch push.