### PR TITLE
fix: sync package.json version to v3.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexo-real",
   "private": true,
-  "version": "1.0.0",
+  "version": "3.4.2",
   "description": "Nexo Real - Plataforma de Afiliaciones",
   "scripts": {
     "prepare": "husky",


### PR DESCRIPTION
## Version Sync to Release

Syncs `package.json` to 3.4.2 on the release branch for the next formal release.