### PR TITLE
fix(ci): trigger cd-backend via workflow_dispatch

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -148,7 +148,7 @@ jobs:
           git commit -m "chore(release): v${NEW_VERSION}"
           git push origin "$BRANCH"
 
-          # Create tag and push (triggers cd-backend.yml)
+          # Create tag and push (manual/3rd-party pushes trigger cd-backend)
           git tag "v${NEW_VERSION}"
           git push origin "v${NEW_VERSION}"
           echo "✅ Tag v${NEW_VERSION} pushed"
@@ -159,13 +159,16 @@ jobs:
             --generate-notes
           echo "✅ Release v${NEW_VERSION} created"
 
+          # Trigger cd-backend directly (tag pushes from GITHUB_TOKEN don't trigger other workflows)
+          gh workflow run cd-backend.yml --ref "v${NEW_VERSION}"
+          echo "✅ cd-backend triggered for v${NEW_VERSION}"
+
           # Create and auto-merge PR to release
           PR_URL=$(gh pr create \
             --base release \
             --head "$BRANCH" \
             --title "chore(release): v${NEW_VERSION}" \
-            --body "Automated version bump: ${CURRENT} → ${NEW_VERSION}" \
-            --label release)
+            --body "Automated version bump: ${CURRENT} → ${NEW_VERSION}")
           echo "✅ PR created: $PR_URL"
 
           gh pr merge "$PR_URL" \

--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [release]
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g., v3.4.3)'
+        required: true
 
 # ── Required Secrets ─────────────────────────────────────────────────
 # DOCKERHUB_USERNAME  — Docker Hub username (used as image namespace)


### PR DESCRIPTION
## Problem
When auto-version creates a tag with GITHUB_TOKEN and pushes it, GitHub does NOT trigger downstream workflows (cd-backend). This is by design — GITHUB_TOKEN push events don't spawn new workflow runs.

## Solution
1. Added `workflow_dispatch` trigger to cd-backend.yml
2. Auto-version now calls `gh workflow run cd-backend.yml --ref vX.Y.Z` directly after creating the tag + release

## Tag push still works
Manual tag pushes (with PAT or user credentials) still trigger cd-backend via the existing `tags: ['v*']` trigger.