### PR TITLE
fix(ci): add --latest flag to gh release create

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -153,10 +153,11 @@ jobs:
           git push origin "v${NEW_VERSION}"
           echo "✅ Tag v${NEW_VERSION} pushed"
 
-          # Create GitHub Release
+          # Create GitHub Release (explicit --latest to avoid draft)
           gh release create "v${NEW_VERSION}" \
             --title "v${NEW_VERSION}" \
-            --generate-notes
+            --generate-notes \
+            --latest
           echo "✅ Release v${NEW_VERSION} created"
 
           # Trigger cd-backend directly (tag pushes from GITHUB_TOKEN don't trigger other workflows)


### PR DESCRIPTION
gh release create with GITHUB_TOKEN creates draft releases by default. Adding --latest ensures the release is published immediately.