### PR TITLE
fix(ci): add actions:write for gh workflow run

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
Needed for `gh workflow run cd-backend.yml` to work from auto-version.