### PR TITLE
feat(admin): create shared CRUD core components

### DIFF
--- a/frontend/src/components/admin/AdminCrudTableTypes.ts
+++ b/frontend/src/components/admin/AdminCrudTableTypes.ts
@@ -1,0 +1,110 @@
+/**
+ * @fileoverview Shared types for AdminCrudTable and related components
+ * @module components/admin/AdminCrudTableTypes
+ */
+
+import type { ReactNode } from 'react';
+
+// ============================================
+// Column & Filter definitions
+// ============================================
+
+export interface ColumnDef<T> {
+  key: string;
+  header: string;
+  align?: 'left' | 'center' | 'right';
+  render: (item: T) => ReactNode;
+  sortable?: boolean;
+  className?: string;
+}
+
+export type FilterType = 'select' | 'text';
+
+export interface SelectFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface FilterDef {
+  key: string;
+  label: string;
+  type: FilterType;
+  value: string;
+  onChange: (value: string) => void;
+  options?: SelectFilterOption[];
+  placeholder?: string;
+  className?: string;
+}
+
+// ============================================
+// Pagination & API
+// ============================================
+
+export interface ListParams {
+  page: number;
+  limit: number;
+  [key: string]: unknown;
+}
+
+export interface ListResponse<T> {
+  data: T[];
+  total: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Generic CRUD API interface for admin entities.
+ * Each entity (property, tour, reservation) provides its own implementation
+ * wrapping the corresponding adminService methods.
+ *
+ * @ready tenantId — when migrating to multi-tenant, add tenantId to list params
+ */
+export interface CrudApi<T extends { id: string }> {
+  list(params: ListParams): Promise<ListResponse<T>>;
+  create?(data: Partial<T>): Promise<T>;
+  update?(id: string, data: Partial<T>): Promise<T>;
+  delete?(id: string): Promise<void>;
+  toggleStatus?(id: string): Promise<T>;
+  updateStatus?(id: string, status: string, notes?: string): Promise<T>;
+}
+
+// ============================================
+// Form modal
+// ============================================
+
+export interface FormProps<T> {
+  /** null = creating, object = editing */
+  initialData: Partial<T> | null;
+  /** Called with form field values when save is triggered */
+  onSave: (data: Record<string, unknown>) => Promise<void>;
+  /** Whether a save operation is in flight */
+  saving: boolean;
+  /** Validation errors keyed by field name */
+  errors?: Record<string, string>;
+}
+
+/**
+ * Configuration for AdminStatusBadge.
+ * Maps a status value to its display label and color.
+ *
+ * @ready tenantId — status configs may differ per tenant
+ */
+export interface StatusConfig {
+  value: string;
+  label: string;
+  color: string;
+}
+
+// ============================================
+// Notes modal (Reservations)
+// ============================================
+
+export interface NotesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  currentStatus: string;
+  statusOptions: { value: string; label: string }[];
+  currentNotes: string;
+  onSave: (status: string, notes: string) => Promise<void>;
+}

--- a/frontend/src/components/admin/AdminFormModal.tsx
+++ b/frontend/src/components/admin/AdminFormModal.tsx
@@ -1,0 +1,91 @@
+/**
+ * @fileoverview AdminFormModal — Reusable create/edit modal for admin CRUD entities.
+ * Uses React children (render prop pattern) to render entity-specific form fields.
+ *
+ * @module components/admin/AdminFormModal
+ */
+import { X, Save } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+
+export interface AdminFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Modal title (e.g. "Nueva propiedad" or "Editar tour") */
+  title: string;
+  /** Called when the form is submitted (handles create vs edit internally) */
+  onSubmit: (e: React.FormEvent) => void;
+  /** Whether a save operation is in flight */
+  saving: boolean;
+  children: React.ReactNode;
+}
+
+/**
+ * Generic form modal for create/edit operations.
+ *
+ * The parent page renders its entity-specific form fields as `children`,
+ * keeping the modal layout (title, save/cancel buttons) shared.
+ *
+ * @example
+ * ```tsx
+ * <AdminFormModal
+ *   isOpen={showForm}
+ *   onClose={closeModal}
+ *   title={editingId ? 'Editar propiedad' : 'Nueva propiedad'}
+ *   saving={saving}
+ *   onSubmit={handleSubmit}
+ * >
+ *   {children}
+ * </AdminFormModal>
+ * ```
+ */
+export default function AdminFormModal({
+  isOpen,
+  onClose,
+  title,
+  saving,
+  onSubmit,
+  children,
+}: AdminFormModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Completá los campos del formulario. Los campos marcados con * son obligatorios.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={onSubmit} className="space-y-4">
+          {children}
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-4 border-t border-slate-200">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-700 bg-white border border-slate-300 rounded-lg hover:bg-slate-50 transition-colors"
+            >
+              <X className="w-4 h-4" />
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <Save className="w-4 h-4" />
+              {saving ? 'Guardando...' : 'Guardar'}
+            </button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/admin/AdminNotesModal.tsx
+++ b/frontend/src/components/admin/AdminNotesModal.tsx
@@ -1,0 +1,140 @@
+/**
+ * @fileoverview AdminNotesModal — Modal for updating reservation status and admin notes.
+ * Used by AdminReservationsPage. Not a generic CRUD modal — reservations have
+ * a different workflow (status transitions + admin notes).
+ *
+ * @module components/admin/AdminNotesModal
+ */
+import { useState } from 'react';
+import { X, Save } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+
+export interface AdminNotesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  currentStatus: string;
+  statusOptions: { value: string; label: string }[];
+  currentNotes: string;
+  onSave: (status: string, notes: string) => Promise<void>;
+}
+
+/**
+ * Modal for editing reservation status and admin notes.
+ *
+ * Not a full CRUD form — this is specific to the reservations workflow
+ * where admins update the reservation status (confirm, cancel, etc.)
+ * and optionally add internal notes.
+ *
+ * @example
+ * ```tsx
+ * <AdminNotesModal
+ *   isOpen={showNotes}
+ *   onClose={closeNotesModal}
+ *   title={`Reserva: ${reservation.guestName}`}
+ *   currentStatus={selectedReservation.status}
+ *   statusOptions={RESERVATION_STATUS_OPS}
+ *   currentNotes={selectedReservation.adminNotes ?? ''}
+ *   onSave={handleSaveNotes}
+ * />
+ * ```
+ */
+export default function AdminNotesModal({
+  isOpen,
+  onClose,
+  title,
+  currentStatus,
+  statusOptions,
+  currentNotes,
+  onSave,
+}: AdminNotesModalProps) {
+  const [status, setStatus] = useState(currentStatus);
+  const [notes, setNotes] = useState(currentNotes);
+  const [saving, setSaving] = useState(false);
+
+  // State syncs from props on each open; the parent controls
+  // the modal lifecycle via `isOpen` which triggers re-mount
+  // in the Dialog primitive.
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await onSave(status, notes);
+      onClose();
+    } catch {
+      // Error handling is the parent's responsibility
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>Actualizar estado y notas de la reserva</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Status selector */}
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">Estado</label>
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+              className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            >
+              {statusOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Admin notes */}
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">
+              Notas del administrador
+            </label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={4}
+              placeholder="Notas internas sobre la reserva..."
+              className="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-y"
+            />
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-4 border-t border-slate-200">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-700 bg-white border border-slate-300 rounded-lg hover:bg-slate-50 transition-colors"
+            >
+              <X className="w-4 h-4" />
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <Save className="w-4 h-4" />
+              {saving ? 'Guardando...' : 'Guardar'}
+            </button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/admin/AdminStatusBadge.tsx
+++ b/frontend/src/components/admin/AdminStatusBadge.tsx
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview AdminStatusBadge — Displays a status badge for admin CRUD entities.
+ * Supports both read-only (span) and toggle (button) modes.
+ *
+ * @module components/admin/AdminStatusBadge
+ */
+import { cn } from '@/lib/utils';
+import type { StatusConfig } from './AdminCrudTableTypes';
+
+export interface AdminStatusBadgeProps {
+  value: string;
+  config: StatusConfig[];
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * Status badge that renders as a `<span>` by default, or as a `<button>`
+ * when `onClick` is provided (toggleable statuses).
+ *
+ * Color classes come from the `config.color` field, which follows the
+ * pattern `text-{color}-700 bg-{color}-100`.
+ *
+ * @example
+ * ```tsx
+ * <AdminStatusBadge
+ *   value="available"
+ *   config={PROPERTY_STATUSES}
+ *   onClick={() => handleToggle(property)}
+ *   disabled={property.status === 'rented' || property.status === 'sold'}
+ * />
+ * ```
+ */
+export default function AdminStatusBadge({
+  value,
+  config,
+  onClick,
+  disabled = false,
+}: AdminStatusBadgeProps) {
+  const statusConfig = config.find((s) => s.value === value);
+
+  if (!statusConfig) {
+    return (
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-slate-100 text-slate-700">
+        {value}
+      </span>
+    );
+  }
+
+  const baseClasses =
+    'inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium';
+  const colorClasses = statusConfig.color;
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={disabled ? undefined : onClick}
+        disabled={disabled}
+        className={cn(
+          baseClasses,
+          colorClasses,
+          'transition-colors',
+          disabled && 'opacity-40 cursor-not-allowed',
+          !disabled && 'hover:opacity-80 cursor-pointer'
+        )}
+        title={disabled ? 'No disponible' : `Cambiar estado`}
+      >
+        {statusConfig.label}
+      </button>
+    );
+  }
+
+  return <span className={cn(baseClasses, colorClasses)}>{statusConfig.label}</span>;
+}

--- a/frontend/src/services/crud-api.ts
+++ b/frontend/src/services/crud-api.ts
@@ -1,0 +1,117 @@
+/**
+ * @fileoverview Generic CRUD API adapter for admin entities.
+ * Wraps adminService methods into a standard CrudApi<T> interface,
+ * normalizing inconsistent API response shapes.
+ *
+ * @module services/crud-api
+ */
+
+import type { CrudApi, ListParams, ListResponse } from '@/components/admin/AdminCrudTableTypes';
+
+/**
+ * Response normalizer — handles inconsistent API response shapes.
+ *
+ * The backend endpoints return different shapes:
+ * - Some return `{ data: [...] }`
+ * - Others return `{ properties: [...] }` or `{ tours: [...] }`
+ *
+ * This normalizer extracts the array using a key fallback chain.
+ */
+function normalizeListResponse<T>(
+  response: unknown,
+  dataKey?: string
+): { items: T[]; total: number } {
+  const resp = response as Record<string, unknown>;
+
+  // If the response itself is an array, use it directly
+  if (Array.isArray(response)) {
+    return { items: response as T[], total: response.length };
+  }
+
+  // Try explicit data key first
+  if (dataKey) {
+    const byKey = resp[dataKey];
+    if (Array.isArray(byKey)) {
+      return { items: byKey as T[], total: (resp.total as number) ?? byKey.length };
+    }
+  }
+
+  // Try common fallback keys
+  const data = resp.data;
+  if (Array.isArray(data)) {
+    return { items: data as T[], total: (resp.total as number) ?? data.length };
+  }
+
+  // Try items key
+  const items = resp.items;
+  if (Array.isArray(items)) {
+    return { items: items as T[], total: (resp.total as number) ?? items.length };
+  }
+
+  return { items: [], total: 0 };
+}
+
+/**
+ * Creates a CrudApi<T> adapter from individual async operations.
+ *
+ * @example
+ * ```ts
+ * const propertyApi = createCrudApi({
+ *   list: (params) => adminService.getAdminProperties(params),
+ *   create: (data) => adminService.createProperty(data),
+ *   update: (id, data) => adminService.updateProperty(id, data),
+ *   delete: (id) => adminService.deleteProperty(id),
+ *   toggleStatus: (id) => adminService.updateProperty(id, { status: 'available' }),
+ *   dataKey: 'properties',
+ * });
+ * ```
+ *
+ * @ready tenantId — when migrating to multi-tenant, pass tenantId through params
+ */
+export function createCrudApi<T extends { id: string }>(config: {
+  list: (params: ListParams) => Promise<unknown>;
+  create?: (data: Partial<T>) => Promise<T>;
+  update?: (id: string, data: Partial<T>) => Promise<T>;
+  delete?: (id: string) => Promise<void>;
+  toggleStatus?: (id: string) => Promise<T>;
+  updateStatus?: (id: string, status: string, notes?: string) => Promise<T>;
+  dataKey?: string;
+}): CrudApi<T> {
+  return {
+    list: async (params: ListParams): Promise<ListResponse<T>> => {
+      const response = await config.list(params);
+      const { items, total } = normalizeListResponse<T>(response, config.dataKey);
+      return { data: items, total };
+    },
+
+    ...(config.create && {
+      create: async (data: Partial<T>): Promise<T> => {
+        return config.create!(data);
+      },
+    }),
+
+    ...(config.update && {
+      update: async (id: string, data: Partial<T>): Promise<T> => {
+        return config.update!(id, data);
+      },
+    }),
+
+    ...(config.delete && {
+      delete: async (id: string): Promise<void> => {
+        return config.delete!(id);
+      },
+    }),
+
+    ...(config.toggleStatus && {
+      toggleStatus: async (id: string): Promise<T> => {
+        return config.toggleStatus!(id);
+      },
+    }),
+
+    ...(config.updateStatus && {
+      updateStatus: async (id: string, status: string, notes?: string): Promise<T> => {
+        return config.updateStatus!(id, status, notes);
+      },
+    }),
+  };
+}


### PR DESCRIPTION
Closes #326

## Chain Context

| Field | Value |
|-------|-------|
| Chain | Admin CRUD Table (Slice 1) |
| Tracker PR | #332 |
| Position | 1 of 3 |
| Base | `feat/refactor-admin-crud-table` |
| Depends on | None |
| Follow-up | #02-table |
| Review budget | ~533 additions / 400 |

### Chain Overview
```
development
 └── #332 feat/refactor-admin-crud-table (tracker)
      └── 📍 #? feat/refactor-admin-crud-table-01-core
           └── #? feat/refactor-admin-crud-table-02-table
                └── #? feat/refactor-admin-crud-table-03-reservations
```

### Scope
- Includes: 5 core shared components for admin CRUD
- Excludes: AdminCrudTable component, page refactors, deletion of old code

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

## Summary
- Created shared types: `ColumnDef`, `FilterDef`, `CrudApi<T>`, `StatusConfig` in `AdminCrudTableTypes.ts`
- Created `createCrudApi()` adapter with response normalizer in `crud-api.ts`
- Created `AdminStatusBadge` — dual span/button status badge
- Created `AdminFormModal` — generic create/edit modal with children render-prop
- Created `AdminNotesModal` — reservation-specific notes/status modal

## Changes
| File | Change |
|------|--------|
| `frontend/src/components/admin/AdminCrudTableTypes.ts` | NEW — shared types |
| `frontend/src/services/crud-api.ts` | NEW — API adapter |
| `frontend/src/components/admin/AdminStatusBadge.tsx` | NEW — status badge |
| `frontend/src/components/admin/AdminFormModal.tsx` | NEW — form modal |
| `frontend/src/components/admin/AdminNotesModal.tsx` | NEW — notes modal |

## Test Plan
- [x] `tsc --noEmit`: 0 errors
- [x] `vitest run`: 70 files, 654 tests passed