### PR TITLE
refactor(stores): extract types, persistence, polling from stores (#329)

### DIFF
--- a/frontend/src/components/EmailCampaigns/CampaignMonitor.tsx
+++ b/frontend/src/components/EmailCampaigns/CampaignMonitor.tsx
@@ -8,8 +8,8 @@
  * @author Nexo Real Development Team
  */
 
-import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { usePolling } from '../../hooks/usePolling';
 import {
   BarChart3,
   Send,
@@ -90,20 +90,12 @@ export function CampaignMonitor({ campaignId, onBack, onViewLogs }: CampaignMoni
     fetchCampaignDetail,
     sendCampaign,
     retryFailed,
-    startPolling,
-    stopPolling,
   } = useEmailCampaignMonitor();
 
-  // Fetch detail and start polling on mount / Al montar: obtener detalle e iniciar polling
-  useEffect(() => {
+  // Poll every 10s (immediate fetch + interval) / Polling cada 10s (fetch inicial + intervalo)
+  usePolling(() => {
     fetchCampaignDetail(campaignId);
-    startPolling(campaignId, 10_000);
-
-    return () => {
-      stopPolling();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [campaignId]);
+  }, 10_000);
 
   // ==========================================
   // Handlers / Manejadores

--- a/frontend/src/components/reservation/price-badge.tsx
+++ b/frontend/src/components/reservation/price-badge.tsx
@@ -9,7 +9,7 @@
 import { useTranslation } from 'react-i18next';
 import { cn } from '../../lib/utils';
 import { formatPrice } from '../../stores/reservationStore';
-import type { PriceBreakdown } from '../../stores/reservationStore';
+import type { PriceBreakdown } from '../../types/reservation';
 
 // ============================================
 // Props / Propiedades

--- a/frontend/src/components/reservation/price-breakdown-card.tsx
+++ b/frontend/src/components/reservation/price-breakdown-card.tsx
@@ -9,7 +9,7 @@
 import { useTranslation } from 'react-i18next';
 import { CreditCard } from 'lucide-react';
 import { formatPrice } from '../../stores/reservationStore';
-import type { PriceBreakdown } from '../../stores/reservationStore';
+import type { PriceBreakdown } from '../../types/reservation';
 
 // ============================================
 // Props / Propiedades

--- a/frontend/src/components/reservation/step-confirm.tsx
+++ b/frontend/src/components/reservation/step-confirm.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { CheckCircle2, Lock, ChevronRight } from 'lucide-react';
 import { Button } from '../ui/button';
 import { useReservationWizard } from '../../stores/reservationStore';
-import type { PriceBreakdown } from '../../stores/reservationStore';
+import type { PriceBreakdown } from '../../types/reservation';
 import PriceBreakdownCard from './price-breakdown-card';
 
 // ============================================

--- a/frontend/src/components/reservation/step-payment.tsx
+++ b/frontend/src/components/reservation/step-payment.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { Wallet, Shield, Clock, AlertCircle, Loader2, ChevronRight } from 'lucide-react';
 import { Button } from '../ui/button';
 import { formatPrice } from '../../stores/reservationStore';
-import type { PriceBreakdown } from '../../stores/reservationStore';
+import type { PriceBreakdown } from '../../types/reservation';
 import PriceBreakdownCard from './price-breakdown-card';
 import { featureFlags } from '../../utils/featureFlags';
 import { cn } from '../../lib/utils';

--- a/frontend/src/hooks/__tests__/usePayment.test.ts
+++ b/frontend/src/hooks/__tests__/usePayment.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { usePayment } from '../usePayment';
-import type { PriceBreakdown } from '../../stores/reservationStore';
+import type { PriceBreakdown } from '../../types/reservation';
 
 // ── Mock Data ───────────────────────────────────────────────────────────────
 

--- a/frontend/src/hooks/usePayment.ts
+++ b/frontend/src/hooks/usePayment.ts
@@ -9,7 +9,7 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useReservationWizard, formatPrice } from '../stores/reservationStore';
-import type { PriceBreakdown } from '../stores/reservationStore';
+import type { PriceBreakdown } from '../types/reservation';
 import { paymentService } from '../services/paymentService';
 import { useWalletBalance } from '../stores/walletStore';
 

--- a/frontend/src/hooks/usePolling.ts
+++ b/frontend/src/hooks/usePolling.ts
@@ -30,19 +30,31 @@ export interface UsePollingOptions {
  * without needing to restart.
  *
  * ES: Hook que llama un callback al montar y luego a intervalo regular.
- * EN: Hook that calls a callback on mount and then at a regular interval.
+ * EN: Generic polling hook — calls callback on mount and then at fixed interval.
  *
  * @param callback - Async or sync function to call on each tick / Función a llamar en cada tick
- * @param options - Polling configuration / Configuración de polling
+ * @param options - Polling configuration ({ intervalMs, enabled? }) / Configuración de polling
  */
-export function usePolling(callback: () => void | Promise<void>, options: UsePollingOptions): void {
-  const { intervalMs, enabled = true } = options;
+export function usePolling(callback: () => void | Promise<void>, options: UsePollingOptions): void;
+/**
+ * Convenience overload — receives intervalMs directly as a number.
+ * Sobrecarga de conveniencia — recibe intervalMs directamente como número.
+ *
+ * @param callback - Function to call on each tick / Función a ejecutar en cada tick
+ * @param intervalMs - Polling interval in milliseconds / Intervalo de polling en ms
+ */
+export function usePolling(callback: () => void | Promise<void>, intervalMs: number): void;
+export function usePolling(
+  callback: () => void | Promise<void>,
+  optionsOrMs: UsePollingOptions | number
+): void {
+  const { intervalMs, enabled = true } =
+    typeof optionsOrMs === 'number' ? { intervalMs: optionsOrMs } : optionsOrMs;
+
   const callbackRef = useRef(callback);
 
-  // Keep the ref up-to-date outside render / Mantener la ref actualizada fuera del render
-  useEffect(() => {
-    callbackRef.current = callback;
-  });
+  // Always keep the ref up-to-date / Mantener la ref actualizada
+  callbackRef.current = callback;
 
   useEffect(() => {
     if (!enabled) return;

--- a/frontend/src/lib/cartPersistence.ts
+++ b/frontend/src/lib/cartPersistence.ts
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Cart persistence — localStorage helpers for cart state
+ * @description Low-level localStorage CRUD for cart persistence.
+ *              Extracted from cartStore.ts for separation of concerns.
+ *              Persistencia localStorage para el estado del carrito.
+ * @module lib/cartPersistence
+ */
+
+import type { CartItemResponse } from '../services/cartService';
+
+// ============================================
+// Constants / Constantes
+// ============================================
+
+const CART_STORAGE_PREFIX = 'mlm_cart_';
+const MAX_RECOVERY_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// ============================================
+// Types / Tipos
+// ============================================
+
+export interface PersistedCartData {
+  items: CartItemResponse[];
+  totalAmount: number;
+  itemCount: number;
+  lastActivityAt: string;
+  savedAt: string;
+}
+
+// ============================================
+// Public API / API pública
+// ============================================
+
+/**
+ * Build the localStorage key for a given user
+ * Construir la clave de localStorage para un usuario dado
+ */
+function storageKey(userId: string): string {
+  return `${CART_STORAGE_PREFIX}${userId}`;
+}
+
+/**
+ * Save cart state to localStorage
+ * Guardar estado del carrito en localStorage
+ */
+export function saveCartToStorage(userId: string, data: Omit<PersistedCartData, 'savedAt'>): void {
+  const payload: PersistedCartData = {
+    ...data,
+    savedAt: new Date().toISOString(),
+  };
+  try {
+    localStorage.setItem(storageKey(userId), JSON.stringify(payload));
+  } catch {
+    // localStorage might be full or unavailable — silently ignore
+  }
+}
+
+/**
+ * Load cart state from localStorage (only if <24hrs old)
+ * Cargar estado del carrito desde localStorage (solo si tiene <24hrs)
+ *
+ * Returns null if nothing stored, expired, or corrupted.
+ * Returns null si no hay datos, expiró, o está corrupto.
+ */
+export function loadCartFromStorage(userId: string): PersistedCartData | null {
+  try {
+    const stored = localStorage.getItem(storageKey(userId));
+    if (!stored) return null;
+
+    const data: PersistedCartData = JSON.parse(stored);
+    const age = Date.now() - new Date(data.savedAt).getTime();
+
+    if (age > MAX_RECOVERY_AGE_MS) {
+      localStorage.removeItem(storageKey(userId));
+      return null;
+    }
+
+    return data;
+  } catch {
+    // Corrupted data — remove it
+    localStorage.removeItem(storageKey(userId));
+    return null;
+  }
+}
+
+/**
+ * Remove cart data from localStorage
+ * Eliminar datos del carrito de localStorage
+ */
+export function clearCartFromStorage(userId: string): void {
+  try {
+    localStorage.removeItem(storageKey(userId));
+  } catch {
+    // Silently ignore
+  }
+}

--- a/frontend/src/stores/cartStore.ts
+++ b/frontend/src/stores/cartStore.ts
@@ -11,14 +11,17 @@ import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 import { cartService } from '../services/cartService';
 import type { CartResponse, CartItemResponse } from '../services/cartService';
+import {
+  saveCartToStorage,
+  loadCartFromStorage,
+  clearCartFromStorage,
+} from '../lib/cartPersistence';
 
 // ============================================
 // Constants / Constantes
 // ============================================
 
-const CART_STORAGE_PREFIX = 'mlm_cart_';
 const SYNC_DEBOUNCE_MS = 30_000; // 30 seconds
-const MAX_RECOVERY_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 // ============================================
 // Types / Tipos
@@ -104,220 +107,188 @@ const initialState = {
 // Store / Store
 // ============================================
 
-export const useCartStore = create<CartState>((set, get) => ({
-  ...initialState,
+export const useCartStore = create<CartState>((set, get) => {
+  // ==========================================
+  // Helper: sync cart state from API response
+  // Helper: sincronizar estado del carrito desde respuesta API
+  // ==========================================
 
-  /**
-   * Fetch the current user's active cart from the API
-   * Obtener el carrito activo del usuario actual desde la API
-   */
-  fetchCart: async () => {
-    set({ isLoading: true, error: null });
-    try {
-      const cart = await cartService.getMyCart();
-      set({
-        cart,
-        items: cart.items ?? [],
-        totalAmount: Number(cart.totalAmount) || 0,
-        itemCount: cart.itemCount ?? cart.items?.length ?? 0,
-        lastActivityAt: cart.lastActivityAt ?? new Date().toISOString(),
-        isLoading: false,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to fetch cart';
-      set({ error: message, isLoading: false });
-    }
-  },
-
-  /**
-   * Add an item to the cart
-   * Agregar un item al carrito
-   */
-  addItem: async (productId: string, quantity: number) => {
-    set({ isAddingItem: true, error: null });
-    try {
-      const cart = await cartService.addItem(productId, quantity);
-      set({
-        cart,
-        items: cart.items ?? [],
-        totalAmount: Number(cart.totalAmount) || 0,
-        itemCount: cart.itemCount ?? cart.items?.length ?? 0,
-        lastActivityAt: cart.lastActivityAt ?? new Date().toISOString(),
-        isAddingItem: false,
-      });
-      return cart;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to add item to cart';
-      set({ error: message, isAddingItem: false });
-      throw error;
-    }
-  },
-
-  /**
-   * Remove an item from the cart
-   * Eliminar un item del carrito
-   */
-  removeItem: async (cartItemId: string) => {
-    set({ isRemovingItem: true, error: null });
-    try {
-      const cart = await cartService.removeItem(cartItemId);
-      set({
-        cart,
-        items: cart.items ?? [],
-        totalAmount: Number(cart.totalAmount) || 0,
-        itemCount: cart.itemCount ?? cart.items?.length ?? 0,
-        lastActivityAt: cart.lastActivityAt ?? new Date().toISOString(),
-        isRemovingItem: false,
-      });
-      return cart;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to remove item from cart';
-      set({ error: message, isRemovingItem: false });
-      throw error;
-    }
-  },
-
-  /**
-   * Update item quantity in the cart
-   * Actualizar la cantidad de un item en el carrito
-   */
-  updateQuantity: async (cartItemId: string, quantity: number) => {
-    set({ isUpdatingQuantity: true, error: null });
-    try {
-      const cart = await cartService.updateQuantity(cartItemId, quantity);
-      set({
-        cart,
-        items: cart.items ?? [],
-        totalAmount: Number(cart.totalAmount) || 0,
-        itemCount: cart.itemCount ?? cart.items?.length ?? 0,
-        lastActivityAt: cart.lastActivityAt ?? new Date().toISOString(),
-        isUpdatingQuantity: false,
-      });
-      return cart;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to update quantity';
-      set({ error: message, isUpdatingQuantity: false });
-      throw error;
-    }
-  },
-
-  /**
-   * Clear cart state (used after successful checkout)
-   * Limpiar el estado del carrito (usado después de checkout exitoso)
-   */
-  clearCart: () => {
+  function syncCartState(cart: CartResponse, extra: Partial<CartState>): void {
     set({
-      cart: null,
-      items: [],
-      totalAmount: 0,
-      itemCount: 0,
-      lastActivityAt: null,
+      cart,
+      items: cart.items ?? [],
+      totalAmount: Number(cart.totalAmount) || 0,
+      itemCount: cart.itemCount ?? cart.items?.length ?? 0,
+      lastActivityAt: cart.lastActivityAt ?? new Date().toISOString(),
       error: null,
+      ...extra,
     });
-  },
+  }
 
-  // ==========================================
-  // Recovery / Recuperación
-  // ==========================================
+  return {
+    ...initialState,
 
-  /**
-   * Preview a cart via recovery token (public, no auth)
-   * Vista previa del carrito via token de recuperación (público, sin auth)
-   */
-  previewRecoveryCart: async (token: string) => {
-    set({ isLoadingRecovery: true, recoveryError: null, recoveryCart: null });
-    try {
-      const cart = await cartService.getCartByRecoveryToken(token);
-      set({
-        recoveryCart: cart,
-        isLoadingRecovery: false,
-      });
-      return cart;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to load recovery cart';
-      set({ recoveryError: message, isLoadingRecovery: false });
-      throw error;
-    }
-  },
+    // ==========================================
+    // CRUD Actions / Acciones CRUD
+    // ==========================================
 
-  /**
-   * Confirm cart recovery — marks token as used, restores cart
-   * Confirmar recuperación — marca token como usado, restaura carrito
-   */
-  confirmRecovery: async (token: string) => {
-    set({ isRecovering: true, recoveryError: null });
-    try {
-      const cart = await cartService.recoverCart(token);
-      set({
-        cart,
-        items: cart.items ?? [],
-        totalAmount: Number(cart.totalAmount) || 0,
-        itemCount: cart.itemCount ?? cart.items?.length ?? 0,
-        lastActivityAt: cart.lastActivityAt ?? new Date().toISOString(),
-        recoveryCart: null,
-        isRecovering: false,
-      });
-      return cart;
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to recover cart';
-      set({ recoveryError: message, isRecovering: false });
-      throw error;
-    }
-  },
-
-  /**
-   * Clear recovery state
-   * Limpiar estado de recuperación
-   */
-  clearRecovery: () => set({ recoveryCart: null, recoveryError: null, isLoadingRecovery: false }),
-
-  // ==========================================
-  // localStorage Persistence / Persistencia
-  // ==========================================
-
-  /**
-   * Sync cart state to localStorage (debounced 30s)
-   * Sincronizar estado del carrito a localStorage (debounced 30s)
-   */
-  syncToLocalStorage: (userId: string) => {
-    debouncedSync(() => {
-      const state = get();
-      if (!state.cart) return;
-
-      const data = {
-        items: state.items,
-        totalAmount: state.totalAmount,
-        itemCount: state.itemCount,
-        lastActivityAt: state.lastActivityAt ?? new Date().toISOString(),
-        savedAt: new Date().toISOString(),
-      };
-
+    /**
+     * Fetch the current user's active cart from the API
+     * Obtener el carrito activo del usuario actual desde la API
+     */
+    fetchCart: async () => {
+      set({ isLoading: true, error: null });
       try {
-        localStorage.setItem(`${CART_STORAGE_PREFIX}${userId}`, JSON.stringify(data));
-      } catch {
-        // localStorage might be full or unavailable — silently ignore
+        const cart = await cartService.getMyCart();
+        syncCartState(cart, { isLoading: false });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to fetch cart';
+        set({ error: message, isLoading: false });
       }
-    });
-  },
+    },
 
-  /**
-   * Load cart from localStorage if <24hrs old
-   * Cargar carrito desde localStorage si tiene <24hrs
-   */
-  loadFromLocalStorage: (userId: string) => {
-    try {
-      const stored = localStorage.getItem(`${CART_STORAGE_PREFIX}${userId}`);
-      if (!stored) return;
-
-      const data = JSON.parse(stored);
-      const savedAt = new Date(data.savedAt).getTime();
-      const age = Date.now() - savedAt;
-
-      // Only restore if <24hrs old / Solo restaurar si tiene <24hrs
-      if (age > MAX_RECOVERY_AGE_MS) {
-        localStorage.removeItem(`${CART_STORAGE_PREFIX}${userId}`);
-        return;
+    /**
+     * Add an item to the cart
+     * Agregar un item al carrito
+     */
+    addItem: async (productId: string, quantity: number) => {
+      set({ isAddingItem: true, error: null });
+      try {
+        const cart = await cartService.addItem(productId, quantity);
+        syncCartState(cart, { isAddingItem: false });
+        return cart;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to add item to cart';
+        set({ error: message, isAddingItem: false });
+        throw error;
       }
+    },
+
+    /**
+     * Remove an item from the cart
+     * Eliminar un item del carrito
+     */
+    removeItem: async (cartItemId: string) => {
+      set({ isRemovingItem: true, error: null });
+      try {
+        const cart = await cartService.removeItem(cartItemId);
+        syncCartState(cart, { isRemovingItem: false });
+        return cart;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to remove item from cart';
+        set({ error: message, isRemovingItem: false });
+        throw error;
+      }
+    },
+
+    /**
+     * Update item quantity in the cart
+     * Actualizar la cantidad de un item en el carrito
+     */
+    updateQuantity: async (cartItemId: string, quantity: number) => {
+      set({ isUpdatingQuantity: true, error: null });
+      try {
+        const cart = await cartService.updateQuantity(cartItemId, quantity);
+        syncCartState(cart, { isUpdatingQuantity: false });
+        return cart;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to update quantity';
+        set({ error: message, isUpdatingQuantity: false });
+        throw error;
+      }
+    },
+
+    /**
+     * Clear cart state (used after successful checkout)
+     * Limpiar el estado del carrito (usado después de checkout exitoso)
+     */
+    clearCart: () => {
+      set({
+        cart: null,
+        items: [],
+        totalAmount: 0,
+        itemCount: 0,
+        lastActivityAt: null,
+        error: null,
+      });
+    },
+
+    // ==========================================
+    // Recovery / Recuperación
+    // ==========================================
+
+    /**
+     * Preview a cart via recovery token (public, no auth)
+     * Vista previa del carrito via token de recuperación (público, sin auth)
+     */
+    previewRecoveryCart: async (token: string) => {
+      set({ isLoadingRecovery: true, recoveryError: null, recoveryCart: null });
+      try {
+        const cart = await cartService.getCartByRecoveryToken(token);
+        set({
+          recoveryCart: cart,
+          isLoadingRecovery: false,
+        });
+        return cart;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to load recovery cart';
+        set({ recoveryError: message, isLoadingRecovery: false });
+        throw error;
+      }
+    },
+
+    /**
+     * Confirm cart recovery — marks token as used, restores cart
+     * Confirmar recuperación — marca token como usado, restaura carrito
+     */
+    confirmRecovery: async (token: string) => {
+      set({ isRecovering: true, recoveryError: null });
+      try {
+        const cart = await cartService.recoverCart(token);
+        syncCartState(cart, { recoveryCart: null, isRecovering: false });
+        return cart;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to recover cart';
+        set({ recoveryError: message, isRecovering: false });
+        throw error;
+      }
+    },
+
+    /**
+     * Clear recovery state
+     * Limpiar estado de recuperación
+     */
+    clearRecovery: () => set({ recoveryCart: null, recoveryError: null, isLoadingRecovery: false }),
+
+    // ==========================================
+    // localStorage Persistence / Persistencia
+    // ==========================================
+
+    /**
+     * Sync cart state to localStorage (debounced 30s)
+     * Sincronizar estado del carrito a localStorage (debounced 30s)
+     */
+    syncToLocalStorage: (userId: string) => {
+      debouncedSync(() => {
+        const state = get();
+        if (!state.cart) return;
+
+        saveCartToStorage(userId, {
+          items: state.items,
+          totalAmount: state.totalAmount,
+          itemCount: state.itemCount,
+          lastActivityAt: state.lastActivityAt ?? new Date().toISOString(),
+        });
+      });
+    },
+
+    /**
+     * Load cart from localStorage if <24hrs old
+     * Cargar carrito desde localStorage si tiene <24hrs
+     */
+    loadFromLocalStorage: (userId: string) => {
+      const data = loadCartFromStorage(userId);
+      if (!data) return;
 
       set({
         items: data.items ?? [],
@@ -325,33 +296,26 @@ export const useCartStore = create<CartState>((set, get) => ({
         itemCount: data.itemCount ?? data.items?.length ?? 0,
         lastActivityAt: data.lastActivityAt ?? null,
       });
-    } catch {
-      // Corrupted data — remove it / Datos corruptos — eliminar
-      localStorage.removeItem(`${CART_STORAGE_PREFIX}${userId}`);
-    }
-  },
+    },
 
-  /**
-   * Clear localStorage for a user (on checkout completion)
-   * Limpiar localStorage de un usuario (al completar checkout)
-   */
-  clearLocalStorage: (userId: string) => {
-    try {
-      localStorage.removeItem(`${CART_STORAGE_PREFIX}${userId}`);
-    } catch {
-      // Silently ignore
-    }
-  },
+    /**
+     * Clear localStorage for a user (on checkout completion)
+     * Limpiar localStorage de un usuario (al completar checkout)
+     */
+    clearLocalStorage: (userId: string) => {
+      clearCartFromStorage(userId);
+    },
 
-  /**
-   * Reset store to initial state
-   * Resetear el store al estado inicial
-   */
-  reset: () => {
-    if (syncTimer) clearTimeout(syncTimer);
-    set(initialState);
-  },
-}));
+    /**
+     * Reset store to initial state
+     * Resetear el store al estado inicial
+     */
+    reset: () => {
+      if (syncTimer) clearTimeout(syncTimer);
+      set(initialState);
+    },
+  };
+});
 
 // ============================================
 // Selector Hooks / Hooks selectores

--- a/frontend/src/stores/emailCampaignStore.ts
+++ b/frontend/src/stores/emailCampaignStore.ts
@@ -49,8 +49,7 @@ interface EmailCampaignState {
   templateError: string | null;
   campaignError: string | null;
 
-  // Polling / Polling
-  pollingInterval: ReturnType<typeof setInterval> | null;
+  // (Polling moved to hooks/usePolling.ts — CampaignMonitor uses it directly)
 
   // Template Actions / Acciones de plantillas
   createTemplate: (data: EmailTemplateCreatePayload) => Promise<EmailTemplate>;
@@ -68,9 +67,7 @@ interface EmailCampaignState {
   // Logs Actions / Acciones de logs
   fetchCampaignLogs: (id: string, params?: CampaignLogsParams) => Promise<void>;
 
-  // Polling Actions / Acciones de polling
-  startPolling: (campaignId: string, intervalMs?: number) => void;
-  stopPolling: () => void;
+  // (Polling actions moved to hooks/usePolling.ts)
 
   // Utils
   clearErrors: () => void;
@@ -98,7 +95,6 @@ const initialState = {
   error: null,
   templateError: null,
   campaignError: null,
-  pollingInterval: null,
 };
 
 // ============================================
@@ -283,39 +279,6 @@ export const useEmailCampaignStore = create<EmailCampaignState>((set, get) => ({
   },
 
   // ==========================================
-  // Polling Actions / Acciones de polling
-  // ==========================================
-
-  /**
-   * Start polling campaign stats every N ms (default 10s)
-   * Iniciar polling de estadísticas de campaña cada N ms (default 10s)
-   */
-  startPolling: (campaignId: string, intervalMs = 10_000) => {
-    const state = get();
-    if (state.pollingInterval) {
-      clearInterval(state.pollingInterval);
-    }
-
-    const interval = setInterval(() => {
-      get().fetchCampaignDetail(campaignId);
-    }, intervalMs);
-
-    set({ pollingInterval: interval });
-  },
-
-  /**
-   * Stop polling
-   * Detener polling
-   */
-  stopPolling: () => {
-    const state = get();
-    if (state.pollingInterval) {
-      clearInterval(state.pollingInterval);
-      set({ pollingInterval: null });
-    }
-  },
-
-  // ==========================================
   // Utils
   // ==========================================
 
@@ -330,10 +293,6 @@ export const useEmailCampaignStore = create<EmailCampaignState>((set, get) => ({
    * Resetear el store al estado inicial
    */
   reset: () => {
-    const state = get();
-    if (state.pollingInterval) {
-      clearInterval(state.pollingInterval);
-    }
     set(initialState);
   },
 }));
@@ -396,8 +355,6 @@ export const useEmailCampaignMonitor = () =>
       fetchCampaignDetail: state.fetchCampaignDetail,
       sendCampaign: state.sendCampaign,
       retryFailed: state.retryFailed,
-      startPolling: state.startPolling,
-      stopPolling: state.stopPolling,
     }))
   );
 

--- a/frontend/src/stores/reservationStore.ts
+++ b/frontend/src/stores/reservationStore.ts
@@ -17,64 +17,25 @@ import type {
 } from '../services/reservationService';
 import type { Property } from '../services/propertyService';
 import type { TourPackage, TourAvailability } from '../services/tourService';
+import type {
+  WizardStep,
+  WizardData,
+  PropertyWizardData,
+  TourWizardData,
+} from '../types/reservation';
 
 // ============================================
-// Types / Tipos
+// Types re-exported / Tipos re-exportados
 // ============================================
-
-/**
- * Wizard step enum (now includes 'payment' for post-confirmation flow)
- * Enum de paso del wizard (ahora incluye 'payment' para flujo post-confirmación)
- */
-export type WizardStep = 'dates' | 'guests' | 'confirm' | 'payment';
-
-/**
- * Wizard data for a property reservation
- * Datos del wizard para reserva de propiedad
- */
-export interface PropertyWizardData {
-  type: 'property';
-  property: Property;
-  checkIn: string;
-  checkOut: string;
-  guests: number;
-  notes: string;
-}
-
-/**
- * Wizard data for a tour reservation
- * Datos del wizard para reserva de tour
- */
-export interface TourWizardData {
-  type: 'tour';
-  tour: TourPackage;
-  availability: TourAvailability;
-  guests: number;
-  notes: string;
-}
-
-export type WizardData = PropertyWizardData | TourWizardData;
-
-/**
- * Computed price breakdown for the current wizard state
- * Desglose de precio calculado para el estado actual del wizard
- */
-export interface PriceBreakdown {
-  /** Price per unit (night for properties, person for tours) / Precio por unidad */
-  pricePerUnit: number;
-  /** Currency code / Código de moneda */
-  currency: string;
-  /** Number of nights (property) or 1 (tour) / Cantidad de noches o 1 */
-  totalNights: number;
-  /** Number of guests / Cantidad de huéspedes */
-  guestCount: number;
-  /** pricePerUnit × totalNights / Subtotal sin multiplicar por huéspedes */
-  subtotal: number;
-  /** pricePerUnit × totalNights × guestCount / Total final */
-  totalPrice: number;
-  /** Whether it's a property (per night) or tour (per person) / Si es propiedad o tour */
-  isProperty: boolean;
-}
+//
+// Types moved to types/reservation.ts — import from there in new code
+// Tipos movidos a types/reservation.ts — importar desde allí en código nuevo
+export type {
+  WizardStep,
+  WizardData,
+  PropertyWizardData,
+  TourWizardData,
+} from '../types/reservation';
 
 /**
  * Reservation store state interface

--- a/frontend/src/types/reservation.ts
+++ b/frontend/src/types/reservation.ts
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview Reservation types — domain types for the reservation wizard
+ * @description Shared types for wizard state, price breakdown, and reservation data.
+ *              Extracted from reservationStore.ts for domain-level reuse.
+ *              Tipos compartidos para estado del wizard, desglose de precio y datos de reserva.
+ * @module types/reservation
+ */
+
+import type { Property } from '../services/propertyService';
+import type { TourPackage, TourAvailability } from '../services/tourService';
+
+// ============================================
+// Wizard Types / Tipos del wizard
+// ============================================
+
+/**
+ * Wizard step enum (includes 'payment' for post-confirmation flow)
+ * Enum de paso del wizard (incluye 'payment' para flujo post-confirmación)
+ */
+export type WizardStep = 'dates' | 'guests' | 'confirm' | 'payment';
+
+/**
+ * Wizard data for a property reservation
+ * Datos del wizard para reserva de propiedad
+ */
+export interface PropertyWizardData {
+  type: 'property';
+  property: Property;
+  checkIn: string;
+  checkOut: string;
+  guests: number;
+  notes: string;
+}
+
+/**
+ * Wizard data for a tour reservation
+ * Datos del wizard para reserva de tour
+ */
+export interface TourWizardData {
+  type: 'tour';
+  tour: TourPackage;
+  availability: TourAvailability;
+  guests: number;
+  notes: string;
+}
+
+export type WizardData = PropertyWizardData | TourWizardData;
+
+// ============================================
+// Price Types / Tipos de precio
+// ============================================
+
+/**
+ * Computed price breakdown for the current wizard state
+ * Desglose de precio calculado para el estado actual del wizard
+ */
+export interface PriceBreakdown {
+  /** Price per unit (night for properties, person for tours) / Precio por unidad */
+  pricePerUnit: number;
+  /** Currency code / Código de moneda */
+  currency: string;
+  /** Number of nights (property) or 1 (tour) / Cantidad de noches o 1 */
+  totalNights: number;
+  /** Number of guests / Cantidad de huéspedes */
+  guestCount: number;
+  /** pricePerUnit × totalNights / Subtotal sin multiplicar por huéspedes */
+  subtotal: number;
+  /** pricePerUnit × totalNights × guestCount / Total final */
+  totalPrice: number;
+  /** Whether it's a property (per night) or tour (per person) / Si es propiedad o tour */
+  isProperty: boolean;
+}

--- a/frontend/src/utils/pricing.ts
+++ b/frontend/src/utils/pricing.ts
@@ -5,7 +5,8 @@
  * @module utils/pricing
  */
 
-import type { WizardData, PriceBreakdown } from '../stores/reservationStore';
+import type { WizardData } from '../stores/reservationStore';
+import type { PriceBreakdown } from '../types/reservation';
 
 /**
  * Calculate the number of days between two date strings


### PR DESCRIPTION
Closes #329

## Summary
- Extract reservation types (WizardStep, WizardData, PriceBreakdown) → `types/reservation.ts`
- Extract cart localStorage persistence → `lib/cartPersistence.ts`
- Merge and enhance `hooks/usePolling.ts` with dual signature
- Remove inline polling from emailCampaignStore — CampaignMonitor uses hook directly
- DRY up cartStore's repeated set pattern with `syncCartState` helper

## Changes

| File | Change |
|------|--------|
| `types/reservation.ts` | New — domain types for reservation wizard |
| `lib/cartPersistence.ts` | New — localStorage CRUD helpers |
| `hooks/usePolling.ts` | Enhanced — dual signature (number | options) |
| `stores/reservationStore.ts` | Types extracted, re-exports for BC |
| `stores/cartStore.ts` | Persistence delegated, DRY set pattern |
| `stores/emailCampaignStore.ts` | Polling actions removed (-43 lines) |
| `components/EmailCampaigns/CampaignMonitor.tsx` | Uses usePolling hook directly |
| `components/reservation/*.tsx` | Updated PriceBreakdown imports |
| `hooks/usePayment.ts`, `hooks/__tests__/usePayment.test.ts` | Updated PriceBreakdown imports |
| `utils/pricing.ts` | Updated PriceBreakdown import |

## Test Plan
- [x] TypeScript: 0 errors (`tsc -b --noEmit`)
- [x] Tests: 71 files, 668 passed (`pnpm test:run`)
- [x] Stores reduced: 1243 → 1126 lines (-117)