### PR TITLE
fix(ci): track .env.production so CI builds resolve the real API base URL (#350)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,8 @@ build/
 .env
 .env.local
 .env.*.local
-.env.production
+# .env.production is TRACKED on purpose: VITE_* vars are public build config
+# (API URL, PWA metadata, VAPID public key) and CI/fresh checkouts need them.
 .env.production.local
 # ===========================================
 # Logs

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,10 @@
+# API URL - Points to backend via Cloudflare Tunnel
+VITE_API_URL=https://api.nexoreal.xyz/api
+
+# PWA Configuration
+VITE_APP_NAME=Nexo Real
+VITE_APP_DESCRIPTION=Nexo Real — Conectamos tu negocio con el mundo
+VITE_APP_THEME_COLOR=#4f46e5
+
+# Push Notifications (VAPID Keys - generate your own)
+VITE_VAPID_PUBLIC_KEY=BP-ZyGBU6k0-ILpbXS7S-KrMix6WHd_AiYDyVq8sWg9Okt1oFchDDA3gCQfG-7udSRmNPnmlk9cIBXB6ZfHORPM


### PR DESCRIPTION
## Problem
19 E2E tests (properties, push-notifications, sprint7-explore, carts) fail only in CI. Root cause: `.env.production` was gitignored, so CI builds fell back to the `/api/v1` default in `client.ts`. The app then fetches `/api/v1/properties`, which never matches the spec inline mock globs (`**/api/properties*` need literal `/api/`) — the shared mock handler answered instead ("Casa en la playa").

## Fix
Track `.env.production` (only public VITE_* build config: API URL, PWA metadata, VAPID public key). Verified no secrets — `VITE_CF_ACCESS_CLIENT_SECRET` stays untracked.

## Evidence
- CI artifact `frontend-dist` (run 30677862910): no `api.nexoreal.xyz`, has `/api/v1` fallback → confirmed missing env
- Local runs pass because `.env.production` exists on disk

Closes #350