### PR TITLE
fix(e2e): skip backend-dependent push tests in CI, fix auth redirect test (#349 #353)

### DIFF
--- a/frontend/e2e/push-notifications.spec.ts
+++ b/frontend/e2e/push-notifications.spec.ts
@@ -123,6 +123,10 @@ test.describe('Push Notifications', () => {
   });
 
   test('should handle push subscription API errors gracefully', async ({ page }) => {
+    // Requires a real backend on localhost:3000 (vite preview proxy target).
+    // The CI runner has no backend, so the proxy returns 502. See #353.
+    test.skip(process.env.CI === 'true', 'requires local backend via vite preview proxy');
+
     // Go to app (not logged in - push subscription requires auth)
     await page.goto(baseURL, { waitUntil: 'networkidle' });
 
@@ -156,6 +160,10 @@ test.describe('Push Notifications', () => {
   });
 
   test('should be able to fetch VAPID public key from backend', async ({ page }) => {
+    // Requires a real backend on localhost:3000 (vite preview proxy target).
+    // The CI runner has no backend, so the proxy returns 502. See #353.
+    test.skip(process.env.CI === 'true', 'requires local backend via vite preview proxy');
+
     // The VAPID public key endpoint should be public
     const response = await page.request.get(`${baseURL}/api/push/vapid-public-key`);
 
@@ -168,6 +176,10 @@ test.describe('Push Notifications', () => {
   });
 
   test('should handle landing page API for products', async ({ page }) => {
+    // Requires a real backend on localhost:3000 (vite preview proxy target).
+    // The CI runner has no backend, so the proxy returns 502. See #353.
+    test.skip(process.env.CI === 'true', 'requires local backend via vite preview proxy');
+
     // Go to a product landing page
     // First we need a product ID - let's try a sample UUID format
     const productId = '00000000-0000-0000-0000-000000000001';
@@ -183,6 +195,10 @@ test.describe('Push Notifications', () => {
   });
 
   test('should handle public profile products API', async ({ page }) => {
+    // Requires a real backend on localhost:3000 (vite preview proxy target).
+    // The CI runner has no backend, so the proxy returns 502. See #353.
+    test.skip(process.env.CI === 'true', 'requires local backend via vite preview proxy');
+
     // Try to fetch products for a sample referral code
     const response = await page.request.get(`${baseURL}/api/public/profile/TESTCODE/products`);
 

--- a/frontend/e2e/tree.spec.ts
+++ b/frontend/e2e/tree.spec.ts
@@ -174,8 +174,24 @@ test.describe('TreeView', () => {
  */
 test.describe('TreeView - Auth Required', () => {
   test('should redirect to login when not authenticated', async ({ page }) => {
-    // Clear any existing session
-    await page.context().clearCookies();
+    // Clear auth state BEFORE any page JS runs: storageState injects a token
+    // and user cache into localStorage, and clearCookies() does not touch
+    // localStorage, so without this the app considers the session valid.
+    await page.addInitScript(() => {
+      localStorage.removeItem('token');
+      localStorage.removeItem('mlm_user_cache');
+      sessionStorage.clear();
+    });
+    // Override auth/me to 401 so the app does not authenticate via the
+    // shared mock handler (which returns 200 for the admin user).
+    await page.route('**/api/auth/me', async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: false, error: 'Unauthorized' }),
+      });
+    });
+
     await page.goto(`${baseURL}/tree`);
     await page.waitForLoadState('networkidle');
 


### PR DESCRIPTION
## Changes
- **push-notifications.spec.ts** (#353): 4 tests hit `${baseURL}/api/*` with `page.request` — the vite preview proxy forwards those to `localhost:3000`, which does not exist on the CI runner → 502. Added `test.skip(process.env.CI === 'true', ...)` (they still run locally against the Docker backend).
- **tree.spec.ts** (#349): the 'not authenticated' test only cleared cookies, but `storageState` injects the token + user cache into localStorage. Now clears auth state via `addInitScript` before any page JS and mocks `/api/auth/me` → 401.

## Evidence
- Local: push-notifications 5 passed / 5 skipped; with `CI=true` simulated: 9 skipped / 1 passed
- tree auth test passes in both modes
- eslint: 0 errors

Closes #349
Closes #353