### PR TITLE
fix(frontend): not-found state + retryable error in detail pages

### DIFF
--- a/frontend/src/lib/error.ts
+++ b/frontend/src/lib/error.ts
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Shared HTTP error helpers
+ * @description Utilities to extract the HTTP status from errors thrown by the API
+ *              client (axios) and to distinguish "not found" from real failures.
+ *
+ *              Utilidades para extraer el status HTTP de los errores lanzados por
+ *              el cliente de API (axios) y para distinguir "no encontrado" de fallos reales.
+ * @module lib/error
+ * @author Nexo Real Development Team
+ */
+
+import axios from 'axios';
+
+/**
+ * Extract the HTTP status from an unknown error when the API client threw an
+ * AxiosError (e.g. 400 VALIDATION_ERROR or 404). Returns undefined otherwise.
+ * Extrae el status HTTP de un error desconocido cuando el cliente de API lanzó
+ * un AxiosError (ej. 400 VALIDATION_ERROR o 404). Devuelve undefined en otro caso.
+ * @param {unknown} error - The caught error / El error capturado
+ * @returns {number | undefined} HTTP status / Status HTTP
+ */
+export function getHttpStatus(error: unknown): number | undefined {
+  return axios.isAxiosError(error) ? error.response?.status : undefined;
+}
+
+/**
+ * Whether the error means the requested resource does not exist.
+ * The backend answers 400 VALIDATION_ERROR for malformed UUIDs and 404 for
+ * missing records, so both count as "not found" for the UI.
+ * Determina si el error significa que el recurso solicitado no existe.
+ * El backend responde 400 VALIDATION_ERROR para UUIDs malformados y 404 para
+ * registros inexistentes, por lo que ambos cuentan como "no encontrado" en la UI.
+ * @param {unknown} error - The caught error / El error capturado
+ * @returns {boolean} True if the error is a 400/404 / True si el error es 400/404
+ */
+export function isNotFoundError(error: unknown): boolean {
+  const status = getHttpStatus(error);
+  return status === 400 || status === 404;
+}

--- a/frontend/src/pages/PropertyDetailPage.tsx
+++ b/frontend/src/pages/PropertyDetailPage.tsx
@@ -12,7 +12,7 @@
  * @author Nexo Real Development Team
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { Helmet } from 'react-helmet-async';
@@ -26,11 +26,14 @@ import {
   ChevronRight,
   Check,
   Lock,
+  SearchX,
+  RefreshCw,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { propertyService } from '../services/propertyService';
 import type { Property, PropertyType } from '../services/propertyService';
 import { useReservationStore } from '../stores/reservationStore';
+import { isNotFoundError } from '../lib/error';
 import { cn } from '../lib/utils';
 import { APP_URL, APP_OG_DEFAULT_IMAGE } from '../config/app.config';
 
@@ -181,8 +184,15 @@ export default function PropertyDetailPage() {
   const [property, setProperty] = useState<Property | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isNotFound, setIsNotFound] = useState(false);
 
-  useEffect(() => {
+  /**
+   * Load the property for the current URL id.
+   * Stable callback so the Retry button can re-trigger the fetch without a reload.
+   * Carga la propiedad del id actual de la URL.
+   * Callback estable para que el botón Reintentar pueda re-disparar la carga sin recargar.
+   */
+  const loadProperty = useCallback(() => {
     if (!id) return;
 
     let cancelled = false;
@@ -193,11 +203,13 @@ export default function PropertyDetailPage() {
         if (!cancelled) {
           setProperty(data);
           setError(null);
+          setIsNotFound(false);
         }
       })
-      .catch(() => {
+      .catch((err: unknown) => {
         if (!cancelled) {
           setError('No se pudo cargar la propiedad. Verificá que el ID sea correcto.');
+          setIsNotFound(isNotFoundError(err));
         }
       })
       .finally(() => {
@@ -211,19 +223,58 @@ export default function PropertyDetailPage() {
     };
   }, [id]);
 
+  useEffect(() => {
+    const cancel = loadProperty();
+    return cancel;
+  }, [loadProperty]);
+
   if (isLoading) return <PropertyDetailSkeleton />;
 
-  if (error || !property) {
+  // Not found state (400/404 from the API) / Estado "no encontrado" (400/404 de la API)
+  if (isNotFound) {
     return (
       <div className="max-w-5xl mx-auto px-4 py-20 text-center">
-        <p className="text-red-500 mb-4">{error ?? 'Propiedad no encontrada'}</p>
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 mb-6">
+          <SearchX className="w-8 h-8 text-slate-400" />
+        </div>
+        <h1 className="text-2xl font-bold text-slate-800 mb-2">No encontramos lo que buscás</h1>
+        <p className="max-w-md mx-auto text-slate-500 mb-8">
+          La propiedad que buscás no existe o ya no está disponible.
+        </p>
         <Button
-          variant="ghost"
           onClick={() => navigate('/properties')}
-          className="text-emerald-600 hover:underline text-sm"
+          className="bg-emerald-600 text-white hover:bg-emerald-700"
         >
           Volver al listado
         </Button>
+      </div>
+    );
+  }
+
+  // Retryable error state (network, 5xx, etc.) / Estado de error reintentable (red, 5xx, etc.)
+  if (error || !property) {
+    return (
+      <div className="max-w-5xl mx-auto px-4 py-20 text-center">
+        <p className="text-red-500 mb-6">{error ?? 'Propiedad no encontrada'}</p>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+          <Button
+            onClick={() => {
+              setIsLoading(true);
+              loadProperty();
+            }}
+            className="bg-emerald-600 text-white hover:bg-emerald-700"
+          >
+            <RefreshCw className="w-4 h-4 mr-2" />
+            Reintentar
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => navigate('/properties')}
+            className="text-emerald-600 hover:underline text-sm"
+          >
+            Volver al listado
+          </Button>
+        </div>
       </div>
     );
   }

--- a/frontend/src/pages/TourDetailPage.tsx
+++ b/frontend/src/pages/TourDetailPage.tsx
@@ -12,7 +12,7 @@
  * @author Nexo Real Development Team
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { Helmet } from 'react-helmet-async';
@@ -29,11 +29,14 @@ import {
   Compass,
   AlertTriangle,
   Lock,
+  SearchX,
+  RefreshCw,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { tourService } from '../services/tourService';
 import type { TourPackage, TourCategory, TourAvailability } from '../services/tourService';
 import { useReservationStore } from '../stores/reservationStore';
+import { isNotFoundError } from '../lib/error';
 import { cn } from '../lib/utils';
 import { APP_URL, APP_OG_DEFAULT_IMAGE } from '../config/app.config';
 
@@ -212,8 +215,15 @@ export default function TourDetailPage() {
   const [selectedAvailability, setSelectedAvailability] = useState<TourAvailability | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isNotFound, setIsNotFound] = useState(false);
 
-  useEffect(() => {
+  /**
+   * Load the tour for the current URL id.
+   * Stable callback so the Retry button can re-trigger the fetch without a reload.
+   * Carga el tour del id actual de la URL.
+   * Callback estable para que el botón Reintentar pueda re-disparar la carga sin recargar.
+   */
+  const loadTour = useCallback(() => {
     if (!id) return;
 
     let cancelled = false;
@@ -224,11 +234,13 @@ export default function TourDetailPage() {
         if (!cancelled) {
           setTour(data);
           setError(null);
+          setIsNotFound(false);
         }
       })
-      .catch(() => {
+      .catch((err: unknown) => {
         if (!cancelled) {
           setError('No se pudo cargar el tour.');
+          setIsNotFound(isNotFoundError(err));
         }
       })
       .finally(() => {
@@ -242,19 +254,58 @@ export default function TourDetailPage() {
     };
   }, [id]);
 
+  useEffect(() => {
+    const cancel = loadTour();
+    return cancel;
+  }, [loadTour]);
+
   if (isLoading) return <TourDetailSkeleton />;
 
-  if (error || !tour) {
+  // Not found state (400/404 from the API) / Estado "no encontrado" (400/404 de la API)
+  if (isNotFound) {
     return (
       <div className="max-w-5xl mx-auto px-4 py-20 text-center">
-        <p className="text-red-500 mb-4">{error ?? 'Tour no encontrado'}</p>
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-slate-100 mb-6">
+          <SearchX className="w-8 h-8 text-slate-400" />
+        </div>
+        <h1 className="text-2xl font-bold text-slate-800 mb-2">No encontramos lo que buscás</h1>
+        <p className="max-w-md mx-auto text-slate-500 mb-8">
+          El tour que buscás no existe o ya no está disponible.
+        </p>
         <Button
-          variant="ghost"
           onClick={() => navigate('/tours')}
-          className="text-emerald-600 hover:underline text-sm"
+          className="bg-emerald-600 text-white hover:bg-emerald-700"
         >
           Volver al listado
         </Button>
+      </div>
+    );
+  }
+
+  // Retryable error state (network, 5xx, etc.) / Estado de error reintentable (red, 5xx, etc.)
+  if (error || !tour) {
+    return (
+      <div className="max-w-5xl mx-auto px-4 py-20 text-center">
+        <p className="text-red-500 mb-6">{error ?? 'Tour no encontrado'}</p>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+          <Button
+            onClick={() => {
+              setIsLoading(true);
+              loadTour();
+            }}
+            className="bg-emerald-600 text-white hover:bg-emerald-700"
+          >
+            <RefreshCw className="w-4 h-4 mr-2" />
+            Reintentar
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => navigate('/tours')}
+            className="text-emerald-600 hover:underline text-sm"
+          >
+            Volver al listado
+          </Button>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Changes
- `src/lib/error.ts` (new): `getHttpStatus`/`isNotFoundError` helpers (axios-based; 400 + 404 → not found)
- `src/pages/TourDetailPage.tsx` + `src/pages/PropertyDetailPage.tsx`: split the single error branch into:
  - **Not found** (400/404): icon + 'No encontramos lo que buscás' + CTA back to list
  - **Retryable error** (network/5xx): message + 'Reintentar' (refetch via stable `useCallback`) + back to list
- Load logic extracted to a stable callback so Retry works without reload; loading skeleton, SEO/Helmet and normal render untouched.

## Why
The backend answers `400 VALIDATION_ERROR` for malformed UUIDs (e.g. `00000000-...`) and 404 for missing records. Both pages previously rendered a bare red line for any failure.

## Evidence
- `pnpm tsc --noEmit`: clean
- eslint: 0 errors
- `pnpm build`: ok (PWA 84 entries)
- `pnpm exec playwright test tours.spec.ts properties.spec.ts`: **54 passed (2.8m)**