### PR TITLE
fix(migrations): 17 migraciones legacy MySQL → PostgreSQL compatibles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
     branches: [development]
     tags-ignore: ['v*']
   pull_request:
-    branches: [main, release]
+    branches: [main, release, development, 'feature/**']
+  workflow_dispatch:
 
 # Cancel duplicate runs for the same branch/PR
 concurrency:

--- a/backend/database/migrations/20260325000001-create-products.js
+++ b/backend/database/migrations/20260325000001-create-products.js
@@ -24,7 +24,8 @@ module.exports = {
           'hbo_max',
           'amazon_prime',
           'youtube_premium',
-          'apple_tv'
+          'apple_tv',
+          'other'
         ),
         allowNull: false,
       },
@@ -55,7 +56,7 @@ module.exports = {
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
     });
 

--- a/backend/database/migrations/20260325000002-create-orders.js
+++ b/backend/database/migrations/20260325000002-create-orders.js
@@ -74,7 +74,7 @@ module.exports = {
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
     });
 

--- a/backend/database/migrations/20260326000001-update-orders-status-enum.js
+++ b/backend/database/migrations/20260326000001-update-orders-status-enum.js
@@ -2,50 +2,95 @@
 
 module.exports = {
   async up(queryInterface, Sequelize) {
-    // 1. Change status ENUM
-    await queryInterface.changeColumn('orders', 'status', {
-      type: Sequelize.ENUM('pending', 'completed', 'failed'),
-      allowNull: false,
-      defaultValue: 'pending',
-    });
+    // sequelize-cli does not wrap migrations in a transaction by default; this migration
+    // rewrites columns and enum types, so it must be atomic — wrap everything explicitly.
+    const t = await queryInterface.sequelize.transaction();
+    const sql = (q) => queryInterface.sequelize.query(q, { transaction: t });
+    try {
+      // 1. Change status ENUM: ('pending','completed','cancelled','refunded') → ('pending','completed','failed')
+      //    PostgreSQL cannot change an enum's value list in place. Sequelize's changeColumn with an
+      //    ENUM type calls pgEnum(), whose CREATE TYPE silently swallows duplicate_object — so the
+      //    column would keep the old values while the migration "succeeds". Use the rename dance:
+      //    create the new type, cast the column, drop the old type. All statements are transactional
+      //    (no ALTER TYPE ... ADD VALUE involved).
+      await sql('ALTER TABLE "orders" ALTER COLUMN "status" DROP DEFAULT;');
+      await sql('ALTER TYPE "enum_orders_status" RENAME TO "enum_orders_status_old";');
+      await sql(`CREATE TYPE "enum_orders_status" AS ENUM ('pending', 'completed', 'failed');`);
+      await sql(
+        `ALTER TABLE "orders" ALTER COLUMN "status" TYPE "enum_orders_status" USING "status"::text::"enum_orders_status";`
+      );
+      await sql(`ALTER TABLE "orders" ALTER COLUMN "status" SET DEFAULT 'pending';`);
+      await sql(`DROP TYPE "enum_orders_status_old";`);
 
-    // 2. Rename column amount to total_amount
-    await queryInterface.renameColumn('orders', 'amount', 'total_amount');
+      // 2. Rename column amount to total_amount
+      await queryInterface.renameColumn('orders', 'amount', 'total_amount', { transaction: t });
 
-    // 3. Change payment_method column to ENUM
-    await queryInterface.changeColumn('orders', 'payment_method', {
-      type: Sequelize.ENUM('manual', 'simulated'),
-      allowNull: false,
-      defaultValue: 'simulated',
-    });
+      // 3. Change payment_method column to ENUM, aligned with the Order model.
+      //    Plain changeColumn() fails on PG ("default ... cannot be cast automatically"):
+      //    it emits SET DEFAULT before the TYPE cast. Order the statements manually.
+      await sql('ALTER TABLE "orders" ALTER COLUMN "payment_method" DROP DEFAULT;');
+      await sql('ALTER TABLE "orders" ALTER COLUMN "payment_method" SET NOT NULL;');
+      await sql(
+        `CREATE TYPE "enum_orders_payment_method" AS ENUM ('manual', 'simulated', 'paypal', 'mercadopago');`
+      );
+      await sql(
+        `ALTER TABLE "orders" ALTER COLUMN "payment_method" TYPE "enum_orders_payment_method" USING "payment_method"::text::"enum_orders_payment_method";`
+      );
+      await sql(`ALTER TABLE "orders" ALTER COLUMN "payment_method" SET DEFAULT 'simulated';`);
 
-    // 4. Add notes column
-    await queryInterface.addColumn('orders', 'notes', {
-      type: Sequelize.TEXT,
-      allowNull: true,
-    });
+      // 4. Add notes column
+      await queryInterface.addColumn(
+        'orders',
+        'notes',
+        { type: Sequelize.TEXT, allowNull: true },
+        { transaction: t }
+      );
 
-    // 5. Remove extra columns if they exist (transaction_id, stream_url, stream_token, expires_at)
-    // Since these columns may not exist, we check for them in a safe way.
-    // We'll attempt to remove them; if they don't exist, the operation will fail but we can ignore.
-    // For simplicity, we'll skip removal for now as they are not in the migration.
+      // 5. Remove extra columns if they exist (transaction_id, stream_url, stream_token, expires_at)
+      // Since these columns may not exist, we check for them in a safe way.
+      // We'll attempt to remove them; if they don't exist, the operation will fail but we can ignore.
+      // For simplicity, we'll skip removal for now as they are not in the migration.
+
+      await t.commit();
+    } catch (error) {
+      await t.rollback();
+      throw error;
+    }
   },
 
   async down(queryInterface, Sequelize) {
-    // Revert changes
-    await queryInterface.changeColumn('orders', 'status', {
-      type: Sequelize.ENUM('pending', 'completed', 'cancelled', 'refunded'),
-      allowNull: false,
-      defaultValue: 'pending',
-    });
+    const t = await queryInterface.sequelize.transaction();
+    const sql = (q) => queryInterface.sequelize.query(q, { transaction: t });
+    try {
+      // Restore the original 4-value status ENUM (rename dance, mirrored from up())
+      await sql('ALTER TABLE "orders" ALTER COLUMN "status" DROP DEFAULT;');
+      await sql('ALTER TYPE "enum_orders_status" RENAME TO "enum_orders_status_tmp";');
+      await sql(
+        `CREATE TYPE "enum_orders_status" AS ENUM ('pending', 'completed', 'cancelled', 'refunded');`
+      );
+      await sql(
+        `ALTER TABLE "orders" ALTER COLUMN "status" TYPE "enum_orders_status" USING "status"::text::"enum_orders_status";`
+      );
+      await sql(`ALTER TABLE "orders" ALTER COLUMN "status" SET DEFAULT 'pending';`);
+      await sql(`DROP TYPE "enum_orders_status_tmp";`);
 
-    await queryInterface.renameColumn('orders', 'total_amount', 'amount');
+      await queryInterface.renameColumn('orders', 'total_amount', 'amount', { transaction: t });
 
-    await queryInterface.changeColumn('orders', 'payment_method', {
-      type: Sequelize.STRING(50),
-      allowNull: true,
-    });
+      // Restore payment_method to its original VARCHAR(50) nullable form (enum → varchar
+      // needs an explicit USING cast; changeColumn() emits none and would fail).
+      await sql('ALTER TABLE "orders" ALTER COLUMN "payment_method" DROP DEFAULT;');
+      await sql('ALTER TABLE "orders" ALTER COLUMN "payment_method" DROP NOT NULL;');
+      await sql(
+        `ALTER TABLE "orders" ALTER COLUMN "payment_method" TYPE VARCHAR(50) USING "payment_method"::text;`
+      );
+      await sql(`DROP TYPE IF EXISTS "enum_orders_payment_method";`);
 
-    await queryInterface.removeColumn('orders', 'notes');
+      await queryInterface.removeColumn('orders', 'notes', { transaction: t });
+
+      await t.commit();
+    } catch (error) {
+      await t.rollback();
+      throw error;
+    }
   },
 };

--- a/backend/database/migrations/20260331223551-create-push-subscriptions.js
+++ b/backend/database/migrations/20260331223551-create-push-subscriptions.js
@@ -49,7 +49,7 @@ module.exports = {
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
     });
 

--- a/backend/database/migrations/20260403120000-create-achievements.js
+++ b/backend/database/migrations/20260403120000-create-achievements.js
@@ -69,7 +69,7 @@ module.exports = {
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
     });
 

--- a/backend/database/migrations/20260403120001-create-badges.js
+++ b/backend/database/migrations/20260403120001-create-badges.js
@@ -41,7 +41,7 @@ module.exports = {
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
     });
 

--- a/backend/database/migrations/20260403120002-create-user-achievements.js
+++ b/backend/database/migrations/20260403120002-create-user-achievements.js
@@ -53,7 +53,7 @@ module.exports = {
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
     });
 

--- a/backend/database/migrations/20260404123836-create-shipping-addresses.js
+++ b/backend/database/migrations/20260404123836-create-shipping-addresses.js
@@ -73,7 +73,7 @@ module.exports = {
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
     });
 

--- a/backend/database/migrations/20260404123837-create-delivery-providers.js
+++ b/backend/database/migrations/20260404123837-create-delivery-providers.js
@@ -49,7 +49,7 @@ module.exports = {
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
     });
 

--- a/backend/database/migrations/20260404123838-create-shipment-trackings.js
+++ b/backend/database/migrations/20260404123838-create-shipment-trackings.js
@@ -69,7 +69,7 @@ module.exports = {
       updated_at: {
         type: Sequelize.DATE,
         allowNull: false,
-        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
       },
     });
 

--- a/backend/src/__tests__/unit/migrations/legacy-migrations-full-chain.test.ts
+++ b/backend/src/__tests__/unit/migrations/legacy-migrations-full-chain.test.ts
@@ -1,0 +1,297 @@
+/**
+ * @fileoverview Integration tests: the full legacy migration chain runs end-to-end on PostgreSQL
+ * @description PR 0b of the wallet-integration change (issue #358). `db:migrate` was blocked by
+ *              17 legacy migrations written in MySQL dialect — the first one
+ *              (`create-products`) aborts with a PostgreSQL syntax error on
+ *              `CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`.
+ *
+ *              This test spawns the real sequelize-cli against a clean temporary PostgreSQL
+ *              database and proves the whole chain applies in order, is idempotent, rolls back,
+ *              and produces a schema aligned with the Sequelize models.
+ *
+ *              NOTE — base tables: this repository has never had create-migrations for the core
+ *              tables (users, purchases, commissions, commission_configs, leads,
+ *              withdrawal_requests); they are created by `sequelize.sync()` at app startup
+ *              (commit 0a82a08 even deleted 28 migrations). The migration chain is therefore
+ *              partial by design and runs on top of a sync-created base schema. The test
+ *              bootstraps exactly those base tables (with the columns the chain touches) to
+ *              reproduce that state, then runs the real migrations.
+ *
+ * @module __tests__/unit/migrations/legacy-migrations-full-chain
+ * @issue #358 — Fix 17 legacy MySQL migrations to PostgreSQL
+ */
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Client } from 'pg';
+
+const BACKEND_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const SEQUELIZE_CLI_BIN = path.join(
+  BACKEND_ROOT,
+  'node_modules',
+  'sequelize-cli',
+  'lib',
+  'sequelize'
+);
+const REAL_MIGRATIONS_DIR = path.join(BACKEND_ROOT, 'database', 'migrations');
+
+const LEGACY_MIGRATION_FILES = [
+  '20260325000001-create-products.js',
+  '20260325000002-create-orders.js',
+  '20260325000003-add-product-id-to-purchases.js',
+  '20260326000001-update-orders-status-enum.js',
+  '20260328062957-addBusinessTypeToPurchases.js',
+  '20260331223551-create-push-subscriptions.js',
+  '20260403120000-create-achievements.js',
+  '20260403120001-create-badges.js',
+  '20260403120002-create-user-achievements.js',
+  '20260403120003-add-login-tracking-to-users.js',
+  '20260404123835-add-shipping-fields-to-orders.js',
+  '20260404123836-create-shipping-addresses.js',
+  '20260404123837-create-delivery-providers.js',
+  '20260404123838-create-shipment-trackings.js',
+  '20260409000000-add-whatsapp-bot-source.js',
+  '20260412000001-commission-type-to-varchar.js',
+  '20260412000002-seed-unilevel-commission-configs.js',
+];
+
+interface DbConfig {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+}
+
+function runtimeDbConfig(): DbConfig {
+  return {
+    host: process.env.TEST_DB_HOST || process.env.DB_HOST || 'localhost',
+    port: Number(process.env.TEST_DB_PORT || process.env.DB_PORT || '5434'),
+    user: process.env.TEST_DB_USER || process.env.DB_USER || 'mlm',
+    password: process.env.TEST_DB_PASSWORD || process.env.DB_PASSWORD || 'mlm123',
+    database: process.env.TEST_DB_NAME || process.env.DB_NAME || 'mlm_test',
+  };
+}
+
+/** Maintenance connection (no target database) used to create/drop the temp database. */
+function maintenanceConfig(): DbConfig {
+  return { ...runtimeDbConfig(), database: 'postgres' };
+}
+
+function postgresReachableSync(): boolean {
+  const { host, port } = runtimeDbConfig();
+  const probe = spawnSync(
+    process.execPath,
+    [
+      '--input-type=commonjs',
+      '-e',
+      [
+        'const net = require("node:net");',
+        `const socket = net.connect({ host: ${JSON.stringify(host)}, port: ${port} });`,
+        'socket.setTimeout(3000);',
+        "socket.once('connect', () => { socket.destroy(); process.exit(0); });",
+        "socket.once('error', () => process.exit(1));",
+        "socket.once('timeout', () => { socket.destroy(); process.exit(1); });",
+      ].join('\n'),
+    ],
+    { timeout: 10000, encoding: 'utf8' }
+  );
+  return probe.status === 0;
+}
+
+interface CliResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: string[]): CliResult {
+  const result = spawnSync(process.execPath, [SEQUELIZE_CLI_BIN, ...args], {
+    cwd: BACKEND_ROOT,
+    env: { ...process.env, NODE_ENV: 'test' },
+    encoding: 'utf8',
+    timeout: 120000,
+  });
+  return { status: result.status, stdout: result.stdout || '', stderr: result.stderr || '' };
+}
+
+/**
+ * Base schema the app normally creates via sequelize.sync() — see file header.
+ * Columns are the minimal surface the migration chain touches.
+ */
+const BASE_SCHEMA_SQL = [
+  'CREATE TABLE "users" ("id" UUID PRIMARY KEY);',
+  'CREATE TABLE "purchases" ("id" UUID PRIMARY KEY);',
+  'CREATE TABLE "commissions" ("id" UUID PRIMARY KEY, "type" VARCHAR(20) NOT NULL);',
+  `CREATE TABLE "commission_configs" (
+     "id" UUID PRIMARY KEY,
+     "business_type" VARCHAR(50) NOT NULL,
+     "level" VARCHAR(20) NOT NULL,
+     "percentage" NUMERIC(10,4) NOT NULL,
+     "is_active" BOOLEAN NOT NULL DEFAULT true,
+     "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+     "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+   );`,
+  `CREATE TYPE "enum_leads_source" AS ENUM ('website','referral','social','landing_page','manual','other');`,
+  `CREATE TABLE "leads" ("id" UUID PRIMARY KEY, "source" "enum_leads_source" NOT NULL DEFAULT 'website');`,
+  'CREATE TABLE "withdrawal_requests" ("id" UUID PRIMARY KEY);',
+];
+
+async function withPg<T>(config: DbConfig, fn: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client(config);
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.end();
+  }
+}
+
+describe('legacy migration chain (17) runs end-to-end on PostgreSQL', () => {
+  const postgresReachable = postgresReachableSync();
+  const pgTest = postgresReachable ? it : it.skip;
+
+  const tempDbName = `mlm_test_mig0b_${process.pid}_${Date.now()}`;
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mlm-migration-chain-'));
+  let tempOptionsPath = '';
+
+  beforeAll(async () => {
+    if (!postgresReachable) return;
+
+    // 1. Clean temp database (drop leftovers from a crashed run, then recreate).
+    await withPg(maintenanceConfig(), async (client) => {
+      await client.query(`DROP DATABASE IF EXISTS "${tempDbName}" WITH (FORCE)`);
+      await client.query(`CREATE DATABASE "${tempDbName}"`);
+    });
+
+    // 2. Bootstrap the base tables that sequelize.sync() normally creates.
+    const tempDb = { ...runtimeDbConfig(), database: tempDbName };
+    await withPg(tempDb, async (client) => {
+      for (const statement of BASE_SCHEMA_SQL) {
+        await client.query(statement);
+      }
+    });
+
+    // 3. Temp --options-path pointing at the REAL migrations dir + the temp DB.
+    const configPath = path.join(tempDir, 'config.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        test: {
+          username: tempDb.user,
+          password: tempDb.password,
+          database: tempDb.database,
+          host: tempDb.host,
+          port: tempDb.port,
+          dialect: 'postgres',
+          logging: false,
+        },
+      })
+    );
+    tempOptionsPath = path.join(tempDir, 'options.json');
+    fs.writeFileSync(
+      tempOptionsPath,
+      JSON.stringify({
+        config: configPath,
+        'migrations-path': REAL_MIGRATIONS_DIR,
+        'seeders-path': path.join(BACKEND_ROOT, 'database', 'seeders'),
+        'models-path': path.join(BACKEND_ROOT, 'src', 'models'),
+      })
+    );
+  });
+
+  afterAll(async () => {
+    if (!postgresReachable) return;
+    await withPg(maintenanceConfig(), async (client) => {
+      await client.query(`DROP DATABASE IF EXISTS "${tempDbName}" WITH (FORCE)`);
+    }).catch(() => {});
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  pgTest('applies all 17 legacy migrations in order without PostgreSQL syntax errors', async () => {
+    const result = runCli(['db:migrate', '--options-path', tempOptionsPath]);
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toMatch(/syntax error|ReferenceError|ES module scope/i);
+    expect(result.stderr).not.toMatch(/ON UPDATE/i);
+
+    await withPg({ ...runtimeDbConfig(), database: tempDbName }, async (client) => {
+      const meta = await client.query('SELECT name FROM "SequelizeMeta" ORDER BY name');
+      const applied = meta.rows.map((r: { name: string }) => r.name);
+      expect(applied).toEqual(LEGACY_MIGRATION_FILES);
+
+      // products.updated_at must not carry the MySQL ON UPDATE clause.
+      const def = await client.query(
+        `SELECT column_default FROM information_schema.columns
+           WHERE table_name = 'products' AND column_name = 'updated_at'`
+      );
+      expect(def.rows[0].column_default).not.toMatch(/ON UPDATE/i);
+
+      // orders.status enum must now be (pending, completed, failed) — the
+      // MySQL-era changeColumn() no-ops on PG, the raw-SQL dance must not.
+      const statusEnum = await client.query(
+        `SELECT e.enumlabel FROM pg_enum e
+           WHERE e.enumtypid = 'enum_orders_status'::regtype
+           ORDER BY e.enumsortorder`
+      );
+      expect(statusEnum.rows.map((r: { enumlabel: string }) => r.enumlabel)).toEqual([
+        'pending',
+        'completed',
+        'failed',
+      ]);
+
+      // orders.payment_method aligned with the Order model (4 values).
+      const paymentEnum = await client.query(
+        `SELECT e.enumlabel FROM pg_enum e
+           WHERE e.enumtypid = 'enum_orders_payment_method'::regtype
+           ORDER BY e.enumsortorder`
+      );
+      expect(paymentEnum.rows.map((r: { enumlabel: string }) => r.enumlabel)).toEqual([
+        'manual',
+        'simulated',
+        'paypal',
+        'mercadopago',
+      ]);
+
+      // commissions.type converted to VARCHAR(20).
+      const commissionType = await client.query(
+        `SELECT data_type, character_maximum_length FROM information_schema.columns
+           WHERE table_name = 'commissions' AND column_name = 'type'`
+      );
+      expect(commissionType.rows[0].data_type).toBe('character varying');
+
+      // whatsapp_bot added to enum_leads_source.
+      const whatsapp = await client.query(
+        `SELECT 1 FROM pg_enum e WHERE e.enumtypid = 'enum_leads_source'::regtype
+           AND e.enumlabel = 'whatsapp_bot'`
+      );
+      expect(whatsapp.rows.length).toBe(1);
+
+      // Seed migration inserted the 10 default unilevel rates.
+      const seeded = await client.query(
+        `SELECT count(*)::int AS n FROM "commission_configs" WHERE "business_type" = 'membresia'`
+      );
+      expect(seeded.rows[0].n).toBe(10);
+    });
+  });
+
+  pgTest('is idempotent: a second db:migrate run executes nothing', async () => {
+    const result = runCli(['db:migrate', '--options-path', tempOptionsPath]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/No migrations were executed/);
+  });
+
+  pgTest('rolls the last migration back with db:migrate:undo (down)', async () => {
+    const result = runCli(['db:migrate:undo', '--options-path', tempOptionsPath]);
+    expect(result.status).toBe(0);
+    await withPg({ ...runtimeDbConfig(), database: tempDbName }, async (client) => {
+      const seeded = await client.query(
+        `SELECT count(*)::int AS n FROM "commission_configs" WHERE "business_type" = 'membresia'`
+      );
+      expect(seeded.rows[0].n).toBe(0);
+      const meta = await client.query('SELECT name FROM "SequelizeMeta"');
+      expect(meta.rows.length).toBe(LEGACY_MIGRATION_FILES.length - 1);
+    });
+  });
+});

--- a/backend/src/__tests__/unit/migrations/legacy-migrations-pg-dialect.test.ts
+++ b/backend/src/__tests__/unit/migrations/legacy-migrations-pg-dialect.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @fileoverview Unit tests: legacy migrations must be PostgreSQL-compatible
+ * @description Scans the 17 legacy migrations in backend/database/migrations for
+ *              MySQL-only constructs that PostgreSQL rejects. The known blocker
+ *              (issue #358): `CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP` in the
+ *              `updated_at` default of the create-table migrations — PostgreSQL has
+ *              no ON UPDATE clause for column defaults and aborts with a syntax
+ *              error, so the first migration (`create-products`) kills `db:migrate`.
+ *
+ *              The scan also locks the contract that timestamp defaults are
+ *              Sequelize literals (not raw strings, which would be quoted as
+ *              text) and that migration enums reproduce the values the Sequelize
+ *              models expect (e.g. products.platform).
+ *
+ * @module __tests__/unit/migrations/legacy-migrations-pg-dialect
+ * @issue #358 — Fix 17 legacy MySQL migrations to PostgreSQL
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { Sequelize } = require('sequelize');
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const createProducts = require('../../../../database/migrations/20260325000001-create-products');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const createOrders = require('../../../../database/migrations/20260325000002-create-orders');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const createPushSubscriptions = require('../../../../database/migrations/20260331223551-create-push-subscriptions');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const createAchievements = require('../../../../database/migrations/20260403120000-create-achievements');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const createBadges = require('../../../../database/migrations/20260403120001-create-badges');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const createUserAchievements = require('../../../../database/migrations/20260403120002-create-user-achievements');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const createShippingAddresses = require('../../../../database/migrations/20260404123836-create-shipping-addresses');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const createDeliveryProviders = require('../../../../database/migrations/20260404123837-create-delivery-providers');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const createShipmentTrackings = require('../../../../database/migrations/20260404123838-create-shipment-trackings');
+
+interface CapturedTable {
+  attributes: Record<string, { type?: { key?: string }; defaultValue?: unknown }>;
+}
+
+function makeCaptureQueryInterface() {
+  const createdTables = new Map<string, CapturedTable>();
+
+  const query = jest.fn().mockResolvedValue([[], {}]);
+  const transaction = {
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const queryInterface = {
+    sequelize: {
+      query,
+      transaction: jest.fn().mockResolvedValue(transaction),
+    },
+    createTable: jest.fn(async (tableName: string, attributes: CapturedTable['attributes']) => {
+      createdTables.set(tableName, { attributes });
+    }),
+    addColumn: jest.fn(),
+    addIndex: jest.fn(),
+    removeIndex: jest.fn(),
+    removeColumn: jest.fn(),
+    dropTable: jest.fn(),
+    changeColumn: jest.fn(),
+    renameColumn: jest.fn(),
+  };
+
+  return { queryInterface, createdTables };
+}
+
+/**
+ * Normalizes a Sequelize default to its raw SQL string.
+ * Sequelize.literal('X') → { val: 'X' }; raw strings pass through unchanged.
+ */
+function defaultSql(defaultValue: unknown): string {
+  if (typeof defaultValue === 'string') return defaultValue;
+  if (defaultValue && typeof defaultValue === 'object' && 'val' in defaultValue) {
+    return String((defaultValue as { val: unknown }).val);
+  }
+  return String(defaultValue);
+}
+
+interface LegacyMigration {
+  up: (queryInterface: Record<string, unknown>, sequelize: typeof Sequelize) => Promise<void>;
+}
+
+const CREATE_TABLE_CASES: Array<{ name: string; migration: LegacyMigration }> = [
+  { name: 'products', migration: createProducts },
+  { name: 'orders', migration: createOrders },
+  { name: 'push_subscriptions', migration: createPushSubscriptions },
+  { name: 'achievements', migration: createAchievements },
+  { name: 'badges', migration: createBadges },
+  { name: 'user_achievements', migration: createUserAchievements },
+  { name: 'shipping_addresses', migration: createShippingAddresses },
+  { name: 'delivery_providers', migration: createDeliveryProviders },
+  { name: 'shipment_trackings', migration: createShipmentTrackings },
+];
+
+describe('Legacy migrations: PostgreSQL dialect scan (issue #358)', () => {
+  describe('timestamp defaults must be PostgreSQL-compatible', () => {
+    for (const { name, migration } of CREATE_TABLE_CASES) {
+      it(`${name}.updated_at must not use MySQL "ON UPDATE CURRENT_TIMESTAMP"`, async () => {
+        const { queryInterface, createdTables } = makeCaptureQueryInterface();
+        await migration.up(queryInterface, Sequelize);
+
+        const table = createdTables.get(name);
+        expect(table).toBeDefined();
+        const updatedAt = table!.attributes.updated_at;
+        expect(updatedAt).toBeDefined();
+        expect(defaultSql(updatedAt!.defaultValue)).not.toMatch(/ON UPDATE/i);
+      });
+
+      it(`${name}.updated_at default must be a Sequelize literal CURRENT_TIMESTAMP`, async () => {
+        const { queryInterface, createdTables } = makeCaptureQueryInterface();
+        await migration.up(queryInterface, Sequelize);
+
+        const table = createdTables.get(name);
+        const updatedAt = table!.attributes.updated_at;
+        expect(defaultSql(updatedAt!.defaultValue)).toBe('CURRENT_TIMESTAMP');
+      });
+
+      it(`${name}.created_at default must be a Sequelize literal CURRENT_TIMESTAMP`, async () => {
+        const { queryInterface, createdTables } = makeCaptureQueryInterface();
+        await migration.up(queryInterface, Sequelize);
+
+        const table = createdTables.get(name);
+        const createdAt = table!.attributes.created_at;
+        expect(createdAt).toBeDefined();
+        expect(defaultSql(createdAt!.defaultValue)).toBe('CURRENT_TIMESTAMP');
+      });
+    }
+  });
+
+  describe('migration enums align with the Sequelize models', () => {
+    it('products.platform enum must include the "other" value from the Product model', async () => {
+      const { queryInterface, createdTables } = makeCaptureQueryInterface();
+      await createProducts.up(queryInterface, Sequelize);
+
+      const platform = createdTables.get('products')!.attributes.platform;
+      const values = (platform!.type as { values?: string[] }).values ?? [];
+      expect(values).toContain('other');
+    });
+  });
+});

--- a/backend/src/__tests__/unit/migrations/migration-runner-esm.test.ts
+++ b/backend/src/__tests__/unit/migrations/migration-runner-esm.test.ts
@@ -218,10 +218,14 @@ describe('migration runner (sequelize-cli under Node ESM)', () => {
 
     beforeAll(async () => {
       if (!postgresReachable) return;
-      // Remove residue from a previous failed run.
+      // Remove residue from a previous failed run. SequelizeMeta may not exist
+      // yet on a clean database — db:migrate creates it in the first test — so
+      // ignore the case where there is nothing to clean.
       await withPg(async (client) => {
         await client.query('DROP TABLE IF EXISTS "migration_runner_probe"');
-        await client.query('DELETE FROM "SequelizeMeta" WHERE name = $1', [FIXTURE_MIGRATION_FILE]);
+        await client
+          .query('DELETE FROM "SequelizeMeta" WHERE name = $1', [FIXTURE_MIGRATION_FILE])
+          .catch(() => {});
       });
     });
 


### PR DESCRIPTION
## Descripción

- 9 migraciones create-table: eliminado `CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP` (PG no soporta ON UPDATE) → `Sequelize.literal(CURRENT_TIMESTAMP)`.
- `update-orders-status-enum` reescrito con rename dance raw-SQL + transacción explícita (el `changeColumn` a ENUM es no-op silencioso en PG).
- `other` agregado a `products.platform` (alineado con modelo `Product.ts`).
- Resto de migraciones ya eran PG-compatibles (sin cambios).

## Tipo de Cambio

- [x] 🐛 **Bug fix** (resuelve el issue #358)

## Issue Relacionado

Closes #358

## Checklist

- [x] Conventional commits
- [x] Cadena completa 17/17 en PG 16 real (DB temporal): idempotente + undo
- [x] Tests: legacy-migrations-pg-dialect (28 unit) + full-chain (3 integración)
- [x] pnpm test 922 pass, lint 0 errores, tsc limpio
- [x] Asignado al usuario para review antes de merge