### PR TITLE
feat(wallet): migración schema payouts — destination + gateway tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
     branches: [development]
     tags-ignore: ['v*']
   pull_request:
-    branches: [main, release]
+    branches: [main, release, development, 'feature/**']
+  workflow_dispatch:
 
 # Cancel duplicate runs for the same branch/PR
 concurrency:

--- a/backend/database/migrations/20260801000001-add-destination-to-withdrawal-requests.js
+++ b/backend/database/migrations/20260801000001-add-destination-to-withdrawal-requests.js
@@ -2,13 +2,13 @@
 
 /**
  * @fileoverview Migration: Add payout destination + gateway tracking to withdrawal_requests
- * @description Adds `destination` JSONB (payout destination: { method, email?, accountId? })
+ * @description Adds `destination` JSONB (payout destination: { method, email })
  *              plus gateway/notification tracking columns to support real money-out
- *              (PayPal Payouts / MercadoPago). All columns are NULL-able so legacy rows
+ *              (PayPal Payouts). All columns are NULL-able so legacy rows
  *              (0 dormant withdrawals) remain valid.
  *
  *              Agrega `destination` JSONB (destino de payout) y columnas de seguimiento
- *              de pasarela/notificación para soportar money-out real (PayPal/MercadoPago).
+ *              de pasarela/notificación para soportar money-out real (PayPal Payouts).
  *              Todas las columnas son NULL-ables para mantener válidas las filas legacy.
  *
  * @issue wallet-integration — Payouts Reales (PR 1: Schema+Migración)
@@ -27,7 +27,7 @@ module.exports = {
   async up(queryInterface, Sequelize) {
     const t = await queryInterface.sequelize.transaction();
     try {
-      // Payout destination: { method: 'paypal'|'mercadopago', email?, accountId? }
+      // Payout destination: { method: 'paypal', email }
       await queryInterface.sequelize.query(
         `ALTER TABLE "withdrawal_requests" ADD COLUMN IF NOT EXISTS "destination" JSONB;`,
         { transaction: t }

--- a/backend/database/migrations/20260801000001-add-destination-to-withdrawal-requests.js
+++ b/backend/database/migrations/20260801000001-add-destination-to-withdrawal-requests.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/**
+ * @fileoverview Migration: Add payout destination + gateway tracking to withdrawal_requests
+ * @description Adds `destination` JSONB (payout destination: { method, email?, accountId? })
+ *              plus gateway/notification tracking columns to support real money-out
+ *              (PayPal Payouts / MercadoPago). All columns are NULL-able so legacy rows
+ *              (0 dormant withdrawals) remain valid.
+ *
+ *              Agrega `destination` JSONB (destino de payout) y columnas de seguimiento
+ *              de pasarela/notificación para soportar money-out real (PayPal/MercadoPago).
+ *              Todas las columnas son NULL-ables para mantener válidas las filas legacy.
+ *
+ * @issue wallet-integration — Payouts Reales (PR 1: Schema+Migración)
+ * @type {import('sequelize-cli').Migration}
+ */
+
+module.exports = {
+  /**
+   * Apply migration — add destination + gateway tracking columns.
+   * Aplica la migración — agrega destination y columnas de seguimiento.
+   *
+   * @param {import('sequelize').QueryInterface} queryInterface
+   * @param {import('sequelize').Sequelize} Sequelize
+   * @returns {Promise<void>}
+   */
+  async up(queryInterface, Sequelize) {
+    const t = await queryInterface.sequelize.transaction();
+    try {
+      // Payout destination: { method: 'paypal'|'mercadopago', email?, accountId? }
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" ADD COLUMN IF NOT EXISTS "destination" JSONB;`,
+        { transaction: t }
+      );
+
+      // Gateway tracking — en-flight state while status stays 'approved' (ADR 8)
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" ADD COLUMN IF NOT EXISTS "gateway_payout_id" VARCHAR(191);`,
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" ADD COLUMN IF NOT EXISTS "gateway_status" VARCHAR(50);`,
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" ADD COLUMN IF NOT EXISTS "last_gateway_sync_at" TIMESTAMPTZ;`,
+        { transaction: t }
+      );
+
+      // Notification tracking — best-effort email retry (ADR 9)
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" ADD COLUMN IF NOT EXISTS "last_notified_status" VARCHAR(50);`,
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" ADD COLUMN IF NOT EXISTS "last_notified_at" TIMESTAMPTZ;`,
+        { transaction: t }
+      );
+
+      await t.commit();
+    } catch (error) {
+      await t.rollback();
+      throw error;
+    }
+  },
+
+  /**
+   * Revert migration — drop destination + gateway tracking columns.
+   * Revierte la migración — elimina destination y columnas de seguimiento.
+   *
+   * @param {import('sequelize').QueryInterface} queryInterface
+   * @param {import('sequelize').Sequelize} Sequelize
+   * @returns {Promise<void>}
+   */
+  async down(queryInterface, Sequelize) {
+    const t = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" DROP COLUMN IF EXISTS "destination";`,
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" DROP COLUMN IF EXISTS "gateway_payout_id";`,
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" DROP COLUMN IF EXISTS "gateway_status";`,
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" DROP COLUMN IF EXISTS "last_gateway_sync_at";`,
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" DROP COLUMN IF EXISTS "last_notified_status";`,
+        { transaction: t }
+      );
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "withdrawal_requests" DROP COLUMN IF EXISTS "last_notified_at";`,
+        { transaction: t }
+      );
+
+      await t.commit();
+    } catch (error) {
+      await t.rollback();
+      throw error;
+    }
+  },
+};

--- a/backend/src/__tests__/unit/migrations/add-destination-withdrawal.test.ts
+++ b/backend/src/__tests__/unit/migrations/add-destination-withdrawal.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @fileoverview Unit tests for migration: add-destination-to-withdrawal-requests
+ * @description Tests the column-add strategy on withdrawal_requests: destination JSONB
+ *              plus gateway/notification tracking columns (gateway_payout_id,
+ *              gateway_status, last_gateway_sync_at, last_notified_status,
+ *              last_notified_at). Verifies the idempotency guard (IF NOT EXISTS),
+ *              correct SQL types, and rollback (down).
+ *
+ * @module __tests__/unit/migrations/add-destination-withdrawal
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const migrationAddDestination = require('../../../../database/migrations/20260801000001-add-destination-to-withdrawal-requests');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeMockQueryInterface() {
+  const commit = jest.fn().mockResolvedValue(undefined);
+  const rollback = jest.fn().mockResolvedValue(undefined);
+  const transaction = { commit, rollback };
+
+  const query = jest.fn().mockResolvedValue([[], {}]);
+
+  const sequelize = {
+    transaction: jest.fn().mockResolvedValue(transaction),
+    query,
+  };
+
+  return { queryInterface: { sequelize }, transaction, commit, rollback, query };
+}
+
+/** Lower-cased SQL of every query issued, joined into one string for matching. */
+function allSql(query: jest.Mock): string {
+  return query.mock.calls.map((c: unknown[]) => c[0] as string).join('\n');
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Migration: add-destination-to-withdrawal-requests', () => {
+  describe('up()', () => {
+    it('should execute SQL queries and commit on success', async () => {
+      const { queryInterface, commit, rollback, query } = makeMockQueryInterface();
+
+      await migrationAddDestination.up(queryInterface, {});
+
+      expect(query.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect(commit).toHaveBeenCalledTimes(1);
+      expect(rollback).not.toHaveBeenCalled();
+    });
+
+    it('should add destination JSONB column to withdrawal_requests', async () => {
+      const { queryInterface, query } = makeMockQueryInterface();
+
+      await migrationAddDestination.up(queryInterface, {});
+
+      expect(allSql(query).toLowerCase()).toMatch(
+        /alter table "withdrawal_requests".*add column.*"destination".*jsonb/i
+      );
+    });
+
+    it('should add gateway_payout_id VARCHAR(191) column', async () => {
+      const { queryInterface, query } = makeMockQueryInterface();
+
+      await migrationAddDestination.up(queryInterface, {});
+
+      expect(allSql(query).toLowerCase()).toMatch(
+        /add column.*"gateway_payout_id".*varchar\(191\)/i
+      );
+    });
+
+    it('should add gateway_status VARCHAR(50) column', async () => {
+      const { queryInterface, query } = makeMockQueryInterface();
+
+      await migrationAddDestination.up(queryInterface, {});
+
+      expect(allSql(query).toLowerCase()).toMatch(/add column.*"gateway_status".*varchar\(50\)/i);
+    });
+
+    it('should add last_gateway_sync_at TIMESTAMPTZ column', async () => {
+      const { queryInterface, query } = makeMockQueryInterface();
+
+      await migrationAddDestination.up(queryInterface, {});
+
+      expect(allSql(query).toLowerCase()).toMatch(
+        /add column.*"last_gateway_sync_at".*timestamptz/i
+      );
+    });
+
+    it('should add last_notified_status VARCHAR(50) column', async () => {
+      const { queryInterface, query } = makeMockQueryInterface();
+
+      await migrationAddDestination.up(queryInterface, {});
+
+      expect(allSql(query).toLowerCase()).toMatch(
+        /add column.*"last_notified_status".*varchar\(50\)/i
+      );
+    });
+
+    it('should add last_notified_at TIMESTAMPTZ column', async () => {
+      const { queryInterface, query } = makeMockQueryInterface();
+
+      await migrationAddDestination.up(queryInterface, {});
+
+      expect(allSql(query).toLowerCase()).toMatch(/add column.*"last_notified_at".*timestamptz/i);
+    });
+
+    it('should guard every ADD COLUMN with IF NOT EXISTS (idempotent)', async () => {
+      const { queryInterface, query } = makeMockQueryInterface();
+
+      await migrationAddDestination.up(queryInterface, {});
+
+      const addColumnStatements = query.mock.calls
+        .map((c: unknown[]) => (c[0] as string).toLowerCase())
+        .filter((sql: string) => /add column/i.test(sql));
+
+      // All six columns must be added with the idempotency guard so re-running
+      // the migration against an already-migrated database does not fail.
+      expect(addColumnStatements).toHaveLength(6);
+      for (const sql of addColumnStatements) {
+        expect(sql).toMatch(/add column if not exists/);
+      }
+    });
+
+    it('should rollback and rethrow on error', async () => {
+      const { queryInterface, commit, rollback, query } = makeMockQueryInterface();
+      query.mockRejectedValueOnce(new Error('DB error'));
+
+      await expect(migrationAddDestination.up(queryInterface, {})).rejects.toThrow('DB error');
+
+      expect(rollback).toHaveBeenCalledTimes(1);
+      expect(commit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('down()', () => {
+    it('should execute SQL queries and commit on success', async () => {
+      const { queryInterface, commit, rollback, query } = makeMockQueryInterface();
+
+      await migrationAddDestination.down(queryInterface, {});
+
+      expect(query.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect(commit).toHaveBeenCalledTimes(1);
+      expect(rollback).not.toHaveBeenCalled();
+    });
+
+    it('should drop all six columns with IF EXISTS (idempotent rollback)', async () => {
+      const { queryInterface, query } = makeMockQueryInterface();
+
+      await migrationAddDestination.down(queryInterface, {});
+
+      const dropColumnStatements = query.mock.calls
+        .map((c: unknown[]) => (c[0] as string).toLowerCase())
+        .filter((sql: string) => /drop column/i.test(sql));
+
+      expect(dropColumnStatements).toHaveLength(6);
+      for (const sql of dropColumnStatements) {
+        expect(sql).toMatch(/drop column if exists/);
+      }
+
+      const sql = allSql(query).toLowerCase();
+      expect(sql).toMatch(/drop column.*"destination"/);
+      expect(sql).toMatch(/drop column.*"gateway_payout_id"/);
+      expect(sql).toMatch(/drop column.*"gateway_status"/);
+      expect(sql).toMatch(/drop column.*"last_gateway_sync_at"/);
+      expect(sql).toMatch(/drop column.*"last_notified_status"/);
+      expect(sql).toMatch(/drop column.*"last_notified_at"/);
+    });
+
+    it('should rollback and rethrow on error', async () => {
+      const { queryInterface, commit, rollback, query } = makeMockQueryInterface();
+      query.mockRejectedValueOnce(new Error('Rollback fail'));
+
+      await expect(migrationAddDestination.down(queryInterface, {})).rejects.toThrow(
+        'Rollback fail'
+      );
+
+      expect(rollback).toHaveBeenCalledTimes(1);
+      expect(commit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/__tests__/unit/migrations/legacy-migrations-full-chain.test.ts
+++ b/backend/src/__tests__/unit/migrations/legacy-migrations-full-chain.test.ts
@@ -55,6 +55,7 @@ const LEGACY_MIGRATION_FILES = [
   '20260409000000-add-whatsapp-bot-source.js',
   '20260412000001-commission-type-to-varchar.js',
   '20260412000002-seed-unilevel-commission-configs.js',
+  '20260801000001-add-destination-to-withdrawal-requests.js',
 ];
 
 interface DbConfig {

--- a/backend/src/__tests__/unit/migrations/legacy-migrations-full-chain.test.ts
+++ b/backend/src/__tests__/unit/migrations/legacy-migrations-full-chain.test.ts
@@ -287,10 +287,20 @@ describe('legacy migration chain (17) runs end-to-end on PostgreSQL', () => {
     const result = runCli(['db:migrate:undo', '--options-path', tempOptionsPath]);
     expect(result.status).toBe(0);
     await withPg({ ...runtimeDbConfig(), database: tempDbName }, async (client) => {
+      // The last migration is now the wallet one (20260801000001): its down()
+      // drops the payout columns from withdrawal_requests.
+      const walletCols = await client.query(
+        `SELECT count(*)::int AS n FROM information_schema.columns
+           WHERE table_name = 'withdrawal_requests'
+             AND column_name IN ('destination', 'gateway_payout_id', 'gateway_status',
+                                 'last_gateway_sync_at', 'last_notified_status', 'last_notified_at')`
+      );
+      expect(walletCols.rows[0].n).toBe(0);
+      // The seed migration is no longer last, so its rows must still be there.
       const seeded = await client.query(
         `SELECT count(*)::int AS n FROM "commission_configs" WHERE "business_type" = 'membresia'`
       );
-      expect(seeded.rows[0].n).toBe(0);
+      expect(seeded.rows[0].n).toBe(10);
       const meta = await client.query('SELECT name FROM "SequelizeMeta"');
       expect(meta.rows.length).toBe(LEGACY_MIGRATION_FILES.length - 1);
     });

--- a/backend/src/__tests__/unit/migrations/migration-runner-esm.test.ts
+++ b/backend/src/__tests__/unit/migrations/migration-runner-esm.test.ts
@@ -218,10 +218,14 @@ describe('migration runner (sequelize-cli under Node ESM)', () => {
 
     beforeAll(async () => {
       if (!postgresReachable) return;
-      // Remove residue from a previous failed run.
+      // Remove residue from a previous failed run. SequelizeMeta may not exist
+      // yet on a clean database — db:migrate creates it in the first test — so
+      // ignore the case where there is nothing to clean.
       await withPg(async (client) => {
         await client.query('DROP TABLE IF EXISTS "migration_runner_probe"');
-        await client.query('DELETE FROM "SequelizeMeta" WHERE name = $1', [FIXTURE_MIGRATION_FILE]);
+        await client
+          .query('DELETE FROM "SequelizeMeta" WHERE name = $1', [FIXTURE_MIGRATION_FILE])
+          .catch(() => {});
       });
     });
 

--- a/backend/src/__tests__/unit/models/WithdrawalRequest.test.ts
+++ b/backend/src/__tests__/unit/models/WithdrawalRequest.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Unit tests for WithdrawalRequest model — payout destination fields
+ * @description Verifies the model maps the new payout-destination / gateway-tracking
+ *              columns added by migration 20260801000001: destination JSONB,
+ *              gatewayPayoutId, gatewayStatus, lastGatewaySyncAt, lastNotifiedStatus,
+ *              lastNotifiedAt — all NULL-able (legacy rows stay valid).
+ *
+ * @module __tests__/unit/models/WithdrawalRequest
+ */
+
+import { WithdrawalRequest } from '../../../models/WithdrawalRequest';
+
+function attribute(name: string) {
+  const attrs = WithdrawalRequest.getAttributes();
+  expect(attrs[name]).toBeDefined();
+  return attrs[name];
+}
+
+describe('WithdrawalRequest model — payout destination fields', () => {
+  it('should map destination as nullable JSONB (field destination)', () => {
+    const dest = attribute('destination');
+    expect(dest.field).toBe('destination');
+    expect(dest.allowNull).toBe(true);
+    expect(dest.type.key).toBe('JSONB');
+  });
+
+  it('should map gatewayPayoutId as nullable VARCHAR(191) (field gateway_payout_id)', () => {
+    const attr = attribute('gatewayPayoutId');
+    expect(attr.field).toBe('gateway_payout_id');
+    expect(attr.allowNull).toBe(true);
+    expect(attr.type.key).toBe('STRING');
+    expect((attr.type as { options?: { length?: number } }).options?.length).toBe(191);
+  });
+
+  it('should map gatewayStatus as nullable VARCHAR(50) (field gateway_status)', () => {
+    const attr = attribute('gatewayStatus');
+    expect(attr.field).toBe('gateway_status');
+    expect(attr.allowNull).toBe(true);
+    expect(attr.type.key).toBe('STRING');
+    expect((attr.type as { options?: { length?: number } }).options?.length).toBe(50);
+  });
+
+  it('should map lastGatewaySyncAt as nullable DATE (field last_gateway_sync_at)', () => {
+    const attr = attribute('lastGatewaySyncAt');
+    expect(attr.field).toBe('last_gateway_sync_at');
+    expect(attr.allowNull).toBe(true);
+    expect(attr.type.key).toBe('DATE');
+  });
+
+  it('should map lastNotifiedStatus as nullable VARCHAR(50) (field last_notified_status)', () => {
+    const attr = attribute('lastNotifiedStatus');
+    expect(attr.field).toBe('last_notified_status');
+    expect(attr.allowNull).toBe(true);
+    expect(attr.type.key).toBe('STRING');
+    expect((attr.type as { options?: { length?: number } }).options?.length).toBe(50);
+  });
+
+  it('should map lastNotifiedAt as nullable DATE (field last_notified_at)', () => {
+    const attr = attribute('lastNotifiedAt');
+    expect(attr.field).toBe('last_notified_at');
+    expect(attr.allowNull).toBe(true);
+    expect(attr.type.key).toBe('DATE');
+  });
+});

--- a/backend/src/models/WithdrawalRequest.ts
+++ b/backend/src/models/WithdrawalRequest.ts
@@ -17,7 +17,11 @@
 import { DataTypes, Model, Optional, ForeignKey } from 'sequelize';
 import { sequelize } from '../config/database.js';
 import { User } from './User.js';
-import type { WithdrawalRequestAttributes, WithdrawalStatus } from '../types/index.js';
+import type {
+  WithdrawalDestination,
+  WithdrawalRequestAttributes,
+  WithdrawalStatus,
+} from '../types/index.js';
 
 type WithdrawalRequestCreation = Optional<
   WithdrawalRequestAttributes,
@@ -37,6 +41,13 @@ export class WithdrawalRequest extends Model<
   declare rejectionReason: string | null;
   declare approvalComment: string | null;
   declare processedAt: Date | null;
+  /** Payout destination (nullable for legacy rows) / Destino de pago (nullable para filas legacy) */
+  declare destination: WithdrawalDestination | null;
+  declare gatewayPayoutId: string | null;
+  declare gatewayStatus: string | null;
+  declare lastGatewaySyncAt: Date | null;
+  declare lastNotifiedStatus: string | null;
+  declare lastNotifiedAt: Date | null;
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
   declare user?: User | null;
@@ -88,6 +99,35 @@ WithdrawalRequest.init(
       type: DataTypes.DATE,
       allowNull: true,
       field: 'processed_at',
+    },
+    destination: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    gatewayPayoutId: {
+      type: DataTypes.STRING(191),
+      allowNull: true,
+      field: 'gateway_payout_id',
+    },
+    gatewayStatus: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+      field: 'gateway_status',
+    },
+    lastGatewaySyncAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'last_gateway_sync_at',
+    },
+    lastNotifiedStatus: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+      field: 'last_notified_status',
+    },
+    lastNotifiedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      field: 'last_notified_at',
     },
   },
   {

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -385,18 +385,17 @@ export type WithdrawalStatus = (typeof WITHDRAWAL_STATUS)[keyof typeof WITHDRAWA
  * Supported payout gateways for withdrawal money-out
  * Pasarelas de payout soportadas para el money-out de retiros
  */
-export type PayoutGatewayType = 'paypal' | 'mercadopago';
+export type PayoutGatewayType = 'paypal';
 
 /**
  * Withdrawal payout destination — the gateway is derived from `method`;
- * each provider requires a different identifier (email vs accountId).
+ * the provider requires an email identifier.
  * Destino de pago del retiro — la pasarela se deriva de `method`;
- * cada proveedor exige un identificador distinto (email vs accountId).
+ * el proveedor exige un identificador de tipo email.
  */
 export interface WithdrawalDestination {
   method: PayoutGatewayType;
-  email?: string;
-  accountId?: string;
+  email: string;
 }
 
 /**

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -382,6 +382,24 @@ export const WITHDRAWAL_STATUS = {
 export type WithdrawalStatus = (typeof WITHDRAWAL_STATUS)[keyof typeof WITHDRAWAL_STATUS];
 
 /**
+ * Supported payout gateways for withdrawal money-out
+ * Pasarelas de payout soportadas para el money-out de retiros
+ */
+export type PayoutGatewayType = 'paypal' | 'mercadopago';
+
+/**
+ * Withdrawal payout destination — the gateway is derived from `method`;
+ * each provider requires a different identifier (email vs accountId).
+ * Destino de pago del retiro — la pasarela se deriva de `method`;
+ * cada proveedor exige un identificador distinto (email vs accountId).
+ */
+export interface WithdrawalDestination {
+  method: PayoutGatewayType;
+  email?: string;
+  accountId?: string;
+}
+
+/**
  * Wallet attributes
  * Atributos de wallet
  */
@@ -449,6 +467,12 @@ export interface WithdrawalRequestAttributes {
   rejectionReason: string | null;
   approvalComment: string | null;
   processedAt: Date | null;
+  destination: WithdrawalDestination | null;
+  gatewayPayoutId: string | null;
+  gatewayStatus: string | null;
+  lastGatewaySyncAt: Date | null;
+  lastNotifiedStatus: string | null;
+  lastNotifiedAt: Date | null;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -466,6 +490,12 @@ export interface WithdrawalRequestCreationAttributes {
   rejectionReason?: string | null;
   approvalComment?: string | null;
   processedAt?: Date | null;
+  destination?: WithdrawalDestination | null;
+  gatewayPayoutId?: string | null;
+  gatewayStatus?: string | null;
+  lastGatewaySyncAt?: Date | null;
+  lastNotifiedStatus?: string | null;
+  lastNotifiedAt?: Date | null;
 }
 
 // ============================================


### PR DESCRIPTION
## Descripción

- Migración `20260801000001-add-destination-to-withdrawal-requests.js` (raw SQL + transacción): `destination JSONB`, `gateway_payout_id VARCHAR(191)`, `gateway_status VARCHAR(50)`, `last_gateway_sync_at TIMESTAMPTZ`, `last_notified_status VARCHAR(50)`, `last_notified_at TIMESTAMPTZ` — todas NULL (filas legacy válidas), idempotente.
- Modelo `WithdrawalRequest.ts` + tipos (`PayoutGatewayType`, `WithdrawalDestination`).

## Tipo de Cambio

- [x] 🚀 **Nueva feature** (base schema del SDD wallet-integration)

## Issue Relacionado

Parte del SDD wallet-integration (payouts reales). No cierra issue directamente (el E2E #347 se resuelve en PR 7).

## Checklist

- [x] Conventional commits
- [x] TDD RED→GREEN (12 + 6 tests)
- [x] Migración verificada UP/UNDO/UP en PG real
- [x] pnpm test, lint, tsc limpios
- [x] Asignado al usuario para review antes de merge