### PR TITLE
feat(wallet): PayoutGateway contract + PayPal Payouts gateway (PR 2a)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -88,6 +88,7 @@ PAYPAL_MODE=sandbox
 PAYPAL_CLIENT_ID=your-paypal-client-id
 PAYPAL_CLIENT_SECRET=your-paypal-client-secret
 PAYPAL_WEBHOOK_ID=your-paypal-webhook-id
+PAYPAL_PAYOUT_WEBHOOK_ID=your-paypal-payout-webhook-id
 
 # ============================================
 # MercadoPago

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
     branches: [development]
     tags-ignore: ['v*']
   pull_request:
-    branches: [main, release]
+    branches: [main, release, development, 'feature/**']
+  workflow_dispatch:
 
 # Cancel duplicate runs for the same branch/PR
 concurrency:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -79,6 +79,7 @@ PAYPAL_MODE=sandbox
 PAYPAL_CLIENT_ID=your_paypal_client_id
 PAYPAL_CLIENT_SECRET=your_paypal_client_secret
 PAYPAL_WEBHOOK_ID=your_paypal_webhook_id
+PAYPAL_PAYOUT_WEBHOOK_ID=your_paypal_payout_webhook_id
 
 # MercadoPago Configuration (Colombia)
 MERCADOPAGO_ACCESS_TOKEN=your_mercadopago_access_token

--- a/backend/src/__tests__/unit/PayPalService.test.ts
+++ b/backend/src/__tests__/unit/PayPalService.test.ts
@@ -175,4 +175,38 @@ describe('PayPalService — SSRF Prevention', () => {
       expect(mockedAxios.post).not.toHaveBeenCalled();
     });
   });
+
+  // ============================================
+  // verifyWebhookSignature — payout webhook id override (PR 2a)
+  // ============================================
+
+  describe('verifyWebhookSignature() — optional webhookId override', () => {
+    it('should use the provided webhookId in the verification payload when given', async () => {
+      // Dev bypass is skipped because an explicit webhookId is provided
+      mockAccessToken();
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { verification_status: 'SUCCESS' },
+      });
+
+      const headers = {
+        'paypal-auth-algo': 'SHA256withRSA',
+        'paypal-cert-url': 'https://api-m.sandbox.paypal.com/v1/notifications/certs/CERT-1',
+        'paypal-transmission-id': 'TXN-1',
+        'paypal-transmission-sig': 'sig',
+        'paypal-transmission-time': '2026-08-01T12:00:00Z',
+      };
+      const rawBody = JSON.stringify({ id: 'WH-1', event_type: 'PAYMENT.PAYOUTS.ITEM.SUCCEEDED' });
+
+      const result = await paypalService.verifyWebhookSignature(
+        headers,
+        rawBody,
+        'payout-webhook-123'
+      );
+
+      expect(result).toBe(true);
+      // call[0] is the OAuth token fetch — the verify call is call[1]
+      const verifyPayload = mockedAxios.post.mock.calls[1]?.[1] as { webhook_id?: string };
+      expect(verifyPayload.webhook_id).toBe('payout-webhook-123');
+    });
+  });
 });

--- a/backend/src/__tests__/unit/env-security.test.ts
+++ b/backend/src/__tests__/unit/env-security.test.ts
@@ -104,6 +104,22 @@ describe('env.ts — security hardening', () => {
     });
   });
 
+  describe('payout webhook env (PR 2a)', () => {
+    it('should read PAYPAL_PAYOUT_WEBHOOK_ID into config.paypal.payoutWebhookId', () => {
+      process.env.JWT_SECRET = 'real-secret-value';
+      process.env.TWO_FACTOR_SECRET_KEY = 'real-2fa-value';
+      process.env.PAYPAL_PAYOUT_WEBHOOK_ID = 'payout-webhook-abc';
+
+      // Prevent dotenv from overwriting our test values
+      jest.mock('dotenv', () => ({ config: jest.fn() }));
+
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { config } = require('../../config/env');
+
+      expect(config.paypal.payoutWebhookId).toBe('payout-webhook-abc');
+    });
+  });
+
   describe('loads correctly with valid secrets', () => {
     it('should load config without throwing when both secrets are set', () => {
       process.env.JWT_SECRET = 'test-jwt-secret';

--- a/backend/src/__tests__/unit/migrations/migration-runner-esm.test.ts
+++ b/backend/src/__tests__/unit/migrations/migration-runner-esm.test.ts
@@ -218,10 +218,14 @@ describe('migration runner (sequelize-cli under Node ESM)', () => {
 
     beforeAll(async () => {
       if (!postgresReachable) return;
-      // Remove residue from a previous failed run.
+      // Remove residue from a previous failed run. SequelizeMeta may not exist
+      // yet on a clean database — db:migrate creates it in the first test — so
+      // ignore the case where there is nothing to clean.
       await withPg(async (client) => {
         await client.query('DROP TABLE IF EXISTS "migration_runner_probe"');
-        await client.query('DELETE FROM "SequelizeMeta" WHERE name = $1', [FIXTURE_MIGRATION_FILE]);
+        await client
+          .query('DELETE FROM "SequelizeMeta" WHERE name = $1', [FIXTURE_MIGRATION_FILE])
+          .catch(() => {});
       });
     });
 

--- a/backend/src/__tests__/unit/payouts/paypal-payouts.gateway.test.ts
+++ b/backend/src/__tests__/unit/payouts/paypal-payouts.gateway.test.ts
@@ -1,0 +1,281 @@
+/**
+ * @fileoverview PayPalPayoutsGateway Unit Tests — PayoutGateway contract (PR 2a)
+ * @description Tests for the PayPal Payouts gateway adapter: createPayout payload
+ *   construction (sender_batch_id = withdrawalId, email recipient, 2-decimal amount),
+ *   getStatus batch lookup + status mapping to the wallet domain, verifyWebhook
+ *   signature rejection/acceptance, the typed payout webhook event parser, and the
+ *   gateway factory that derives the adapter from the destination shape.
+ *
+ *   Pruebas del adaptador de payout PayPal: construcción del payload de createPayout,
+ *   mapeo de estados de getStatus al dominio wallet, verificación de firma de
+ *   webhook, parser tipado del evento de payout y la factory de gateways.
+ *
+ * @module __tests__/unit/payouts/paypal-payouts.gateway
+ */
+
+// ============================================
+// MOCKS — Must go BEFORE imports / Deben ir ANTES de los imports
+// ============================================
+
+jest.mock('../../../config/env', () => ({
+  config: {
+    paypal: {
+      mode: 'sandbox',
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+      webhookId: '',
+      payoutWebhookId: 'payout-webhook-123',
+    },
+    app: {
+      frontendUrl: 'http://localhost:3000',
+    },
+  },
+}));
+
+jest.mock('axios');
+
+jest.mock('../../../services/PayPalService', () => ({
+  paypalService: {
+    getAccessToken: jest.fn(),
+    verifyWebhookSignature: jest.fn(),
+  },
+}));
+
+import axios from 'axios';
+import { AppError } from '../../../middleware/error.middleware';
+import { paypalService } from '../../../services/PayPalService';
+import {
+  PayPalPayoutsGateway,
+  mapPayPalBatchStatus,
+  parsePayPalPayoutWebhookEvent,
+} from '../../../services/payouts/PayPalPayoutsGateway';
+import type { PayoutRequest } from '../../../services/payouts/PayoutGateway';
+import { getPayoutGateway } from '../../../services/payouts';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedPayPalService = paypalService as jest.Mocked<typeof paypalService>;
+
+const gateway = new PayPalPayoutsGateway();
+
+const basePayoutRequest: PayoutRequest = {
+  withdrawalId: 'withdrawal-uuid-1',
+  amount: 95.5,
+  currency: 'USD',
+  destination: { method: 'paypal', email: 'user@example.com' },
+};
+
+const validWebhookBody = JSON.stringify({
+  id: 'WH-20260801-001',
+  event_type: 'PAYMENT.PAYOUTS.ITEM.SUCCEEDED',
+  create_time: '2026-08-01T12:00:00Z',
+  resource: {
+    payout_batch_id: 'PTB123',
+    sender_batch_id: 'withdrawal-uuid-1',
+    payout_item_id: 'ITEM-1',
+    transaction_id: 'TRX-1',
+    payout_item: {
+      transaction_status: 'SUCCESS',
+      amount: { currency: 'USD', value: '95.50' },
+    },
+  },
+});
+
+const paypalHeaders = {
+  'paypal-auth-algo': 'SHA256withRSA',
+  'paypal-cert-url': 'https://api-m.sandbox.paypal.com/v1/notifications/certs/CERT-1',
+  'paypal-transmission-id': 'TXN-1',
+  'paypal-transmission-sig': 'sig',
+  'paypal-transmission-time': '2026-08-01T12:00:00Z',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PayPalPayoutsGateway.createPayout', () => {
+  it('builds the Payouts payload with sender_batch_id = withdrawalId, email, currency and 2-decimal amount', async () => {
+    mockedPayPalService.getAccessToken.mockResolvedValue('token-1');
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { batch_header: { payout_batch_id: 'PTB123', batch_status: 'PENDING' } },
+    });
+
+    const result = await gateway.createPayout(basePayoutRequest);
+
+    expect(result).toEqual({ payoutId: 'PTB123', status: 'pending' });
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    const [url, body, opts] = mockedAxios.post.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+      { headers: Record<string, string> },
+    ];
+    expect(url).toBe('https://api-m.sandbox.paypal.com/v1/payments/payouts');
+    expect(opts.headers.Authorization).toBe('Bearer token-1');
+    expect(opts.headers['Content-Type']).toBe('application/json');
+
+    const senderBatchHeader = (body as { sender_batch_header: Record<string, string> })
+      .sender_batch_header;
+    expect(senderBatchHeader.sender_batch_id).toBe('withdrawal-uuid-1');
+
+    const items = (body as { items: Array<Record<string, unknown>> }).items;
+    expect(items).toHaveLength(1);
+    expect(items[0].recipient_type).toBe('EMAIL');
+    expect(items[0].receiver).toBe('user@example.com');
+    const amount = items[0].amount as { value: string; currency: string };
+    expect(amount.value).toBe('95.50');
+    expect(amount.currency).toBe('USD');
+  });
+
+  it('formats the amount with fixed 2 decimals without float errors', async () => {
+    mockedPayPalService.getAccessToken.mockResolvedValue('token-1');
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { batch_header: { payout_batch_id: 'PTB2', batch_status: 'PENDING' } },
+    });
+
+    await gateway.createPayout({ ...basePayoutRequest, amount: 0.1 + 0.2 });
+
+    const [, body] = mockedAxios.post.mock.calls[0] as [string, Record<string, unknown>];
+    const items = (body as { items: Array<{ amount: { value: string } }> }).items;
+    expect(items[0].amount.value).toBe('0.30');
+  });
+
+  it('rejects a destination without a PayPal email (INVALID_DESTINATION) before any API call', async () => {
+    await expect(
+      gateway.createPayout({
+        ...basePayoutRequest,
+        destination: { method: 'paypal', accountId: 'MP_123' },
+      })
+    ).rejects.toMatchObject({ statusCode: 400, code: 'INVALID_DESTINATION' });
+
+    expect(mockedPayPalService.getAccessToken).not.toHaveBeenCalled();
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+});
+
+describe('mapPayPalBatchStatus (pure status mapping)', () => {
+  it('maps PENDING and PROCESSING to the wallet domain status "pending"', () => {
+    expect(mapPayPalBatchStatus('PENDING')).toBe('pending');
+    expect(mapPayPalBatchStatus('PROCESSING')).toBe('pending');
+  });
+
+  it('maps SUCCESS to "paid"', () => {
+    expect(mapPayPalBatchStatus('SUCCESS')).toBe('paid');
+  });
+
+  it('maps DENIED, FAILED and CANCELED to "failed"', () => {
+    expect(mapPayPalBatchStatus('DENIED')).toBe('failed');
+    expect(mapPayPalBatchStatus('FAILED')).toBe('failed');
+    expect(mapPayPalBatchStatus('CANCELED')).toBe('failed');
+  });
+
+  it('maps any other batch status to "unknown"', () => {
+    expect(mapPayPalBatchStatus('')).toBe('unknown');
+    expect(mapPayPalBatchStatus('BOGUS')).toBe('unknown');
+  });
+});
+
+describe('PayPalPayoutsGateway.getStatus', () => {
+  it('queries the payout batch and returns the mapped wallet status', async () => {
+    mockedPayPalService.getAccessToken.mockResolvedValue('token-1');
+    mockedAxios.get.mockResolvedValueOnce({
+      data: { batch_header: { payout_batch_id: 'PTB123', batch_status: 'SUCCESS' } },
+    });
+
+    const status = await gateway.getStatus('PTB123');
+
+    expect(status).toBe('paid');
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://api-m.sandbox.paypal.com/v1/payments/payouts/PTB123',
+      expect.objectContaining({ headers: { Authorization: 'Bearer token-1' } })
+    );
+  });
+
+  it('rejects invalid payout ids (SSRF prevention) without any HTTP call', async () => {
+    await expect(gateway.getStatus('../../../etc/passwd')).rejects.toMatchObject({
+      statusCode: 400,
+      code: 'INVALID_PAYPAL_ID',
+    });
+
+    expect(mockedPayPalService.getAccessToken).not.toHaveBeenCalled();
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('PayPalPayoutsGateway.verifyWebhook', () => {
+  it('rejects an event with an invalid signature', async () => {
+    mockedPayPalService.verifyWebhookSignature.mockResolvedValue(false);
+
+    await expect(gateway.verifyWebhook(paypalHeaders, validWebhookBody)).resolves.toBe(false);
+    expect(mockedPayPalService.verifyWebhookSignature).toHaveBeenCalledWith(
+      paypalHeaders,
+      validWebhookBody,
+      'payout-webhook-123'
+    );
+  });
+
+  it('accepts a valid signed event and exposes its event id as the idempotency key', async () => {
+    mockedPayPalService.verifyWebhookSignature.mockResolvedValue(true);
+
+    await expect(gateway.verifyWebhook(paypalHeaders, validWebhookBody)).resolves.toBe(true);
+
+    const event = parsePayPalPayoutWebhookEvent(validWebhookBody);
+    expect(event.id).toBe('WH-20260801-001');
+    expect(event.event_type).toBe('PAYMENT.PAYOUTS.ITEM.SUCCEEDED');
+    // The event id is the persistent idempotency key used by WebhookEvent (isEventProcessed)
+    expect(event.id).toMatch(/^WH-/);
+  });
+
+  it('rejects a malformed payload without verifying the signature', async () => {
+    await expect(gateway.verifyWebhook(paypalHeaders, 'not-json{')).resolves.toBe(false);
+    expect(mockedPayPalService.verifyWebhookSignature).not.toHaveBeenCalled();
+  });
+});
+
+describe('parsePayPalPayoutWebhookEvent (typed event parser)', () => {
+  it('parses a valid payout webhook event into a typed object', () => {
+    const event = parsePayPalPayoutWebhookEvent(validWebhookBody);
+
+    expect(event.id).toBe('WH-20260801-001');
+    expect(event.event_type).toBe('PAYMENT.PAYOUTS.ITEM.SUCCEEDED');
+    expect(event.resource?.payout_batch_id).toBe('PTB123');
+    expect(event.resource?.sender_batch_id).toBe('withdrawal-uuid-1');
+    expect(event.resource?.payout_item?.transaction_status).toBe('SUCCESS');
+    expect(event.resource?.payout_item?.amount?.value).toBe('95.50');
+  });
+
+  it('throws on malformed JSON payloads', () => {
+    expect(() => parsePayPalPayoutWebhookEvent('not-json{')).toThrow();
+    expect(() => parsePayPalPayoutWebhookEvent('')).toThrow();
+  });
+
+  it('throws when the payload is not a webhook event object', () => {
+    expect(() => parsePayPalPayoutWebhookEvent(JSON.stringify({ foo: 'bar' }))).toThrow();
+  });
+});
+
+describe('getPayoutGateway factory', () => {
+  it('returns the PayPal gateway for email destinations', () => {
+    const gatewayForEmail = getPayoutGateway({ method: 'paypal', email: 'user@example.com' });
+
+    expect(gatewayForEmail.type).toBe('paypal');
+    expect(typeof gatewayForEmail.createPayout).toBe('function');
+    expect(typeof gatewayForEmail.getStatus).toBe('function');
+    expect(typeof gatewayForEmail.verifyWebhook).toBe('function');
+  });
+
+  it('reserves the MercadoPago slot for accountId destinations (not implemented in PR 2a)', () => {
+    expect(() => getPayoutGateway({ method: 'mercadopago', accountId: 'MP_123' })).toThrowError(
+      AppError
+    );
+    expect(() => getPayoutGateway({ method: 'mercadopago', accountId: 'MP_123' })).toThrowError(
+      expect.objectContaining({ statusCode: 501, code: 'GATEWAY_NOT_IMPLEMENTED' })
+    );
+  });
+
+  it('rejects destinations with neither an email nor an accountId', () => {
+    expect(() => getPayoutGateway({ method: 'paypal' })).toThrowError(AppError);
+    expect(() => getPayoutGateway({ method: 'paypal' })).toThrowError(
+      expect.objectContaining({ statusCode: 400, code: 'INVALID_DESTINATION' })
+    );
+  });
+});

--- a/backend/src/__tests__/unit/payouts/paypal-payouts.gateway.test.ts
+++ b/backend/src/__tests__/unit/payouts/paypal-payouts.gateway.test.ts
@@ -143,7 +143,7 @@ describe('PayPalPayoutsGateway.createPayout', () => {
     await expect(
       gateway.createPayout({
         ...basePayoutRequest,
-        destination: { method: 'paypal', accountId: 'MP_123' },
+        destination: { method: 'paypal' },
       })
     ).rejects.toMatchObject({ statusCode: 400, code: 'INVALID_DESTINATION' });
 
@@ -263,16 +263,7 @@ describe('getPayoutGateway factory', () => {
     expect(typeof gatewayForEmail.verifyWebhook).toBe('function');
   });
 
-  it('reserves the MercadoPago slot for accountId destinations (not implemented in PR 2a)', () => {
-    expect(() => getPayoutGateway({ method: 'mercadopago', accountId: 'MP_123' })).toThrowError(
-      AppError
-    );
-    expect(() => getPayoutGateway({ method: 'mercadopago', accountId: 'MP_123' })).toThrowError(
-      expect.objectContaining({ statusCode: 501, code: 'GATEWAY_NOT_IMPLEMENTED' })
-    );
-  });
-
-  it('rejects destinations with neither an email nor an accountId', () => {
+  it('rejects destinations without a PayPal email (INVALID_DESTINATION)', () => {
     expect(() => getPayoutGateway({ method: 'paypal' })).toThrowError(AppError);
     expect(() => getPayoutGateway({ method: 'paypal' })).toThrowError(
       expect.objectContaining({ statusCode: 400, code: 'INVALID_DESTINATION' })

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -184,6 +184,8 @@ export const config = {
     clientSecret: process.env.PAYPAL_CLIENT_SECRET || '',
     /** PayPal webhook ID for signature verification / Webhook ID de PayPal para verificación de firma */
     webhookId: process.env.PAYPAL_WEBHOOK_ID || '',
+    /** PayPal Payouts webhook ID (separate webhook for PAYMENT.PAYOUTS.* events) / Webhook ID de PayPal Payouts */
+    payoutWebhookId: process.env.PAYPAL_PAYOUT_WEBHOOK_ID || '',
   },
 
   /**

--- a/backend/src/services/PayPalService.ts
+++ b/backend/src/services/PayPalService.ts
@@ -95,8 +95,10 @@ class PayPalService {
 
   /**
    * Get OAuth token from PayPal
+   * Public: reused by payout/refund adapters that call the same REST API.
+   * Public: reutilizado por los adaptadores de payout que llaman a la misma API REST.
    */
-  private async getAccessToken(): Promise<string> {
+  async getAccessToken(): Promise<string> {
     // Return cached token if still valid
     if (this.accessToken && Date.now() < this.tokenExpiry) {
       return this.accessToken;
@@ -255,11 +257,19 @@ class PayPalService {
    *
    * @param headers - HTTP headers from the incoming webhook request
    * @param rawBody - Raw JSON string body of the webhook event
+   * @param webhookId - Optional webhook id override (payouts webhook uses its own id).
+   *                    Defaults to config.paypal.webhookId.
+   *                    Webhook id opcional (el webhook de payouts usa su propio id).
    * @returns true if signature is valid (or dev mode bypass), false otherwise
    */
-  async verifyWebhookSignature(headers: Record<string, string>, rawBody: string): Promise<boolean> {
+  async verifyWebhookSignature(
+    headers: Record<string, string>,
+    rawBody: string,
+    webhookId?: string
+  ): Promise<boolean> {
+    const effectiveWebhookId = webhookId ?? config.paypal.webhookId;
     // Dev mode bypass: if no webhook ID is configured, skip verification
-    if (!config.paypal.webhookId) {
+    if (!effectiveWebhookId) {
       return true;
     }
 
@@ -273,7 +283,7 @@ class PayPalService {
         transmission_id: headers['paypal-transmission-id'],
         transmission_sig: headers['paypal-transmission-sig'],
         transmission_time: headers['paypal-transmission-time'],
-        webhook_id: config.paypal.webhookId,
+        webhook_id: effectiveWebhookId,
         webhook_event: JSON.parse(rawBody) as unknown,
       };
 

--- a/backend/src/services/payouts/PayPalPayoutsGateway.ts
+++ b/backend/src/services/payouts/PayPalPayoutsGateway.ts
@@ -1,0 +1,207 @@
+/**
+ * @fileoverview PayPal Payouts Gateway — REST /v1/payments/payouts
+ * @description Adapter for the PayPal Payouts API. Reuses the OAuth token from
+ *   PayPalService (no duplicated auth) and the PayPal Notifications API for
+ *   webhook signature verification. Maps PayPal batch statuses into the
+ *   wallet-domain PayoutStatus.
+ *
+ *   Adaptador de la API PayPal Payouts. Reutiliza el token OAuth de
+ *   PayPalService y la API de Notificaciones para verificar firmas de webhook.
+ * @module services/payouts/PayPalPayoutsGateway
+ */
+
+import axios from 'axios';
+import { config } from '../../config/env.js';
+import { AppError } from '../../middleware/error.middleware.js';
+import { paypalService } from '../PayPalService.js';
+import type { PayoutGatewayType } from '../../types/index.js';
+import type { PayoutGateway, PayoutRequest, PayoutResult, PayoutStatus } from './PayoutGateway.js';
+
+const PAYPAL_API_BASE =
+  config.paypal.mode === 'sandbox'
+    ? 'https://api-m.sandbox.paypal.com'
+    : 'https://api-m.paypal.com';
+
+/**
+ * Validate a PayPal identifier (batch ids, etc.) to prevent SSRF.
+ * Same allowlist as PayPalService: alphanumeric, hyphen, underscore.
+ *
+ * Valida formato de identificador PayPal para prevenir SSRF.
+ * @throws {AppError} if the id contains invalid characters
+ */
+function validatePayPalId(id: string, label: string): void {
+  if (!id || !/^[A-Za-z0-9_-]+$/.test(id)) {
+    throw new AppError(400, 'INVALID_PAYPAL_ID', `Invalid ${label}: got "${id}"`);
+  }
+}
+
+/**
+ * Map a PayPal Payouts batch status into the wallet-domain PayoutStatus.
+ *
+ * Mapea el estado de batch de PayPal Payouts al dominio wallet.
+ * Pure function — no side effects, unit-tested directly.
+ */
+export function mapPayPalBatchStatus(batchStatus: string | undefined): PayoutStatus {
+  switch (batchStatus) {
+    case 'PENDING':
+    case 'PROCESSING':
+      return 'pending';
+    case 'SUCCESS':
+      return 'paid';
+    case 'DENIED':
+    case 'FAILED':
+    case 'CANCELED':
+      return 'failed';
+    default:
+      return 'unknown';
+  }
+}
+
+/**
+ * Typed PayPal Payouts webhook event (PAYMENT.PAYOUTS.*).
+ * The event `id` is the persistent idempotency key (WebhookEvent table).
+ */
+export interface PayPalPayoutWebhookEvent {
+  id: string;
+  event_type: string;
+  create_time?: string;
+  resource?: {
+    payout_batch_id?: string;
+    sender_batch_id?: string;
+    payout_item_id?: string;
+    transaction_id?: string;
+    payout_item?: {
+      transaction_status?: string;
+      amount?: { currency?: string; value?: string };
+    };
+  };
+}
+
+/**
+ * Parse and validate a raw PayPal webhook payload into a typed event.
+ * Pure function — throws AppError(400) when the payload is not a valid
+ * payout webhook event.
+ *
+ * @throws {AppError} INVALID_WEBHOOK_PAYLOAD when the payload cannot be parsed
+ */
+export function parsePayPalPayoutWebhookEvent(rawBody: string): PayPalPayoutWebhookEvent {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    throw new AppError(400, 'INVALID_WEBHOOK_PAYLOAD', 'Webhook body is not valid JSON');
+  }
+
+  const event = parsed as Partial<PayPalPayoutWebhookEvent>;
+  if (
+    !event ||
+    typeof event !== 'object' ||
+    typeof event.id !== 'string' ||
+    typeof event.event_type !== 'string'
+  ) {
+    throw new AppError(
+      400,
+      'INVALID_WEBHOOK_PAYLOAD',
+      'Webhook payload is not a PayPal payout event'
+    );
+  }
+
+  return event as PayPalPayoutWebhookEvent;
+}
+
+/**
+ * PayPal Payouts gateway adapter — implements the PayoutGateway contract.
+ * POST /v1/payments/payouts (create), GET /v1/payments/payouts/{batchId}
+ * (status) and webhook signature verification via PayPalService.
+ */
+export class PayPalPayoutsGateway implements PayoutGateway {
+  readonly type: PayoutGatewayType = 'paypal';
+
+  async createPayout(req: PayoutRequest): Promise<PayoutResult> {
+    const { destination } = req;
+    if (destination.method !== 'paypal' || !destination.email) {
+      throw new AppError(
+        400,
+        'INVALID_DESTINATION',
+        'PayPal payouts require a valid email destination'
+      );
+    }
+
+    const token = await paypalService.getAccessToken();
+    // Fixed 2 decimals avoids float artifacts (0.1 + 0.2 → "0.30")
+    const value = req.amount.toFixed(2);
+
+    const response = await axios.post(
+      `${PAYPAL_API_BASE}/v1/payments/payouts`,
+      {
+        sender_batch_header: {
+          sender_batch_id: req.withdrawalId,
+          email_subject: 'Nexo Real payout',
+          email_message: 'You have received a payout from Nexo Real.',
+        },
+        items: [
+          {
+            recipient_type: 'EMAIL',
+            receiver: destination.email,
+            amount: {
+              value,
+              currency: req.currency,
+            },
+            note: `Withdrawal ${req.withdrawalId}`,
+          },
+        ],
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    const batchHeader = response.data?.batch_header as
+      | { payout_batch_id?: string; batch_status?: string }
+      | undefined;
+
+    if (!batchHeader?.payout_batch_id) {
+      throw new AppError(
+        502,
+        'GATEWAY_ERROR',
+        'PayPal Payouts response did not include payout_batch_id'
+      );
+    }
+
+    return {
+      payoutId: batchHeader.payout_batch_id,
+      status: mapPayPalBatchStatus(batchHeader.batch_status),
+    };
+  }
+
+  async getStatus(payoutId: string): Promise<PayoutStatus> {
+    validatePayPalId(payoutId, 'PayPal payout batch id');
+    const token = await paypalService.getAccessToken();
+
+    const response = await axios.get(`${PAYPAL_API_BASE}/v1/payments/payouts/${payoutId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const batchHeader = response.data?.batch_header as { batch_status?: string } | undefined;
+    return mapPayPalBatchStatus(batchHeader?.batch_status);
+  }
+
+  async verifyWebhook(headers: Record<string, string>, rawBody: string): Promise<boolean> {
+    try {
+      // Reject malformed payloads before touching signature verification
+      parsePayPalPayoutWebhookEvent(rawBody);
+    } catch {
+      return false;
+    }
+    // Payout webhooks use their own webhook id (PAYPAL_PAYOUT_WEBHOOK_ID)
+    return paypalService.verifyWebhookSignature(headers, rawBody, config.paypal.payoutWebhookId);
+  }
+}
+
+/** Singleton instance for the payout gateway registry */
+export const paypalPayoutsGateway = new PayPalPayoutsGateway();

--- a/backend/src/services/payouts/PayoutGateway.ts
+++ b/backend/src/services/payouts/PayoutGateway.ts
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Payout Gateway contract — money-out abstraction
+ * @description Common interface implemented by every payout provider adapter
+ *   (PayPal Payouts REST, MercadoPago money-out). The wallet service talks to
+ *   this interface, never to a concrete provider.
+ *
+ *   Contrato de pasarela de payout — abstracción de money-out implementada por
+ *   cada adaptador de proveedor (PayPal Payouts REST, MercadoPago money-out).
+ * @module services/payouts/PayoutGateway
+ */
+
+import type { PayoutGatewayType, WithdrawalDestination } from '../../types/index.js';
+
+/**
+ * Wallet-domain payout status — the neutral status the rest of the system
+ * consumes, regardless of the provider's own vocabulary.
+ *
+ * Estado de payout en el dominio wallet — estado neutro que consume el resto
+ * del sistema, independiente del vocabulario del proveedor.
+ */
+export type PayoutStatus = 'pending' | 'paid' | 'failed' | 'unknown';
+
+/**
+ * Request to create a real payout on the provider.
+ *
+ * `withdrawalId` doubles as the provider idempotency key (PayPal
+ * `sender_batch_id` / MercadoPago `external_reference`): re-sending the same
+ * id does not create a second payout.
+ *
+ * Solicitud para crear un payout real en el proveedor. `withdrawalId` actúa
+ * como clave idempotente del proveedor.
+ */
+export interface PayoutRequest {
+  /** Internal withdrawal id — idempotency key for the provider */
+  withdrawalId: string;
+  /** Net amount to pay out, in USD (2 decimals) */
+  amount: number;
+  /** ISO 4217 currency code (e.g. 'USD') */
+  currency: string;
+  /** Provider-specific payout destination */
+  destination: WithdrawalDestination;
+}
+
+/** Result of creating a payout — provider payout id plus initial status */
+export interface PayoutResult {
+  /** Provider-assigned payout id (stored as gatewayPayoutId on the withdrawal) */
+  payoutId: string;
+  status: PayoutStatus;
+}
+
+/**
+ * Payout gateway abstraction — one adapter per provider.
+ *
+ * Pasarela de payout — un adaptador por proveedor.
+ */
+export interface PayoutGateway {
+  readonly type: PayoutGatewayType;
+  createPayout(req: PayoutRequest): Promise<PayoutResult>;
+  getStatus(payoutId: string): Promise<PayoutStatus>;
+  verifyWebhook(headers: Record<string, string>, rawBody: string): Promise<boolean>;
+}

--- a/backend/src/services/payouts/index.ts
+++ b/backend/src/services/payouts/index.ts
@@ -1,13 +1,13 @@
 /**
  * @fileoverview Payout gateway registry / factory
  * @description Derives the payout gateway adapter from the withdrawal
- *   destination shape: `email` → PayPal Payouts, `accountId` → MercadoPago
- *   money-out (reserved slot, implemented in PR 2b). Consumers (WalletService,
- *   webhook controller) must go through `getPayoutGateway` and never
- *   instantiate adapters directly.
+ *   destination: `email` → PayPal Payouts (the only supported money-out
+ *   provider; MercadoPago has no payout API to third parties). Consumers
+ *   (WalletService, webhook controller) must go through `getPayoutGateway`
+ *   and never instantiate adapters directly.
  *
- *   Fábrica de pasarelas de payout: deriva el adaptador de la forma del
- *   destino del retiro (email → PayPal, accountId → MercadoPago).
+ *   Fábrica de pasarelas de payout: deriva el adaptador del destino del
+ *   retiro (email → PayPal Payouts, única vía de money-out soportada).
  * @module services/payouts
  */
 
@@ -22,28 +22,14 @@ export type { PayoutGateway, PayoutRequest, PayoutResult, PayoutStatus } from '.
 
 /**
  * Resolve the payout gateway for a withdrawal destination.
- * The provider is derived from the destination shape (ADR-3): email → paypal,
- * accountId → mercadopago.
+ * The provider is derived from the destination shape (ADR-3): email → paypal.
  *
  * Resuelve la pasarela de payout para un destino de retiro.
- * @throws {AppError} 501 GATEWAY_NOT_IMPLEMENTED for MercadoPago (PR 2b)
- * @throws {AppError} 400 INVALID_DESTINATION when no provider shape matches
+ * @throws {AppError} 400 INVALID_DESTINATION when the destination lacks a paypal email
  */
 export function getPayoutGateway(destination: WithdrawalDestination): PayoutGateway {
   if (destination.email) {
     return paypalPayoutsGateway;
   }
-  if (destination.accountId) {
-    // TODO(wallet 2b): MercadoPagoMoneyOutGateway — SDK payment.get + REST disbursements
-    throw new AppError(
-      501,
-      'GATEWAY_NOT_IMPLEMENTED',
-      'MercadoPago payout gateway is not implemented yet'
-    );
-  }
-  throw new AppError(
-    400,
-    'INVALID_DESTINATION',
-    'Destination must provide a paypal email or a MercadoPago accountId'
-  );
+  throw new AppError(400, 'INVALID_DESTINATION', 'Destination must provide a paypal email');
 }

--- a/backend/src/services/payouts/index.ts
+++ b/backend/src/services/payouts/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Payout gateway registry / factory
+ * @description Derives the payout gateway adapter from the withdrawal
+ *   destination shape: `email` → PayPal Payouts, `accountId` → MercadoPago
+ *   money-out (reserved slot, implemented in PR 2b). Consumers (WalletService,
+ *   webhook controller) must go through `getPayoutGateway` and never
+ *   instantiate adapters directly.
+ *
+ *   Fábrica de pasarelas de payout: deriva el adaptador de la forma del
+ *   destino del retiro (email → PayPal, accountId → MercadoPago).
+ * @module services/payouts
+ */
+
+import { AppError } from '../../middleware/error.middleware.js';
+import type { WithdrawalDestination } from '../../types/index.js';
+import { paypalPayoutsGateway } from './PayPalPayoutsGateway.js';
+import type { PayoutGateway } from './PayoutGateway.js';
+
+export { PayPalPayoutsGateway, parsePayPalPayoutWebhookEvent } from './PayPalPayoutsGateway.js';
+export type { PayPalPayoutWebhookEvent } from './PayPalPayoutsGateway.js';
+export type { PayoutGateway, PayoutRequest, PayoutResult, PayoutStatus } from './PayoutGateway.js';
+
+/**
+ * Resolve the payout gateway for a withdrawal destination.
+ * The provider is derived from the destination shape (ADR-3): email → paypal,
+ * accountId → mercadopago.
+ *
+ * Resuelve la pasarela de payout para un destino de retiro.
+ * @throws {AppError} 501 GATEWAY_NOT_IMPLEMENTED for MercadoPago (PR 2b)
+ * @throws {AppError} 400 INVALID_DESTINATION when no provider shape matches
+ */
+export function getPayoutGateway(destination: WithdrawalDestination): PayoutGateway {
+  if (destination.email) {
+    return paypalPayoutsGateway;
+  }
+  if (destination.accountId) {
+    // TODO(wallet 2b): MercadoPagoMoneyOutGateway — SDK payment.get + REST disbursements
+    throw new AppError(
+      501,
+      'GATEWAY_NOT_IMPLEMENTED',
+      'MercadoPago payout gateway is not implemented yet'
+    );
+  }
+  throw new AppError(
+    400,
+    'INVALID_DESTINATION',
+    'Destination must provide a paypal email or a MercadoPago accountId'
+  );
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -102,6 +102,7 @@ services:
       PAYPAL_CLIENT_ID: ${PAYPAL_CLIENT_ID:-}
       PAYPAL_CLIENT_SECRET: ${PAYPAL_CLIENT_SECRET:-}
       PAYPAL_WEBHOOK_ID: ${PAYPAL_WEBHOOK_ID:-}
+      PAYPAL_PAYOUT_WEBHOOK_ID: ${PAYPAL_PAYOUT_WEBHOOK_ID:-}
 
       # ── MercadoPago ───────────────────────────────────────────────────
       MERCADOPAGO_ACCESS_TOKEN: ${MERCADOPAGO_ACCESS_TOKEN:-}


### PR DESCRIPTION
## Resumen
Implementa el contrato de pasarelas de payout y la primera implementación real: **PayPal Payouts**. Incluye la factory de selección por destino y el wiring del webhook de payouts.

## Cambios
- `PayoutGateway` — interfaz con `createPayout`, `getStatus`, `verifyWebhook`
- `PayPalPayoutsGateway` — Payouts API v1, SSRF guard en getStatus, montos con 2 decimales
- `getPayoutGateway` factory — email → paypal; accountId → MercadoPago (slot 501, aún sin implementar)
- `PayPalService.getAccessToken()` público + `verifyWebhookSignature(headers, rawBody, webhookId?)` con override
- `PAYPAL_PAYOUT_WEBHOOK_ID` en env + ejemplos + docker-compose.prod.yml
- Tests: 32/32 tocados pass

## Cadena
Este PR es el 3º de la cadena wallet-integration. Base: `1-schema` (PR #362). Siguiente: 2b (Gateway MercadoPago).

Closes: — (depende de #362)

cc @bladimir