### PR TITLE
fix(lint): clear 4 eslint errors blocking Auto Version (#347)

### DIFF
--- a/backend/src/__tests__/unit/SchedulerService.tokenRefresh.test.ts
+++ b/backend/src/__tests__/unit/SchedulerService.tokenRefresh.test.ts
@@ -104,6 +104,7 @@ describe('SchedulerService — MercadoPago Token Refresh Job (B7)', () => {
   });
 
   it('runs refreshTokens when MARKETPLACE_ENABLED is true', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy require of env config per-case
     const config = require('../../config/env').config as {
       marketplace: { enabled: boolean };
     };
@@ -118,6 +119,7 @@ describe('SchedulerService — MercadoPago Token Refresh Job (B7)', () => {
   });
 
   it('skips refreshTokens when MARKETPLACE_ENABLED is false', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy require of env config per-case
     const config = require('../../config/env').config as {
       marketplace: { enabled: boolean };
     };

--- a/backend/src/__tests__/unit/payouts/mercadopago-moneyout.gateway.test.ts
+++ b/backend/src/__tests__/unit/payouts/mercadopago-moneyout.gateway.test.ts
@@ -60,7 +60,6 @@ jest.mock('../../../services/MercadoPagoService', () => ({
 }));
 
 import axios from 'axios';
-import { AppError } from '../../../middleware/error.middleware';
 import { mercadoPagoService } from '../../../services/MercadoPagoService';
 import {
   MercadoPagoMoneyOutGateway,

--- a/backend/src/models/VendorMercadoPagoAccount.ts
+++ b/backend/src/models/VendorMercadoPagoAccount.ts
@@ -7,10 +7,7 @@
  */
 import { DataTypes, Model, Optional } from 'sequelize';
 import { sequelize } from '../config/database.js';
-import type {
-  VendorMercadoPagoAccountAttributes,
-  VendorMercadoPagoAccountCreationAttributes,
-} from '../types/index.js';
+import type { VendorMercadoPagoAccountAttributes } from '../types/index.js';
 
 type VendorMercadoPagoAccountCreation = Optional<
   VendorMercadoPagoAccountAttributes,


### PR DESCRIPTION
Re-emisión de lint fixes (4 eslint errors) bloqueados en auto-version validate.
Files: SchedulerService.tokenRefresh.test.ts, mercadopago-moneyout.gateway.test.ts, VendorMercadoPagoAccount.ts
Refs #347 #373. Backend eslint 0 errors, 23/23 affected tests pass.