### PR TITLE
chore(release): promote main to release — #347/#347 + marketplace SDD chain

### DIFF
--- a/backend/src/__tests__/unit/SchedulerService.tokenRefresh.test.ts
+++ b/backend/src/__tests__/unit/SchedulerService.tokenRefresh.test.ts
@@ -104,6 +104,7 @@ describe('SchedulerService — MercadoPago Token Refresh Job (B7)', () => {
   });
 
   it('runs refreshTokens when MARKETPLACE_ENABLED is true', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy require of env config per-case
     const config = require('../../config/env').config as {
       marketplace: { enabled: boolean };
     };
@@ -118,6 +119,7 @@ describe('SchedulerService — MercadoPago Token Refresh Job (B7)', () => {
   });
 
   it('skips refreshTokens when MARKETPLACE_ENABLED is false', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- lazy require of env config per-case
     const config = require('../../config/env').config as {
       marketplace: { enabled: boolean };
     };

--- a/backend/src/__tests__/unit/payouts/mercadopago-moneyout.gateway.test.ts
+++ b/backend/src/__tests__/unit/payouts/mercadopago-moneyout.gateway.test.ts
@@ -60,7 +60,6 @@ jest.mock('../../../services/MercadoPagoService', () => ({
 }));
 
 import axios from 'axios';
-import { AppError } from '../../../middleware/error.middleware';
 import { mercadoPagoService } from '../../../services/MercadoPagoService';
 import {
   MercadoPagoMoneyOutGateway,

--- a/backend/src/models/VendorMercadoPagoAccount.ts
+++ b/backend/src/models/VendorMercadoPagoAccount.ts
@@ -7,10 +7,7 @@
  */
 import { DataTypes, Model, Optional } from 'sequelize';
 import { sequelize } from '../config/database.js';
-import type {
-  VendorMercadoPagoAccountAttributes,
-  VendorMercadoPagoAccountCreationAttributes,
-} from '../types/index.js';
+import type { VendorMercadoPagoAccountAttributes } from '../types/index.js';
 
 type VendorMercadoPagoAccountCreation = Optional<
   VendorMercadoPagoAccountAttributes,


### PR DESCRIPTION
## Promoción `main → release` (ruta development -> main -> release)

Promueve **todo** `main` a `release` (119 commits), según autorización. Incluye:
- **#347** feature flag cryptoWallet (887a387) + fixes E2E wallet (#347).
- **#373** wallet E2E: auth token-strip + mock shape + i18n (9a5342a).
- Flujo SDD completo del Marketplace/wallet-integration: MPs split, OAuth, payouts,
  wallet-integration chain (PRs #343, #359, #360/#361/#362/#363, #365, #367, #369, #370).

`main` ya está CI-verde (run 32235185002: backend×3 + frontend + playwright success).
Al fusionar a `release` se disparan `cd-backend` + `deploy-frontend` (Vercel prod).

> Nota: este es un release grande (incluye el flujo SDD del Marketplace completo).
