### PR TITLE
fix(ci): use PAT for release PR creation in auto-version

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -166,14 +166,20 @@ jobs:
           echo "✅ cd-backend triggered for v${NEW_VERSION}"
 
           # Create and auto-merge PR to release
-          PR_URL=$(gh pr create \
+          # The default GITHUB_TOKEN cannot create/approve a PR in a run that
+          # was triggered by an Actions-generated push to release
+          # ("GitHub Actions is not permitted to create or approve pull requests").
+          # Authenticate these two gh calls with a PAT (repo + workflow scopes)
+          # stored as `RELEASE_TOKEN`; the step-level GITHUB_TOKEN above still
+          # backs git push, gh release create, and gh workflow run (those work).
+          PR_URL=$(GH_TOKEN="${{ secrets.RELEASE_TOKEN }}" gh pr create \
             --base release \
             --head "$BRANCH" \
             --title "chore(release): v${NEW_VERSION}" \
             --body "Automated version bump: ${CURRENT} → ${NEW_VERSION}")
           echo "✅ PR created: $PR_URL"
 
-          gh pr merge "$PR_URL" \
+          GH_TOKEN="${{ secrets.RELEASE_TOKEN }}" gh pr merge "$PR_URL" \
             --merge \
             --admin \
             --subject "chore(release): v${NEW_VERSION} [skip ci]"


### PR DESCRIPTION
## Problema
v3.5.0: auto-version (`Auto Version #14`) creó el tag y el GitHub Release y disparó cd-backend, pero falló al final:
```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```
El bump de versión quedó varado en `chore/release-v3.5.0` (`release` HEAD ≠ tag v3.5.0).

## Causa
`github.token` (GITHUB_TOKEN default) no puede crear+mergear un PR desde un run disparado por un push a release originado en GitHub Actions. Sólo los dos `gh pr` lo necesitan; `git push`/`gh release create`/`gh workflow run` siguen con el GITHUB_TOKEN (funcionan).

## Fix
```diff
- PR_URL=$(gh pr create + PR_URL=$(GH_TOKEN="${{ secrets.RELEASE_TOKEN }}" gh pr create    ...
- gh pr merge "$PR_URL" + GH_TOKEN="${{ secrets.RELEASE_TOKEN }}" gh pr merge "$PR_URL" ```

## ⚠️ Admin: agregar secret `RELEASE_TOKEN`
Antes de mergear, agregar al repo el secret **`RELEASE_TOKEN`** = classic PAT con scopes `repo` + `workflow` (o fine-grained: `pull-requests: write`, `contents: write`, `workflows: read`). Sin él, el step falla explícitamente — preferible al error críptico.