### PR TITLE
fix(ci): align auto-version release PR to env secret RELEASE_PAT

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -62,6 +62,7 @@ jobs:
 
   version-bump:
     needs: [validate]
+    environment: release  # read env secret RELEASE_PAT; env "Release" has no required reviewers
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -169,17 +170,18 @@ jobs:
           # The default GITHUB_TOKEN cannot create/approve a PR in a run that
           # was triggered by an Actions-generated push to release
           # ("GitHub Actions is not permitted to create or approve pull requests").
-          # Authenticate these two gh calls with a PAT (repo + workflow scopes)
-          # stored as `RELEASE_TOKEN`; the step-level GITHUB_TOKEN above still
-          # backs git push, gh release create, and gh workflow run (those work).
-          PR_URL=$(GH_TOKEN="${{ secrets.RELEASE_TOKEN }}" gh pr create \
+          # These two gh calls authenticate with the env PAT RELEASE_PAT
+          # (secret in Environment "Release"; requires environment: release on the
+          # job). The step-level GITHUB_TOKEN above still backs git push,
+          # gh release create, and gh workflow run (those work).
+          PR_URL=$(GH_TOKEN="${{ secrets.RELEASE_PAT }}" gh pr create \
             --base release \
             --head "$BRANCH" \
             --title "chore(release): v${NEW_VERSION}" \
             --body "Automated version bump: ${CURRENT} → ${NEW_VERSION}")
           echo "✅ PR created: $PR_URL"
 
-          GH_TOKEN="${{ secrets.RELEASE_TOKEN }}" gh pr merge "$PR_URL" \
+          GH_TOKEN="${{ secrets.RELEASE_PAT }}" gh pr merge "$PR_URL" \
             --merge \
             --admin \
             --subject "chore(release): v${NEW_VERSION} [skip ci]"


### PR DESCRIPTION
Corrige #378: el PAT esta en Environment 'Release' como secret RELEASE_PAT (no repo-level RELEASE_TOKEN). Agrega environment: release al job version-bump y usa secrets.RELEASE_PAT en gh pr create/merge. Env 'Release' sin reviewers -> sin gate de aprobacion. Necesario para que el auto-merge del release PR funcione.